### PR TITLE
Added visibility to text in features section

### DIFF
--- a/src/styles/ExportDemo.css
+++ b/src/styles/ExportDemo.css
@@ -3,13 +3,14 @@
     max-width: 1200px;
     margin: 0 auto;
     padding: 30px 20px;
-    color: #333;
+    /* color:#667eea; */
+    color:#2c3e50;
     line-height: 1.6;
 }
 
 .export-demo h2 {
     text-align: center;
-    color: #2c3e50;
+    /* color:red; */
     margin-bottom: 40px;
     font-size: 2.5rem;
     font-weight: 700;
@@ -73,36 +74,40 @@
 }
 
 .usage-steps {
-    background: #f8f9fa;
+    /* background-color: red; */
     padding: 40px;
     border-radius: 15px;
     margin-bottom: 40px;
+    color:white;
 }
 
 .usage-steps h3 {
     text-align: center;
-    color: #2c3e50;
+    color: white;
     margin-bottom: 30px;
     font-size: 1.8rem;
+    /* background-color: white; */
 }
 
 .steps-container {
+     /* background-color: aliceblue; */
     display: grid;
     gap: 25px;
+   
 }
 
 .step {
+
     display: flex;
     align-items: flex-start;
     gap: 20px;
     padding: 20px;
-    background: white;
     border-radius: 10px;
     box-shadow: 0 5px 15px rgba(0, 0, 0, 0.08);
 }
 
 .step-number {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+
     color: white;
     width: 40px;
     height: 40px;


### PR DESCRIPTION
There was an issue in the unclear visibility of the text in the ExportDemo features  section at homepage.

Now i have fixed the issue . Previously it was looks like this-

<img width="1804" height="869" alt="Screenshot 2025-08-13 223057" src="https://github.com/user-attachments/assets/78ad4492-cde2-4a7c-b88f-7da61550f526" />

But now it is visible -

<img width="1909" height="1015" alt="Screenshot 2025-08-14 151821" src="https://github.com/user-attachments/assets/5a3cefd0-6f04-4ff8-89d3-a3fedf40ea35" />

There was the same problem in the top H2 tag -

<img width="1896" height="648" alt="Screenshot 2025-08-14 152111" src="https://github.com/user-attachments/assets/b99d9563-2672-4c2a-b26f-c16f405aa058" />

Now it is clear and matching with the UI theme  -

<img width="1871" height="707" alt="Screenshot 2025-08-14 151843" src="https://github.com/user-attachments/assets/0f831df5-3850-4d33-954a-4d62dc6db55f" />

@RhythmPahwa14 can you please check and merge this PR . This was the #28 issue. 
 Thanks! 

 