### PR TITLE
Added  visibility to Hamburger Menu

### DIFF
--- a/src/styles/navbar.css
+++ b/src/styles/navbar.css
@@ -28,11 +28,11 @@
 .av-container {
     max-width: 1200px;
     margin: 0 auto;
-    padding: 14px 20px;
+    padding: 10px 15px;
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: 16px;
+    gap: 10px;
 }
 
 /* ----------------- Logo ----------------- */
@@ -182,16 +182,17 @@
 
 /* ----------------- Hamburger Menu ----------------- */
 .hamburger {
-    display: none;
+    display: flex;
     flex-direction: column;
     cursor: pointer;
-    border: none;
-    background: none;
+    border: 1px solid blue;
+    background:none;
     padding: 0;
+    width:15px;
 }
 
 .hamburger .bar {
-    width: 20px;
+    width: 15px;
     height: 2px;
     margin: 4px 0;
     background-color: #cfd9e6;
@@ -200,7 +201,7 @@
 
 /* Light mode hamburger */
 [data-theme="light"] .hamburger .bar {
-    background-color: #013862;
+    background-color:#6fa8ea;
 }
 
 /* ----------------- Responsive ----------------- */
@@ -213,12 +214,12 @@
         position: fixed;
         top: 64px;
         right: -100%;
-        height: calc(100vh - 64px);
+        height: calc(100vh - 40px);
         width: 100%;
         flex-direction: column;
         justify-content: flex-start;
         align-items: flex-start;
-        background: rgba(10, 10, 26, 0.95);
+        background:#e6edf3;
         backdrop-filter: blur(6px);
         padding: 20px;
         transition: right 0.35s ease-in-out;
@@ -245,7 +246,9 @@
     }
 
     .hamburger {
-        display: flex;
+        /* display: flex; */
+        display: block;
+        background-color: #8b949e;
     }
 }
 


### PR DESCRIPTION
I added visibility to the Hamburger menu in the both modes ( light and dark mode) in the responsiveness also.

Now it is look like this- 

<img width="1877" height="243" alt="Screenshot 2025-08-22 180123" src="https://github.com/user-attachments/assets/1236ab19-dbd8-43a5-84d8-a01d4458ae94" />

In the mobile responsiveness in dark mode -

<img width="1513" height="929" alt="Screenshot 2025-08-22 180049" src="https://github.com/user-attachments/assets/f322bc4e-796e-4dc8-8e66-41775f8e81c7" />

@RhythmPahwa14 please check this PR and merge it with label .
Thanks!