### PR TITLE
Fixed the color issue in Sorting Page for light theme as mentioned

### DIFF
--- a/src/pages/Sorting.js
+++ b/src/pages/Sorting.js
@@ -114,6 +114,21 @@ const Sorting = () => {
   const stopSortingRef = useRef(false);
   const [showCodeExplanation, setShowCodeExplanation] = useState(false);
 
+  // Contributed By Devika Harshey
+  const [theme, setTheme] = useState('light');
+  useEffect(() => {
+    const observer = new MutationObserver(() => {
+      if (document.documentElement.classList.contains('dark')) {
+        setTheme('dark');
+      } else {
+        setTheme('light');
+      }
+    });
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
+
+    return () => observer.disconnect();
+  }, []);
+
   const delayRef = useRef(delay);
   useEffect(() => { delayRef.current = delay; }, [delay]);
 
@@ -599,7 +614,7 @@ const Sorting = () => {
         {/* Pseudocode panel */}
         <div style={{ flex: '0 0 300px', minWidth: '280px', maxWidth: '100%', background: 'rgba(102,204,255,0.07)', border: '1px solid rgba(102,204,255,0.15)', borderRadius: '12px', padding: '18px', overflowX: 'auto' }}>
           <h3 style={{ color: '#66ccff', marginBottom: '10px' }}>{getAlgorithmName()} Pseudocode</h3>
-          <pre style={{ background: 'rgba(26,26,46,0.95)', borderRadius: '8px', padding: '14px', fontSize: '15px', color: '#e0e6ed', marginBottom: '10px', overflowX: 'auto' }}>
+          <pre style={{ background: theme === 'dark' ? 'rgba(26,26,46,0.95)' : 'rgba(255,255,255,0.95)', borderRadius: '8px', padding: '14px', fontSize: '15px', color: '#e0e6ed', marginBottom: '10px', overflowX: 'auto' }}>
             {(ALGORITHM_PSEUDOCODE[algorithm] || []).map((line) => (
               <div key={line.code} style={{ padding: '2px 6px' }}>{line.code}</div>
             ))}

--- a/src/styles/Sorting.css
+++ b/src/styles/Sorting.css
@@ -665,7 +665,12 @@ button:disabled {
     font-weight: bold;
 }
 
-
+/* Contributed By Devika Harshey */
+@media (prefers-color-scheme: dark) {
+    .stat-value {
+        color: #000000;
+    }
+}
 
 /* =========================
    Algorithm Information Section


### PR DESCRIPTION
Hey! @RhythmPahwa14  I've fixed the color issue in Sorting Page for light theme as mentioned. 

It looks like this now (refresh the page before that because for first time, it is appearing as it was previously.. maybe because of any existing states or styles) - 

<img width="1578" height="755" alt="image" src="https://github.com/user-attachments/assets/cc1d25a8-b2d8-4379-82c3-75f0ebd0c1f6" />

Please check it and merge if everything looks fine.