### PR TITLE
Fixed : Enhancement: Improve Hover Styling on 'Contribute on GitHub" Button

### DIFF
--- a/src/styles/Contributors.css
+++ b/src/styles/Contributors.css
@@ -340,6 +340,8 @@
 .btn-primary:hover {
   transform: translateY(-2px);
   box-shadow: 0 8px 16px rgba(99,102,241,0.3);
+  text-decoration: none;
+  color: white;
 }
 
 .btn-secondary {
@@ -352,6 +354,7 @@
   background: var(--highlight);
   color: white;
   transform: translateY(-2px);
+ text-decoration: none;
 }
 
 /* ------------------------


### PR DESCRIPTION
## What's New?
### Description:

This PR enhances the styling of the "Contribute on GitHub" button on the homepage to improve visual consistency and user experience.

### Changes Made:

- Removed underline on hover using text-decoration: none

- Changed hover text color to white for better contrast

- Ensured styling aligns with overall site aesthetics

### Related Issue:

Fixes: #163 

### BEFORE
<img width="1176" height="464" alt="y" src="https://github.com/user-attachments/assets/e6557042-cb13-4b84-b45b-38653ce3c9a2" />

### AFTER
<img width="955" height="313" alt="y" src="https://github.com/user-attachments/assets/51b329c5-baeb-420d-a1ab-eaa745411d37" />

Please merge this pull request.
