### PR TITLE
Fix: Remove duplicate Back to Top #135

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -35,7 +35,6 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-      <button id="backToTop" title="Go to top">↑</button>
       <!-- Link to external JavaScript -->
   <script src="src/navigatetotop.js"></script>
 


### PR DESCRIPTION
## Summary
- Removed the redundant "Back to Top" button from HTML.
- Ensured only one functional button remains on the page.

## Fixes
Closes #135

## Before
- Two "Back to Top" buttons were visible.
- Only one worked; the other was useless.

## After
- Only one working button is visible.
- Cleaner UI and less user confusion.

<img width="1454" height="807" alt="Screenshot 2025-08-21 at 10 32 16 PM" src="https://github.com/user-attachments/assets/2e5ca27d-c5e8-4e93-839d-0dea3180dc15" />
