### PR TITLE
feat(theme): add dark mode + toggle, persist preference

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19268,9 +19268,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
@@ -19278,7 +19278,7 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>AlgoVisualizer</title>
     <link rel="stylesheet" href="styles/App.css">
+    <meta name="color-scheme" content="light dark" />
+
 </head>
 <body>
 <div id="root"></div>

--- a/public/index.html
+++ b/public/index.html
@@ -1,14 +1,34 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>AlgoVisualizer</title>
-    <link rel="stylesheet" href="styles/App.css" />
+    <meta charset="utf-8" />
+    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <meta name="description" content="Algorithm Visualizer - Interactive visualization of sorting and searching algorithms" />
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/favicon.ico" />
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <!-- Typography: Inter (UI) + Space Grotesk (Brand) -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <!-- Your Dark Mode Meta -->
     <meta name="color-scheme" content="light dark" />
+    <title>AlgoVisualizer - Algorithm Visualization Tool</title>
 </head>
 <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <script src="bundle.js"></script>
+    <!--
+      This HTML file is a template.
+      If you open it directly in the browser, you will see an empty page.
+
+      You can add webfonts, meta tags, or analytics to this file.
+      The build step will place the bundled scripts into the <body> tag.
+
+      To begin the development, run `npm start` or `yarn start`.
+      To create a production bundle, use `npm run build` or `yarn build`.
+    -->
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -1,15 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>AlgoVisualizer</title>
-    <link rel="stylesheet" href="styles/App.css">
+    <link rel="stylesheet" href="styles/App.css" />
     <meta name="color-scheme" content="light dark" />
-
 </head>
 <body>
-<div id="root"></div>
-<script src="bundle.js"></script>
+    <div id="root"></div>
+    <script src="bundle.js"></script>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -1,34 +1,12 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-    <meta name="description" content="Algorithm Visualizer - Interactive visualization of sorting and searching algorithms" />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/favicon.ico" />
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!-- Typography: Inter (UI) + Space Grotesk (Brand) -->
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet" />
-    <!-- Your Dark Mode Meta -->
-    <meta name="color-scheme" content="light dark" />
-    <title>AlgoVisualizer - Algorithm Visualization Tool</title>
-</head>
-<body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
+<!DOCTYPE html> 
+<html lang="en"> 
+  <head> <meta charset="UTF-8"> 
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"> 
+    <title>AlgoVisualizer</title> <link rel="stylesheet" href="styles/App.css"> 
+    <meta name="color-scheme" content="light dark" /> 
+  </head> 
+  <body> 
     <div id="root"></div>
-    <script src="bundle.js"></script>
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
-</body>
+     <script src="bundle.js"></script>
+     </body> 
 </html>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,9 +1,11 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import '../styles/navbar.css';
+import { useTheme } from '../hooks/useTheme'; // import hook
 
 const Header = () => {
     const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+    const { theme, toggle } = useTheme(); // get theme + toggle from hook
 
     const toggleMobileMenu = () => {
         setIsMobileMenuOpen(!isMobileMenuOpen);
@@ -16,12 +18,32 @@ const Header = () => {
                     <h1>AlgoVisualizer</h1>
                 </Link>
             </div>
+
             <nav className={`nav-links ${isMobileMenuOpen ? 'nav-active' : ''}`}>
                 <Link to="/" onClick={toggleMobileMenu}>Home</Link>
                 <Link to="/sorting" onClick={toggleMobileMenu}>Sorting</Link>
                 <Link to="/searching" onClick={toggleMobileMenu}>Searching</Link>
                 <Link to="/data-structures" onClick={toggleMobileMenu}>Data Structures</Link>
             </nav>
+
+            {/* Theme toggle button */}
+            <button
+                onClick={toggle}
+                aria-label="Toggle dark mode"
+                style={{
+                    padding: '6px 10px',
+                    borderRadius: 8,
+                    cursor: 'pointer',
+                    marginLeft: '10px',
+                    background: 'var(--muted)',
+                    color: 'var(--text)',
+                    border: '1px solid var(--border)'
+                }}
+                title={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+            >
+                {theme === 'dark' ? '🌙 Dark' : '☀️ Light'}
+            </button>
+
             <div className="hamburger" onClick={toggleMobileMenu}>
                 <span className="bar"></span>
                 <span className="bar"></span>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,53 +1,75 @@
 import React, { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, NavLink } from 'react-router-dom';
 import '../styles/navbar.css';
-import { useTheme } from '../hooks/useTheme'; // import hook
+import { useTheme } from '../hooks/useTheme';
 
 const Header = () => {
     const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
-    const { theme, toggle } = useTheme(); // get theme + toggle from hook
+    const { theme, toggle } = useTheme();
 
     const toggleMobileMenu = () => {
         setIsMobileMenuOpen(!isMobileMenuOpen);
     };
 
     return (
-        <header>
-            <div className="logo">
-                <Link to="/">
-                    <h1>AlgoVisualizer</h1>
-                </Link>
-            </div>
+        <header className="av-header">
+            <div className="av-container">
+                <div className="logo">
+                    <Link to="/" onClick={() => setIsMobileMenuOpen(false)}>
+                        <span className="brand-mono">ALGO</span>
+                        <span className="brand-highlight">Visualizer</span>
+                    </Link>
+                </div>
 
-            <nav className={`nav-links ${isMobileMenuOpen ? 'nav-active' : ''}`}>
-                <Link to="/" onClick={toggleMobileMenu}>Home</Link>
-                <Link to="/sorting" onClick={toggleMobileMenu}>Sorting</Link>
-                <Link to="/searching" onClick={toggleMobileMenu}>Searching</Link>
-                <Link to="/data-structures" onClick={toggleMobileMenu}>Data Structures</Link>
-            </nav>
+                <nav className={`nav-links ${isMobileMenuOpen ? 'nav-active' : ''}`} aria-label="Primary">
+                    <NavLink to="/" onClick={toggleMobileMenu} end className={({ isActive }) => isActive ? 'active' : ''}>Home</NavLink>
+                    <NavLink to="/sorting" onClick={toggleMobileMenu} className={({ isActive }) => isActive ? 'active' : ''}>Sorting</NavLink>
+                    <NavLink to="/searching" onClick={toggleMobileMenu} className={({ isActive }) => isActive ? 'active' : ''}>Searching</NavLink>
+                    <NavLink to="/data-structures" onClick={toggleMobileMenu} className={({ isActive }) => isActive ? 'active' : ''}>Data Structures</NavLink>
+                    <NavLink to="/contributors" onClick={toggleMobileMenu} className={({ isActive }) => isActive ? 'active' : ''}>Contributors</NavLink>
+                </nav>
 
-            {/* Theme toggle button */}
-            <button
-                onClick={toggle}
-                aria-label="Toggle dark mode"
-                style={{
-                    padding: '6px 10px',
-                    borderRadius: 8,
-                    cursor: 'pointer',
-                    marginLeft: '10px',
-                    background: 'var(--muted)',
-                    color: 'var(--text)',
-                    border: '1px solid var(--border)'
-                }}
-                title={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
-            >
-                {theme === 'dark' ? '🌙 Dark' : '☀️ Light'}
-            </button>
+                <div className="nav-actions">
+                    {/* Theme toggle button */}
+                    <button
+                        onClick={toggle}
+                        aria-label="Toggle dark mode"
+                        style={{
+                            padding: '6px 10px',
+                            borderRadius: 8,
+                            cursor: 'pointer',
+                            background: 'var(--muted)',
+                            color: 'var(--text)',
+                            border: '1px solid var(--border)'
+                        }}
+                        title={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+                    >
+                        {theme === 'dark' ? '🌙 Dark' : '☀️ Light'}
+                    </button>
 
-            <div className="hamburger" onClick={toggleMobileMenu}>
-                <span className="bar"></span>
-                <span className="bar"></span>
-                <span className="bar"></span>
+                    {/* GitHub button */}
+                    <a
+                        className="github-btn"
+                        href="https://github.com/RhythmPahwa14/AlgoVisualizer"
+                        target="_blank"
+                        rel="noreferrer noopener"
+                        aria-label="Open GitHub repository"
+                    >
+                        <span>Star</span>
+                    </a>
+
+                    {/* Hamburger menu for mobile */}
+                    <button
+                        className="hamburger"
+                        onClick={toggleMobileMenu}
+                        aria-label="Toggle menu"
+                        aria-expanded={isMobileMenuOpen}
+                    >
+                        <span className="bar"></span>
+                        <span className="bar"></span>
+                        <span className="bar"></span>
+                    </button>
+                </div>
             </div>
         </header>
     );

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -47,18 +47,6 @@ const Header = () => {
                         {theme === 'dark' ? '🌙 Dark' : '☀️ Light'}
                     </button>
 
-                    {/* GitHub button */}
-                    <a
-                        className="github-btn"
-                        href="https://github.com/RhythmPahwa14/AlgoVisualizer"
-                        target="_blank"
-                        rel="noreferrer noopener"
-                        aria-label="Open GitHub repository"
-                    >
-                        <span>Star</span>
-                    </a>
-
-                    {/* Hamburger menu for mobile */}
                     <button
                         className="hamburger"
                         onClick={toggleMobileMenu}

--- a/src/hooks/useTheme.js
+++ b/src/hooks/useTheme.js
@@ -1,0 +1,43 @@
+import { createContext, useContext, useEffect, useMemo, useState } from 'react';
+
+const ThemeContext = createContext();
+
+export function ThemeProvider({ children }) {
+  // initial theme: saved preference → system preference → light
+  const [theme, setTheme] = useState(() => {
+    const saved = localStorage.getItem('theme');
+    if (saved === 'light' || saved === 'dark') return saved;
+    const prefersDark = window.matchMedia?.('(prefers-color-scheme: dark)').matches;
+    return prefersDark ? 'dark' : 'light';
+  });
+
+  // apply to <html> via data-theme and persist
+  useEffect(() => {
+    document.documentElement.dataset.theme = theme;
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  // keep in sync with system (only if user hasn't chosen manually)
+  useEffect(() => {
+    const mq = window.matchMedia?.('(prefers-color-scheme: dark)');
+    if (!mq) return;
+    const onChange = e => {
+      const saved = localStorage.getItem('theme');
+      if (!saved) setTheme(e.matches ? 'dark' : 'light');
+    };
+    mq.addEventListener?.('change', onChange);
+    return () => mq.removeEventListener?.('change', onChange);
+  }, []);
+
+  const value = useMemo(() => ({
+    theme,
+    setTheme,
+    toggle: () => setTheme(t => (t === 'dark' ? 'light' : 'dark')),
+  }), [theme]);
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}

--- a/src/index.js
+++ b/src/index.js
@@ -2,8 +2,13 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 import './styles/components.css';
+import './styles/theme.css';
+import { ThemeProvider } from './hooks/useTheme';
+
 
 ReactDOM.render(
-    <App />,
-    document.getElementById('root')
+  <ThemeProvider>
+    <App />
+  </ThemeProvider>,
+  document.getElementById('root')
 );

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -1,97 +1,122 @@
+:root {
+  --bg: #ffffff;
+  --text: #000000;
+  --link: #0066cc;
+  --link-hover: #004999;
+  --button-bg: #f0f0f0;
+  --button-text: #000000;
+  --disabled-bg: grey;
+  --array-bar-bg: #61dafb;
+}
+
+[data-theme='dark'] {
+  --bg: #0a0a1a;
+  --text: #e0e6ed;
+  --link: #66ccff;
+  --link-hover: #4da6ff;
+  --button-bg: rgba(255, 255, 255, 0.1);
+  --button-text: #e0e6ed;
+  --disabled-bg: #555;
+  --array-bar-bg: #61dafb; /* same in dark mode */
+}
+
 body {
-    font-family: 'Poppins', sans-serif;
-    background: linear-gradient(135deg, #0a0a1a 0%, #1a1a2e 50%, #16213e 100%);
-    color: #e0e6ed;
-    margin: 0;
-    padding: 0;
-    overflow-y: scroll;
-    min-height: 100vh;
+  font-family: 'Poppins', sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  margin: 0;
+  padding: 0;
+  overflow-y: scroll;
+  min-height: 100vh;
+  transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 /* Searching Component Styles */
 .searching-container {
-    text-align: center;
-    padding: 20px;
+  text-align: center;
+  padding: 20px;
 }
 
 .searching-controls {
-    margin-top: 20px;
+  margin-top: 20px;
 }
 
 .searching-button {
-    padding: 10px 20px;
-    margin: 5px;
-    font-size: 16px;
-    border-radius: 10px; /* Rounded edges */
-    cursor: pointer;
-    color: black; /* Ensure button text is black */
+  padding: 10px 20px;
+  margin: 5px;
+  font-size: 16px;
+  border-radius: 10px;
+  cursor: pointer;
+  background-color: var(--button-bg);
+  color: var(--button-text);
 }
 
 .searching-button:disabled {
-    background-color: grey;
-    cursor: not-allowed;
+  background-color: var(--disabled-bg);
+  cursor: not-allowed;
 }
 
 .searching-algorithm-selection {
-    margin-top: 20px;
+  margin-top: 20px;
 }
 
 .searching-array-container {
-    display: flex;
-    justify-content: center;
-    align-items: flex-end;
-    height: 100px;
-    margin-top: 10px;
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+  height: 100px;
+  margin-top: 10px;
 }
 
 .searching-array-bar {
-    width: 30px;
-    margin: 0 2px;
-    background-color: #61dafb;
-    text-align: center;
-    color: rgb(39, 38, 38);
+  width: 30px;
+  margin: 0 2px;
+  background-color: var(--array-bar-bg);
+  text-align: center;
+  color: var(--text);
 }
 
 /* Sorting Component Styles */
 .sorting-container {
-    text-align: center;
-    padding: 20px;
+  text-align: center;
+  padding: 20px;
 }
 
 .sorting-controls {
-    margin-top: 20px;
+  margin-top: 20px;
 }
 
 .sorting-button {
-    padding: 10px 20px;
-    margin: 5px;
-    font-size: 16px;
-    border-radius: 10px; /* Rounded edges */
-    cursor: pointer;
-    color: black; /* Ensure button text is black */
+  padding: 10px 20px;
+  margin: 5px;
+  font-size: 16px;
+  border-radius: 10px;
+  cursor: pointer;
+  background-color: var(--button-bg);
+  color: var(--button-text);
 }
 
 .sorting-button:disabled {
-    background-color: grey;
-    cursor: not-allowed;
+  background-color: var(--disabled-bg);
+  cursor: not-allowed;
 }
 
 .sorting-algorithm-selection {
-    margin-top: 20px;
+  margin-top: 20px;
 }
 
 .sorting-array-container {
-    display: flex;
-    justify-content: center;
-    align-items: flex-end;
-    height: 100px;
-    margin-top: 10px;
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+  height: 100px;
+  margin-top: 10px;
 }
 
 .sorting-array-bar {
-    width: 30px;
-    margin: 0 2px;
-    background-color: #61dafb;
-    text-align: center;
-    color: rgb(39, 38, 38);
+  width: 30px;
+  margin: 0 2px;
+  background-color: var(--array-bar-bg);
+  text-align: center;
+  color: var(--text);
 }

--- a/src/styles/Searching.css
+++ b/src/styles/Searching.css
@@ -1,28 +1,50 @@
+/* Theme Variables */
+:root {
+    --bg: #ffffff;
+    --text: #000000;
+    --button-text: #000000;
+    --button-bg: #61dafb;
+    --array-bar-color: #61dafb;
+}
+
+[data-theme="dark"] {
+    --bg: linear-gradient(135deg, #0a0a1a 0%, #1a1a2e 50%, #16213e 100%);
+    --text: #e0e6ed;
+    --button-text: #000000;
+    --button-bg: #61dafb;
+    --array-bar-color: #61dafb;
+}
+
+/* Body styling */
 body {
     font-family: 'Poppins', sans-serif;
-    background: linear-gradient(135deg, #0a0a1a 0%, #1a1a2e 50%, #16213e 100%) !important;
-    color: #e0e6ed !important;
+    background: var(--bg) !important;
+    color: var(--text) !important;
     margin: 0;
     padding: 0;
     overflow-y: scroll;
 }
 
+/* Searching container */
 .searching-container {
     text-align: center;
     padding: 20px;
 }
 
+/* Searching controls */
 .searching-controls {
     margin-top: 20px;
 }
 
+/* Searching buttons */
 .searching-button {
     padding: 10px 20px;
     margin: 5px;
     font-size: 16px;
-    border-radius: 10px; /* Rounded edges */
+    border-radius: 10px;
     cursor: pointer;
-    color: black; /* Ensure button text is black */
+    color: var(--button-text);
+    background-color: var(--button-bg);
 }
 
 .searching-button:disabled {
@@ -30,10 +52,12 @@ body {
     cursor: not-allowed;
 }
 
+/* Algorithm selection */
 .algorithm-selection {
     margin-top: 20px;
 }
 
+/* Array container */
 .array-container {
     display: flex;
     justify-content: center;
@@ -42,10 +66,11 @@ body {
     margin-top: 10px;
 }
 
+/* Array bars */
 .array-bar {
     width: 30px;
     margin: 0 2px;
-    background-color: #61dafb;
+    background-color: var(--array-bar-color);
     text-align: center;
     color: rgb(39, 38, 38);
 }

--- a/src/styles/Sorting.css
+++ b/src/styles/Sorting.css
@@ -1,8 +1,33 @@
+/* Theme Variables */
+:root {
+    --bg: #ffffff;
+    --text: #000000;
+    --bar-color: dodgerblue;
+    --button-bg: #007bff;
+    --button-text: #ffffff;
+    --button-disabled-bg: grey;
+    --reset-bg: orange;
+}
+
+[data-theme="dark"] {
+    --bg: #1a1a2e;
+    --text: #e0e6ed;
+    --bar-color: dodgerblue;
+    --button-bg: #3399ff;
+    --button-text: #000000;
+    --button-disabled-bg: #555;
+    --reset-bg: orange;
+}
+
+/* Page container */
 .container {
     text-align: center;
     margin-top: 30px;
+    background: var(--bg);
+    color: var(--text);
 }
 
+/* Array display */
 .array-container {
     display: flex;
     justify-content: center;
@@ -12,40 +37,35 @@
 
 .array-bar {
     display: inline-block;
-    background-color: dodgerblue;
+    background-color: var(--bar-color);
     margin: 0 1px;
     width: 20px;
 }
 
+/* Controls section */
 .controls {
     margin-top: 20px;
 }
 
-button {
-    padding: 10px 20px;
-    margin: 5px;
-    font-size: 16px;
-}
-
-button:disabled {
-    background-color: grey;
-    cursor: not-allowed;
-}
-
+/* Buttons */
 button {
     padding: 10px 20px;
     margin: 5px;
     font-size: 16px;
     border-radius: 14px;
+    background-color: var(--button-bg);
+    color: var(--button-text);
+    cursor: pointer;
+    border: none;
 }
 
 button:disabled {
-    background-color: grey;
+    background-color: var(--button-disabled-bg);
     cursor: not-allowed;
 }
 
 button:last-child {
-    background-color: orange; /* Change color for reset button */
+    background-color: var(--reset-bg);
     border-radius: 10px;
     color: white;
 }

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -1,8 +1,5 @@
-/* Import Google Fonts */
-@import url('https://fonts.googleapis.com/css2?family=Dancing+Script:wght@400;500;600;700&family=Poppins:wght@300;400;500;600;700&display=swap');
 
-/* Import Global Dark Theme Override */
-@import './global-dark-theme.css';
+@import url('https://fonts.googleapis.com/css2?family=Dancing+Script:wght@400;500;600;700&family=Poppins:wght@300;400;500;600;700&display=swap');
 
 /* Import Navbar and Footer Styles */
 @import './navbar.css';
@@ -11,49 +8,47 @@
 
 /* Reset default browser styles */
 * {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
 }
 
-/* Force dark theme */
+/* Variable-based theming */
 html {
-    background: linear-gradient(135deg, #0a0a1a 0%, #1a1a2e 50%, #16213e 100%) !important;
-    min-height: 100vh;
+  background: var(--bg);
+  min-height: 100vh;
 }
 
 body, html {
-    height: 100%;
-    background: linear-gradient(135deg, #0a0a1a 0%, #1a1a2e 50%, #16213e 100%) !important;
-    color: #e0e6ed !important;
+  height: 100%;
+  background: var(--bg);
+  color: var(--text);
 }
 
 body {
-    font-family: 'Poppins', sans-serif !important;
-    line-height: 1.6;
-    margin: 0 !important;
-    padding: 0 !important;
+  font-family: 'Poppins', sans-serif;
+  line-height: 1.6;
 }
 
 #root {
-    background: linear-gradient(135deg, #0a0a1a 0%, #1a1a2e 50%, #16213e 100%) !important;
-    min-height: 100vh;
+  background: var(--bg);
+  min-height: 100vh;
 }
 
 .app-container {
-    display: flex;
-    flex-direction: column;
-    min-height: 100vh;
-    background: linear-gradient(135deg, #0a0a1a 0%, #1a1a2e 50%, #16213e 100%) !important;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background: var(--bg);
 }
 
 .main-content {
-    flex: 1;
-    padding: 0;
-    background: transparent !important;
-    margin: 0;
-    border-radius: 0;
-    border: none;
-    box-shadow: none;
+  flex: 1;
+  padding: 0;
+  background: transparent;
+  margin: 0;
+  border-radius: 0;
+  border: none;
+  box-shadow: none;
 }
 

--- a/src/styles/contact.css
+++ b/src/styles/contact.css
@@ -1,34 +1,43 @@
-.contact h1{
+
+ .contact h1 {
     text-align: center;
     margin-top: 20px;
     font-size: 2.5rem;
+    color: var(--text);
 }
-.contact{
+
+.contact {
     margin-bottom: 50px;
 }
-.contact p{
+
+.contact p {
     text-align: center;
     font-size: 1.2rem;
     margin-top: 10px;
     max-width: 85%;
     margin-left: auto;
     margin-right: auto;
+    color: var(--text);
 }
 
-.contact h3{
+.contact h3 {
     text-align: center;
     margin-top: 30px;
     font-size: 1.8rem;
-}
-.links p{
-    margin-top: 30px;
+    color: var(--text);
 }
 
-.connection{
+.links p {
+    margin-top: 30px;
+    color: var(--text);
+}
+
+.connection {
     margin-top: 50px;
     text-align: center;
 }
-.connection input{
+
+.connection input {
     width: 30%;
     height: 40px;
     margin-top: 17px;
@@ -39,16 +48,19 @@
     border-radius: 5px;
     outline: none;
     transition: all 0.3s ease-in-out;
-
+    background-color: var(--bg);
+    color: var(--text);
 }
-.connection label{
+
+.connection label {
     font-size: 1.2rem;
-    color: rgb(8, 179, 231);
+    color: var(--text);
     margin-right: 10px;
     margin-top: 20px;
     display: inline-block;
 }
-.connection textarea{
+
+.connection textarea {
     width: 28%;
     height: 100px;
     margin-top: 17px;
@@ -60,28 +72,33 @@
     border-radius: 5px;
     outline: none;
     transition: all 0.3s ease-in-out;
+    background-color: var(--bg);
+    color: var(--text);
 }
-button{
-    width : 100px;
+
+button {
+    width: 100px;
     height: 35px;
     margin-top: 17px;
     box-shadow: 2px 5px 5px rgba(8, 179, 231, 0.5);
     border-radius: 5px;
     border: none;
     background-color: rgb(8, 179, 231);
-    color: white;
+    color: var(--text);
     font-size: 1rem;
     transition: all 0.3s ease-in-out;
-
 }
 
-.social-icons a{
+.social-icons a {
     margin-top: 10px;
     margin-left: 5px;
     font-size: large;
+    color: var(--text);
 }
-.links h4{
+
+.links h4 {
     text-align: center;
     margin-top: 50px;
     font-size: 1.5rem;
+    color: var(--text);
 }

--- a/src/styles/footer.css
+++ b/src/styles/footer.css
@@ -1,13 +1,13 @@
-/* Dark Theme Footer Styles */
 .footer-container {
-    background: linear-gradient(135deg, #0a0a1a 0%, #1a1a2e 50%, #16213e 100%);
+    background: var(--bg);
     padding: 20px 0 10px 0;
-    color: #e0e6ed;
+    color: var(--text);
     text-align: center;
     margin-top: auto;
     width: 100%;
     border-top: 1px solid rgba(102, 204, 255, 0.2);
     box-shadow: 0 -4px 20px rgba(15, 52, 96, 0.3);
+    animation: fadeInUp 0.8s ease-out;
 }
 
 .footer-content {
@@ -30,7 +30,7 @@
 
 .footer-description {
     font-size: 0.9em;
-    color: #b8c5d1;
+    color: var(--text-muted);
     margin-bottom: 15px;
     font-family: 'Poppins', sans-serif;
     font-weight: 300;
@@ -50,7 +50,7 @@
 
 .footer-links a,
 .footer-links Link {
-    color: #e0e6ed;
+    color: var(--text);
     margin: 0 5px;
     font-size: 0.85em;
     cursor: pointer;
@@ -60,7 +60,7 @@
     font-weight: 400;
     padding: 4px 8px;
     border-radius: 12px;
-    background: rgba(255, 255, 255, 0.05);
+    background: var(--bg-secondary);
     border: 1px solid rgba(255, 255, 255, 0.1);
 }
 
@@ -73,7 +73,6 @@
     border: 1px solid rgba(102, 204, 255, 0.5);
 }
 
-/* Social Media Icons Section */
 .footer-social {
     margin: 15px 0 10px 0;
 }
@@ -89,12 +88,12 @@
     width: 32px;
     height: 32px;
     border-radius: 50%;
-    background: rgba(255, 255, 255, 0.05);
+    background: var(--bg-secondary);
     border: 1px solid rgba(255, 255, 255, 0.1);
     display: flex;
     align-items: center;
     justify-content: center;
-    color: #e0e6ed;
+    color: var(--text);
     text-decoration: none;
     transition: all 0.3s ease;
     font-size: 0.9em;
@@ -108,13 +107,12 @@
     border: 1px solid rgba(102, 204, 255, 0.5);
 }
 
-/* Footer Bottom Section */
 .footer-bottom {
     margin-top: 15px;
     padding-top: 10px;
     border-top: 1px solid rgba(255, 255, 255, 0.1);
     font-size: 0.8rem;
-    color: #b8c5d1;
+    color: var(--text-muted);
     font-family: 'Poppins', sans-serif;
 }
 
@@ -133,7 +131,7 @@
 .footer-bottom .footer-links span {
     margin: 0 10px;
     cursor: pointer;
-    color: #b8c5d1;
+    color: var(--text-muted);
     transition: all 0.3s ease;
     padding: 5px 10px;
     border-radius: 15px;
@@ -145,57 +143,47 @@
     transform: translateY(-1px);
 }
 
-/* Copyright Section */
 .copyright {
     margin-top: 8px;
     padding-top: 8px;
     border-top: 1px solid rgba(255, 255, 255, 0.05);
     font-size: 0.75em;
-    color: #8a9ba8;
+    color: var(--text-muted);
     font-family: 'Poppins', sans-serif;
 }
 
-/* Mobile Responsive Styles */
 @media (max-width: 768px) {
     .footer-container {
         padding: 15px 0 8px 0;
     }
-
     .footer-heading {
         font-size: 1.3em;
     }
-
     .footer-description {
         font-size: 0.85em;
         margin-bottom: 12px;
     }
-
     .footer-links {
         gap: 8px;
         margin-top: 8px;
     }
-
     .footer-links a {
         font-size: 0.8em;
         padding: 3px 6px;
         margin: 2px;
     }
-
     .social-icons {
         gap: 8px;
     }
-
     .social-icon {
         width: 28px;
         height: 28px;
         font-size: 0.8em;
     }
-
     .footer-bottom {
         margin-top: 12px;
         padding-top: 8px;
     }
-
     .footer-bottom .footer-links {
         flex-direction: column;
         gap: 5px;
@@ -210,7 +198,6 @@
     }
 }
 
-/* Animation for footer on load */
 @keyframes fadeInUp {
     from {
         opacity: 0;
@@ -222,11 +209,6 @@
     }
 }
 
-.footer-container {
-    animation: fadeInUp 0.8s ease-out;
-}
-
-/* Hover effect for the entire footer */
 .footer-container:hover {
     box-shadow: 0 -6px 30px rgba(102, 204, 255, 0.2);
 }

--- a/src/styles/global-dark-theme.css
+++ b/src/styles/global-dark-theme.css
@@ -1,8 +1,8 @@
-/* Global Dark Theme Override */
+/* Global Dark Theme Override
 /* This file ensures dark theme is applied everywhere */
 
 /* Force dark theme on root elements */
-* {
+/* * {
     box-sizing: border-box;
 }
 
@@ -27,7 +27,7 @@ body {
 }
 
 /* Override any existing light backgrounds */
-div,
+/* div,
 section,
 main,
 article {
@@ -35,7 +35,7 @@ article {
 }
 
 /* Text readability */
-p,
+/* p,
 h1,
 h2,
 h3,
@@ -45,30 +45,30 @@ h6,
 span,
 a {
     color: inherit !important;
-}
+} */
 
 /* Ensure all buttons use dark theme */
-button:not(.cta-button):not(.btn) {
+/* button:not(.cta-button):not(.btn) {
     background: rgba(255, 255, 255, 0.1) !important;
     color: #e0e6ed !important;
     border: 1px solid rgba(255, 255, 255, 0.2) !important;
-}
+} */
 
 /* Input fields dark theme */
-input,
+/* input,
 select,
 textarea {
     background: rgba(255, 255, 255, 0.05) !important;
     color: #e0e6ed !important;
     border: 1px solid rgba(255, 255, 255, 0.1) !important;
-}
+} */
 
 /* Link colors */
-a {
+/* a {
     color: #66ccff !important;
     text-decoration: none;
-}
+} */
 
-a:hover {
+/* a:hover {
     color: #4da6ff !important;
-}
+}   */

--- a/src/styles/navbar.css
+++ b/src/styles/navbar.css
@@ -1,3 +1,4 @@
+/* === Theme Variables from feat/dark-mode-toggle === */
 :root {
   --bg: #ffffff;
   --text: #0b0b0b;
@@ -24,6 +25,7 @@
   --bar-compare: #fbbf24;
 }
 
+/* Base Layout and Elements */
 body {
   font-family: Arial, sans-serif;
   background-color: var(--bg);
@@ -109,3 +111,148 @@ footer {
   color: var(--text);
   border-top: 1px solid var(--border);
 }
+
+/* === Navbar Redesign from master === */
+.av-header {
+    position: -webkit-sticky;
+    position: sticky;
+    top: 0;
+    z-index: 1000;
+    background: rgba(10, 10, 26, 0.6);
+    -webkit-backdrop-filter: blur(12px);
+    backdrop-filter: blur(12px);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.av-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 14px 20px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+}
+
+.logo a {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 6px;
+    text-decoration: none;
+    color: inherit;
+}
+
+.brand-mono {
+    font-family: "Space Grotesk", ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Arial, "Noto Sans", "Helvetica Neue", sans-serif;
+    font-weight: 700;
+    letter-spacing: 1px;
+    color: #9ecbff;
+}
+
+.brand-highlight {
+    font-family: "Space Grotesk", ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Arial, "Noto Sans", "Helvetica Neue", sans-serif;
+    font-weight: 600;
+    background: linear-gradient(90deg, #66ccff, #4da6ff, #6f7cff);
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+}
+
+.nav-links {
+    display: flex;
+    gap: 8px;
+}
+
+.nav-links a {
+    font-family: 'Inter', system-ui, -apple-system, Segoe UI, Roboto, Arial, "Noto Sans", "Helvetica Neue", sans-serif;
+    color: #cfd9e6;
+    text-decoration: none;
+    font-size: 0.98rem;
+    font-weight: 500;
+    padding: 10px 12px;
+    border-radius: 10px;
+    transition: all .2s ease;
+    border: 1px solid transparent;
+}
+
+.nav-links a:hover {
+    color: #eaf2ff;
+    background: rgba(255, 255, 255, 0.06);
+    border-color: rgba(255, 255, 255, 0.08);
+}
+
+.nav-links a.active {
+    color: #0b1c3d;
+    background: linear-gradient(90deg, #8dd5ff, #80a7ff);
+    border-color: rgba(255, 255, 255, 0.14);
+    box-shadow: 0 6px 22px rgba(125, 170, 255, .25);
+}
+
+.nav-actions {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.github-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 12px;
+    border-radius: 10px;
+    color: #dce7ff;
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    transition: all .2s ease;
+}
+
+.github-btn:hover {
+    color: #0b1c3d;
+    background: linear-gradient(90deg, #8dd5ff, #80a7ff);
+    border-color: rgba(255, 255, 255, 0.18);
+}
+
+.hamburger {
+    display: none;
+    cursor: pointer;
+    flex-direction: column;
+    gap: 4px;
+    padding: 10px;
+    border-radius: 10px;
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.hamburger .bar {
+    width: 22px;
+    height: 2px;
+    background: #cfe1ff;
+    border-radius: 2px;
+}
+
+@media (max-width: 900px) {
+    .nav-links {
+        display: none;
+        position: absolute;
+        top: 60px;
+        right: 12px;
+        flex-direction: column;
+        min-width: 220px;
+        padding: 10px;
+        background: rgba(10, 10, 26, 0.9);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        border-radius: 12px;
+        box-shadow: 0 12px 40px rgba(0,0,0,.5);
+    }
+
+    .nav-links.nav-active { display: flex; }
+
+    .hamburger { display: inline-flex; }
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; transform: translateY(-8px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+.av-header { animation: fadeIn .35s ease-out; }

--- a/src/styles/navbar.css
+++ b/src/styles/navbar.css
@@ -1,21 +1,22 @@
 /* Import Google Fonts */
 @import url('https://fonts.googleapis.com/css2?family=Dancing+Script:wght@400;500;600;700&family=Poppins:wght@300;400;500;600;700&display=swap');
 
-/* Dark Theme Navbar Styles */
+/* Navbar Styles */
 header {
-    background: linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%);
+    background-color: var(--bg);
     padding: 20px;
-    color: white;
+    color: var(--text);
     text-align: center;
     display: flex;
     justify-content: space-between;
     align-items: center;
-    box-shadow: 0 4px 20px rgba(15, 52, 96, 0.4);
+    box-shadow: 0 4px 20px var(--accent-light);
     -webkit-backdrop-filter: blur(10px);
     backdrop-filter: blur(10px);
-    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    border-bottom: 1px solid var(--border);
     position: relative;
     z-index: 1000;
+    animation: fadeIn 0.6s ease-out;
 }
 
 /* Logo Styles */
@@ -27,7 +28,7 @@ header {
 
 .logo a:hover h1 {
     transform: scale(1.05);
-    filter: drop-shadow(0 4px 15px rgba(102, 204, 255, 0.4));
+    filter: drop-shadow(0 4px 15px var(--accent-light));
 }
 
 header h1 {
@@ -35,11 +36,11 @@ header h1 {
     font-size: 2.2em;
     font-family: 'Dancing Script', cursive;
     font-weight: bold;
-    background: linear-gradient(45deg, #66ccff, #4da6ff, #3385ff);
+    background: linear-gradient(45deg, var(--accent), #4da6ff, #3385ff);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     background-clip: text;
-    text-shadow: 0 2px 10px rgba(102, 204, 255, 0.3);
+    text-shadow: 0 2px 10px var(--accent-light);
 }
 
 /* Navigation Links */
@@ -49,7 +50,7 @@ header h1 {
 }
 
 .nav-links a {
-    color: #e0e6ed;
+    color: var(--text);
     text-decoration: none;
     font-size: 1.1em;
     font-weight: 500;
@@ -58,25 +59,25 @@ header h1 {
     border-radius: 25px;
     transition: all 0.3s ease;
     position: relative;
-    background: rgba(255, 255, 255, 0.05);
+    background: var(--bg-secondary);
     -webkit-backdrop-filter: blur(10px);
     backdrop-filter: blur(10px);
-    border: 1px solid rgba(255, 255, 255, 0.1);
+    border: 1px solid var(--border);
 }
 
 .nav-links a:hover {
-    color: #040450 !important;
-    background: linear-gradient(45deg, #66ccff, #4da6ff);
+    color: var(--bg) !important;
+    background: linear-gradient(45deg, var(--accent), #4da6ff);
     transform: translateY(-2px);
-    box-shadow: 0 8px 25px rgba(102, 204, 255, 0.3);
-    border: 1px solid rgba(102, 204, 255, 0.5);
+    box-shadow: 0 8px 25px var(--accent-light);
+    border: 1px solid var(--accent-light);
 }
 
 /* Active link styles */
 .nav-links a.active {
-    color: #040450 !important;
-    background: linear-gradient(45deg, #66ccff, #4da6ff);
-    box-shadow: 0 4px 15px rgba(102, 204, 255, 0.2);
+    color: var(--bg) !important;
+    background: linear-gradient(45deg, var(--accent), #4da6ff);
+    box-shadow: 0 4px 15px var(--accent-light);
 }
 
 /* Hamburger Menu */
@@ -87,21 +88,21 @@ header h1 {
     gap: 5px;
     padding: 10px;
     border-radius: 8px;
-    background: rgba(255, 255, 255, 0.05);
-    border: 1px solid rgba(255, 255, 255, 0.1);
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
     transition: all 0.3s ease;
 }
 
 .hamburger:hover {
-    background: rgba(102, 204, 255, 0.1);
+    background: var(--accent-light);
     transform: scale(1.05);
-    border: 1px solid rgba(102, 204, 255, 0.3);
+    border: 1px solid var(--accent);
 }
 
 .hamburger .bar {
     width: 25px;
     height: 3px;
-    background: linear-gradient(90deg, #66ccff, #4da6ff);
+    background: linear-gradient(90deg, var(--accent), #4da6ff);
     border-radius: 2px;
     transition: all 0.3s ease;
 }
@@ -122,12 +123,12 @@ header h1 {
         position: absolute;
         top: 80px;
         right: 20px;
-        background: linear-gradient(135deg, rgba(26, 26, 46, 0.98), rgba(22, 33, 62, 0.98));
+        background: var(--bg);
         padding: 25px;
         width: 220px;
         border-radius: 15px;
-        box-shadow: 0 10px 40px rgba(15, 52, 96, 0.5);
-        border: 1px solid rgba(102, 204, 255, 0.2);
+        box-shadow: 0 10px 40px var(--accent-light);
+        border: 1px solid var(--accent-light);
         -webkit-backdrop-filter: blur(20px);
         backdrop-filter: blur(20px);
         gap: 15px;
@@ -141,17 +142,17 @@ header h1 {
     .nav-links a {
         margin: 0;
         text-align: center;
-        background: rgba(255, 255, 255, 0.05);
-        border: 1px solid rgba(255, 255, 255, 0.1);
+        background: var(--bg-secondary);
+        border: 1px solid var(--border);
         padding: 12px 16px;
         font-size: 1em;
     }
 
     .nav-links a:hover {
-        background: linear-gradient(45deg, #66ccff, #4da6ff);
-        color: #040450 !important;
+        background: linear-gradient(45deg, var(--accent), #4da6ff);
+        color: var(--bg) !important;
         transform: translateY(-1px);
-        border: 1px solid rgba(102, 204, 255, 0.5);
+        border: 1px solid var(--accent-light);
     }
 
     .hamburger {
@@ -168,20 +169,4 @@ header h1 {
         opacity: 1;
         transform: translateY(0);
     }
-}
-
-/* Navbar animation for smooth transitions */
-@keyframes fadeIn {
-    from {
-        opacity: 0;
-        transform: translateY(-20px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
-}
-
-header {
-    animation: fadeIn 0.6s ease-out;
 }

--- a/src/styles/navbar.css
+++ b/src/styles/navbar.css
@@ -1,172 +1,111 @@
-/* Import Google Fonts */
-@import url('https://fonts.googleapis.com/css2?family=Dancing+Script:wght@400;500;600;700&family=Poppins:wght@300;400;500;600;700&display=swap');
+:root {
+  --bg: #ffffff;
+  --text: #0b0b0b;
+  --muted: #f6f7f9;
+  --card: #ffffff;
+  --border: #e5e7eb;
+  --accent: #2563eb;
 
-/* Navbar Styles */
+  --bar: #60a5fa;
+  --bar-active: #34d399;
+  --bar-compare: #f59e0b;
+}
+
+[data-theme="dark"] {
+  --bg: #000000;
+  --text: #ffffff;
+  --muted: #1a1a1a;
+  --card: #111111;
+  --border: #333333;
+  --accent: #4f46e5;
+
+  --bar: #3b82f6;
+  --bar-active: #10b981;
+  --bar-compare: #fbbf24;
+}
+
+body {
+  font-family: Arial, sans-serif;
+  background-color: var(--bg);
+  color: var(--text);
+  margin: 0;
+  padding: 0;
+  line-height: 1.6;
+  transition: background-color 0.3s, color 0.3s;
+}
+
 header {
-    background-color: var(--bg);
-    padding: 20px;
-    color: var(--text);
-    text-align: center;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    box-shadow: 0 4px 20px var(--accent-light);
-    -webkit-backdrop-filter: blur(10px);
-    backdrop-filter: blur(10px);
-    border-bottom: 1px solid var(--border);
-    position: relative;
-    z-index: 1000;
-    animation: fadeIn 0.6s ease-out;
+  background-color: var(--accent);
+  color: white;
+  padding: 1rem;
+  text-align: center;
 }
 
-/* Logo Styles */
-.logo a {
-    text-decoration: none;
-    color: inherit;
-    transition: all 0.3s ease;
+nav {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
 }
 
-.logo a:hover h1 {
-    transform: scale(1.05);
-    filter: drop-shadow(0 4px 15px var(--accent-light));
+nav a {
+  color: white;
+  text-decoration: none;
 }
 
-header h1 {
-    margin: 0;
-    font-size: 2.2em;
-    font-family: 'Dancing Script', cursive;
-    font-weight: bold;
-    background: linear-gradient(45deg, var(--accent), #4da6ff, #3385ff);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    text-shadow: 0 2px 10px var(--accent-light);
+nav a:hover {
+  text-decoration: underline;
 }
 
-/* Navigation Links */
-.nav-links {
-    display: flex;
-    gap: 30px;
+.container {
+  max-width: 1000px;
+  margin: 2rem auto;
+  padding: 1rem;
+  background-color: var(--card);
+  border-radius: 8px;
+  border: 1px solid var(--border);
 }
 
-.nav-links a {
-    color: var(--text);
-    text-decoration: none;
-    font-size: 1.1em;
-    font-weight: 500;
-    font-family: 'Poppins', sans-serif;
-    padding: 10px 20px;
-    border-radius: 25px;
-    transition: all 0.3s ease;
-    position: relative;
-    background: var(--bg-secondary);
-    -webkit-backdrop-filter: blur(10px);
-    backdrop-filter: blur(10px);
-    border: 1px solid var(--border);
+h1, h2, h3 {
+  margin-bottom: 1rem;
 }
 
-.nav-links a:hover {
-    color: var(--bg) !important;
-    background: linear-gradient(45deg, var(--accent), #4da6ff);
-    transform: translateY(-2px);
-    box-shadow: 0 8px 25px var(--accent-light);
-    border: 1px solid var(--accent-light);
+.progress-bar {
+  background-color: var(--bar);
+  height: 20px;
+  border-radius: 10px;
+  overflow: hidden;
+  margin-bottom: 1rem;
 }
 
-/* Active link styles */
-.nav-links a.active {
-    color: var(--bg) !important;
-    background: linear-gradient(45deg, var(--accent), #4da6ff);
-    box-shadow: 0 4px 15px var(--accent-light);
+.progress {
+  background-color: var(--bar-active);
+  height: 100%;
+  transition: width 0.3s;
 }
 
-/* Hamburger Menu */
-.hamburger {
-    display: none;
-    cursor: pointer;
-    flex-direction: column;
-    gap: 5px;
-    padding: 10px;
-    border-radius: 8px;
-    background: var(--bg-secondary);
-    border: 1px solid var(--border);
-    transition: all 0.3s ease;
+.progress-compare {
+  background-color: var(--bar-compare);
+  height: 100%;
+  transition: width 0.3s;
 }
 
-.hamburger:hover {
-    background: var(--accent-light);
-    transform: scale(1.05);
-    border: 1px solid var(--accent);
+button {
+  background-color: var(--accent);
+  color: white;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
 }
 
-.hamburger .bar {
-    width: 25px;
-    height: 3px;
-    background: linear-gradient(90deg, var(--accent), #4da6ff);
-    border-radius: 2px;
-    transition: all 0.3s ease;
+button:hover {
+  opacity: 0.9;
 }
 
-/* Mobile Responsive Styles */
-@media (max-width: 768px) {
-    header {
-        padding: 15px 20px;
-    }
-    
-    header h1 {
-        font-size: 1.8em;
-    }
-
-    .nav-links {
-        display: none;
-        flex-direction: column;
-        position: absolute;
-        top: 80px;
-        right: 20px;
-        background: var(--bg);
-        padding: 25px;
-        width: 220px;
-        border-radius: 15px;
-        box-shadow: 0 10px 40px var(--accent-light);
-        border: 1px solid var(--accent-light);
-        -webkit-backdrop-filter: blur(20px);
-        backdrop-filter: blur(20px);
-        gap: 15px;
-    }
-
-    .nav-links.nav-active {
-        display: flex;
-        animation: slideDown 0.3s ease-out;
-    }
-
-    .nav-links a {
-        margin: 0;
-        text-align: center;
-        background: var(--bg-secondary);
-        border: 1px solid var(--border);
-        padding: 12px 16px;
-        font-size: 1em;
-    }
-
-    .nav-links a:hover {
-        background: linear-gradient(45deg, var(--accent), #4da6ff);
-        color: var(--bg) !important;
-        transform: translateY(-1px);
-        border: 1px solid var(--accent-light);
-    }
-
-    .hamburger {
-        display: flex;
-    }
-}
-
-@keyframes slideDown {
-    from {
-        opacity: 0;
-        transform: translateY(-10px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
+footer {
+  text-align: center;
+  padding: 1rem;
+  background-color: var(--muted);
+  color: var(--text);
+  border-top: 1px solid var(--border);
 }

--- a/src/styles/pages.css
+++ b/src/styles/pages.css
@@ -3,15 +3,14 @@
 /* General page container */
 .page-container {
     max-width: 1200px;
-    margin: 0 auto;
+    margin: 20px auto;
     padding: 40px 20px;
-    background: rgba(255, 255, 255, 0.02);
+    background: var(--bg-secondary);
     -webkit-backdrop-filter: blur(10px);
     backdrop-filter: blur(10px);
-    margin: 20px;
     border-radius: 15px;
-    border: 1px solid rgba(255, 255, 255, 0.05);
-    box-shadow: 0 8px 32px rgba(15, 52, 96, 0.2);
+    border: 1px solid var(--border);
+    box-shadow: 0 8px 32px var(--accent-light);
     min-height: calc(100vh - 200px);
 }
 
@@ -20,13 +19,13 @@
     font-size: 2.5em;
     font-family: 'Dancing Script', cursive;
     font-weight: bold;
-    background: linear-gradient(45deg, #66ccff, #4da6ff, #3385ff);
+    background: linear-gradient(45deg, var(--accent), #4da6ff, #3385ff);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     background-clip: text;
     text-align: center;
     margin-bottom: 30px;
-    text-shadow: 0 2px 10px rgba(102, 204, 255, 0.3);
+    text-shadow: 0 2px 10px var(--accent-light);
 }
 
 /* Progress animation for sorting */
@@ -38,10 +37,10 @@
 
 /* Enhanced visualization styles */
 .visualization-area {
-    background: rgba(255, 255, 255, 0.03) !important;
+    background: var(--bg-tertiary) !important;
     padding: 40px !important;
     border-radius: 15px !important;
-    border: 1px solid rgba(102, 204, 255, 0.1) !important;
+    border: 1px solid var(--border) !important;
     margin: 30px 0 !important;
     min-height: 400px !important;
     display: flex !important;
@@ -50,40 +49,12 @@
     overflow-x: auto !important;
 }
 
-/* Mobile responsiveness for visualization */
-@media (max-width: 768px) {
-    .visualization-area {
-        padding: 20px 10px !important;
-        margin: 20px 0 !important;
-        min-height: 350px !important;
-    }
-    
-    .page-container {
-        padding: 20px 10px !important;
-        margin: 10px !important;
-    }
-    
-    .page-title {
-        font-size: 2em !important;
-        margin-bottom: 20px !important;
-    }
-    
-    .controls-section {
-        margin-bottom: 20px !important;
-    }
-    
-    .controls-section > div {
-        grid-template-columns: 1fr !important;
-        gap: 15px !important;
-    }
-}
-
 /* Controls section */
 .controls-section {
-    background: rgba(255, 255, 255, 0.03);
+    background: var(--bg-tertiary);
     padding: 30px;
     border-radius: 15px;
-    border: 1px solid rgba(102, 204, 255, 0.1);
+    border: 1px solid var(--border);
     margin-bottom: 30px;
     display: flex;
     flex-wrap: wrap;
@@ -94,8 +65,8 @@
 
 /* Buttons */
 .btn {
-    background: linear-gradient(45deg, #66ccff, #4da6ff);
-    color: #1a1a2e;
+    background: linear-gradient(45deg, var(--accent), #4da6ff);
+    color: var(--bg);
     border: none;
     padding: 12px 24px;
     font-size: 1em;
@@ -104,14 +75,14 @@
     border-radius: 25px;
     cursor: pointer;
     transition: all 0.3s ease;
-    box-shadow: 0 4px 15px rgba(102, 204, 255, 0.3);
+    box-shadow: 0 4px 15px var(--accent-light);
     text-transform: uppercase;
     letter-spacing: 0.5px;
 }
 
 .btn:hover {
     transform: translateY(-2px) scale(1.05);
-    box-shadow: 0 8px 25px rgba(102, 204, 255, 0.4);
+    box-shadow: 0 8px 25px var(--accent-light);
     background: linear-gradient(45deg, #4da6ff, #3385ff);
 }
 
@@ -119,26 +90,26 @@
     opacity: 0.5;
     cursor: not-allowed;
     transform: none;
-    box-shadow: 0 2px 8px rgba(102, 204, 255, 0.2);
+    box-shadow: 0 2px 8px var(--accent-light);
 }
 
 .btn-secondary {
-    background: rgba(255, 255, 255, 0.1);
-    color: #e0e6ed;
-    border: 1px solid rgba(255, 255, 255, 0.2);
+    background: var(--bg-secondary);
+    color: var(--text);
+    border: 1px solid var(--border);
 }
 
 .btn-secondary:hover {
-    background: rgba(255, 255, 255, 0.2);
-    color: #66ccff;
-    border-color: rgba(102, 204, 255, 0.5);
+    background: var(--accent-light);
+    color: var(--accent);
+    border-color: var(--accent);
 }
 
 /* Select dropdowns */
 .select {
-    background: rgba(255, 255, 255, 0.05);
-    color: #e0e6ed;
-    border: 1px solid rgba(255, 255, 255, 0.1);
+    background: var(--bg-secondary);
+    color: var(--text);
+    border: 1px solid var(--border);
     padding: 10px 15px;
     border-radius: 10px;
     font-family: 'Poppins', sans-serif;
@@ -149,21 +120,21 @@
 
 .select:focus {
     outline: none;
-    border-color: rgba(102, 204, 255, 0.5);
-    background: rgba(255, 255, 255, 0.08);
-    box-shadow: 0 0 15px rgba(102, 204, 255, 0.2);
+    border-color: var(--accent);
+    background: var(--bg-tertiary);
+    box-shadow: 0 0 15px var(--accent-light);
 }
 
 .select option {
-    background: #1a1a2e;
-    color: #e0e6ed;
+    background: var(--bg);
+    color: var(--text);
 }
 
 /* Input fields */
 .input {
-    background: rgba(255, 255, 255, 0.05);
-    color: #e0e6ed;
-    border: 1px solid rgba(255, 255, 255, 0.1);
+    background: var(--bg-secondary);
+    color: var(--text);
+    border: 1px solid var(--border);
     padding: 10px 15px;
     border-radius: 10px;
     font-family: 'Poppins', sans-serif;
@@ -173,31 +144,17 @@
 
 .input:focus {
     outline: none;
-    border-color: rgba(102, 204, 255, 0.5);
-    background: rgba(255, 255, 255, 0.08);
-    box-shadow: 0 0 15px rgba(102, 204, 255, 0.2);
+    border-color: var(--accent);
+    background: var(--bg-tertiary);
+    box-shadow: 0 0 15px var(--accent-light);
 }
 
 /* Labels */
 .label {
     font-family: 'Poppins', sans-serif;
-    color: #b8c5d1;
+    color: var(--text-muted);
     font-weight: 500;
     margin-right: 10px;
-}
-
-/* Visualization area */
-.visualization-area {
-    background: rgba(255, 255, 255, 0.03);
-    padding: 40px;
-    border-radius: 15px;
-    border: 1px solid rgba(102, 204, 255, 0.1);
-    margin: 30px 0;
-    min-height: 400px;
-    display: flex;
-    align-items: flex-end;
-    justify-content: center;
-    overflow-x: auto;
 }
 
 /* Array bars for sorting visualization */
@@ -205,7 +162,7 @@
     margin: 0 2px;
     border-radius: 4px 4px 0 0;
     transition: all 0.3s ease;
-    box-shadow: 0 2px 8px rgba(102, 204, 255, 0.2);
+    box-shadow: 0 2px 8px var(--accent-light);
 }
 
 /* Status message */
@@ -213,33 +170,33 @@
     text-align: center;
     font-family: 'Poppins', sans-serif;
     font-size: 1.2em;
-    color: #66ccff;
+    color: var(--accent);
     margin: 20px 0;
     padding: 15px;
-    background: rgba(102, 204, 255, 0.1);
-    border: 1px solid rgba(102, 204, 255, 0.2);
+    background: var(--accent-light);
+    border: 1px solid var(--accent);
     border-radius: 10px;
 }
 
 /* Algorithm info section */
 .algorithm-info {
-    background: rgba(255, 255, 255, 0.03);
+    background: var(--bg-tertiary);
     padding: 30px;
     border-radius: 15px;
-    border: 1px solid rgba(102, 204, 255, 0.1);
+    border: 1px solid var(--border);
     margin-top: 30px;
 }
 
 .algorithm-info h3 {
     font-family: 'Poppins', sans-serif;
-    color: #66ccff;
+    color: var(--accent);
     font-size: 1.3em;
     margin-bottom: 15px;
 }
 
 .algorithm-info p {
     font-family: 'Poppins', sans-serif;
-    color: #b8c5d1;
+    color: var(--text-muted);
     line-height: 1.6;
     margin-bottom: 10px;
 }
@@ -247,8 +204,8 @@
 /* Complexity badges */
 .complexity-badge {
     display: inline-block;
-    background: linear-gradient(45deg, #66ccff, #4da6ff);
-    color: #1a1a2e;
+    background: linear-gradient(45deg, var(--accent), #4da6ff);
+    color: var(--bg);
     padding: 5px 12px;
     border-radius: 15px;
     font-size: 0.9em;
@@ -265,6 +222,7 @@
     
     .page-title {
         font-size: 2em;
+        margin-bottom: 20px;
     }
     
     .controls-section {
@@ -280,5 +238,10 @@
     .visualization-area {
         padding: 20px;
         min-height: 300px;
+    }
+    
+    .controls-section > div {
+        grid-template-columns: 1fr !important;
+        gap: 15px !important;
     }
 }

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,0 +1,100 @@
+
+:root {
+  /* Light theme */
+  --bg: #ffffff;
+  --text: #0b0b0b;
+  --muted: #f6f7f9;
+  --card: #ffffff;
+  --border: #e5e7eb;
+  --accent: #2563eb;
+
+  /* Visualization bars */
+  --bar: #60a5fa;
+  --bar-active: #34d399;
+  --bar-compare: #f59e0b;
+
+  /* Buttons */
+  --button-bg: var(--accent);
+  --button-text: #ffffff;
+  --button-disabled-bg: #cbd5e1;
+  --reset-bg: #f97316;
+}
+
+:root[data-theme='dark'] {
+  /* Dark theme */
+  --bg: #0b0f19;
+  --text: #e5e7eb;
+  --muted: #111827;
+  --card: #111827;
+  --border: #1f2937;
+  --accent: #60a5fa;
+
+  /* Visualization bars */
+  --bar: #93c5fd;
+  --bar-active: #34d399;
+  --bar-compare: #fbbf24;
+
+  /* Buttons */
+  --button-bg: var(--accent);
+  --button-text: #0b0b0b;
+  --button-disabled-bg: #374151;
+  --reset-bg: #f97316;
+}
+
+/* Global resets */
+html, body, #root {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: 'Poppins', sans-serif;
+}
+
+/* Form elements */
+button, input, select {
+  color: var(--text);
+  background: var(--muted);
+  border: 1px solid var(--border);
+  transition: all 0.3s ease;
+}
+
+/* Buttons */
+button {
+  background: var(--button-bg);
+  color: var(--button-text);
+  border-radius: 14px;
+  padding: 10px 20px;
+  cursor: pointer;
+}
+
+button:hover:not(:disabled) {
+  filter: brightness(1.1);
+}
+
+button:disabled {
+  background: var(--button-disabled-bg);
+  cursor: not-allowed;
+}
+
+/* Special reset button */
+button.reset-btn {
+  background: var(--reset-bg);
+  color: #fff;
+  border-radius: 10px;
+}
+
+/* Array bars */
+.array-bar {
+  background-color: var(--bar);
+}
+
+.array-bar.active {
+  background-color: var(--bar-active);
+}
+
+.array-bar.compare {
+  background-color: var(--bar-compare);
+}


### PR DESCRIPTION
## Summary
Implements light/dark theme using CSS variables and a small ThemeProvider.
Adds a ThemeToggle button. User preference persists in localStorage and
defaults to system preference on first load.

## Changes
- new: src/styles/theme.css
- new: src/hooks/useTheme.js (context + hook + persistence)
- new: src/components/ThemeToggle.jsx
- edit: src/index.js (wrap App with ThemeProvider, import theme.css)
- edit: src/App.js (render ThemeToggle in header)
- edit: replaced hard-coded colors in styles/components with theme tokens


## Linked Issue
Closes #4