### PR TITLE
fix: remove list style from privacy and terms lists for consistent formatting

### DIFF
--- a/src/styles/privacy.css
+++ b/src/styles/privacy.css
@@ -68,6 +68,7 @@
 .privacy-list {
     padding-left: 1.5rem;
     margin: 1.5rem 0;
+    list-style: none;
 }
 
 .privacy-list li {

--- a/src/styles/terms.css
+++ b/src/styles/terms.css
@@ -110,6 +110,7 @@
 .terms-list {
     padding-left: 1.5rem;
     margin: 1.5rem 0;
+    list-style: none;
 }
 
 .terms-list li {


### PR DESCRIPTION

Fix double bullet points by using `list-style:none`

fixes #145 