### PR TITLE
fix: align GitHub star button & improve theme toggle icons

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -35,7 +35,6 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-      <button id="backToTop" title="Go to top">↑</button>
       <!-- Link to external JavaScript -->
   <script src="src/navigatetotop.js"></script>
 

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -2,6 +2,8 @@ import React, { useState } from 'react';
 import { Link, NavLink } from 'react-router-dom';
 import '../styles/navbar.css';
 import { useTheme } from '../ThemeContext'; // ← import useTheme
+import { FaGithub, FaMoon } from 'react-icons/fa6';
+import { FaSun } from 'react-icons/fa6';
 
 const Header = () => {
     const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
@@ -31,43 +33,16 @@ const Header = () => {
 
                 <div className="nav-actions">
                     <a className="github-btn" href="https://github.com/RhythmPahwa14/AlgoVisualizer" target="_blank" rel="noreferrer noopener" aria-label="Open GitHub repository">
-                        <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                            <path fillRule="evenodd" d="M12 .5C5.73.5.9 5.33.9 11.6c0 4.88 3.16 9.02 7.55 10.48.55.1.75-.24.75-.53 0-.26-.01-1.12-.02-2.03-3.07.67-3.72-1.3-3.72-1.3-.5-1.26-1.22-1.6-1.22-1.6-.99-.67.07-.65.07-.65 1.1.08 1.68 1.12 1.68 1.12.97 1.66 2.55 1.18 3.17.9.1-.7.38-1.18.69-1.45-2.45-.28-5.02-1.22-5.02-5.43 0-1.2.43-2.18 1.13-2.95-.11-.28-.49-1.41.11-2.94 0 0 .93-.3 3.05 1.13.88-.24 1.82-.36 2.76-.36.94 0 1.88.12 2.76.36 2.12-1.43 3.05-1.13 3.05-1.13.6 1.53.22 2.66.11 2.94.7.77 1.13 1.75 1.13 2.95 0 4.22-2.58 5.14-5.04 5.41.39.33.73.99.73 2 0 1.44-.01 2.6-.01 2.95 0 .29.2.64.76.53 4.38-1.46 7.54-5.6 7.54-10.48C23.1 5.33 18.27.5 12 .5z" clipRule="evenodd"/>
-                        </svg>
+                        <FaGithub />
                         <span>Star</span>
                     </a>
 
                     {/* Dark/Light mode toggle */}
                     <button onClick={toggleTheme} className="theme-toggle-btn" aria-label="Toggle dark/light mode">
                         {theme === 'light' ? (
-                            <svg viewBox="0 0 32 32" aria-hidden="true" focusable="false">
-                                <circle cx="16" cy="16" r="12.4" fill="currentColor"/>
-                                <circle cx="22.5" cy="16" r="12.9" fill="currentColor"/>
-                            </svg>
+                            <FaMoon/>
                         ) : (
-                            <svg viewBox="0 0 32 32" aria-hidden="true" focusable="false">
-                                <defs>
-                                    <filter id="btnGlow" x="-50%" y="-50%" width="200%" height="200%">
-                                        <feDropShadow dx="0" dy="0" stdDeviation="2.8" floodColor="#0b3a57" floodOpacity="0.55"/>
-                                    </filter>
-                                </defs>
-                                <g filter="url(#btnGlow)">
-                                    <circle cx="16" cy="16" r="15" fill="#0b0e13"/>
-                                </g>
-                                <circle cx="16" cy="16" r="14" fill="none" stroke="#3b414c" strokeWidth="2"/>
-                                <circle cx="16" cy="16" r="12" fill="#2a2f39"/>
-                                <circle cx="16" cy="16" r="6.2" fill="#b9c8ff"/>
-                                <g fill="#b9c8ff">
-                                    <rect x="15" y="5" width="2" height="5" rx="1"/>
-                                    <rect x="15" y="22" width="2" height="5" rx="1"/>
-                                    <rect x="22" y="15" width="5" height="2" rx="1"/>
-                                    <rect x="5" y="15" width="5" height="2" rx="1"/>
-                                    <rect x="20.2" y="8.2" width="2" height="5" rx="1" transform="rotate(45 21.2 10.7)"/>
-                                    <rect x="9.8" y="18.8" width="2" height="5" rx="1" transform="rotate(45 10.8 21.3)"/>
-                                    <rect x="9.8" y="8.2" width="2" height="5" rx="1" transform="rotate(-45 10.8 10.7)"/>
-                                    <rect x="20.2" y="18.8" width="2" height="5" rx="1" transform="rotate(-45 21.2 21.3)"/>
-                                </g>
-                            </svg>
+                            <FaSun/>
                         )}
                     </button>
 

--- a/src/styles/navbar.css
+++ b/src/styles/navbar.css
@@ -104,6 +104,12 @@
     box-shadow: 0 0 8px rgba(59, 130, 246, 0.4);
 }
 
+.nav-actions{
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
 /* Light Mode Overrides */
 [data-theme="light"] .nav-links a {
     color: #013862 !important;
@@ -135,11 +141,7 @@
     font-size: 0.9rem;
     padding: 8px 14px;
     transition: all 0.25s ease;
-}
-
-.theme-toggle-btn {
-    background-color: var(--text-color);
-    color: var(--bg-color);
+    color: #ffffff
 }
 
 .theme-toggle-btn:hover {


### PR DESCRIPTION
Closes #136 

Light Mode
<img width="1454" height="85" alt="Screenshot 2025-08-21 at 11 21 24 PM" src="https://github.com/user-attachments/assets/ed158ebb-ad39-4c63-9da8-0fa70a8e1ed2" />


Dark Mode
<img width="1454" height="85" alt="Screenshot 2025-08-21 at 11 21 08 PM" src="https://github.com/user-attachments/assets/78743805-8614-4f9b-a20b-24c15dedc4a3" />