### PR TITLE
Added Dijkstra's Algorithm Visualization

### DIFF
--- a/src/components/GraphVisualizer.js
+++ b/src/components/GraphVisualizer.js
@@ -1,34 +1,73 @@
-import React, { useState, useRef, useEffect } from 'react';
-import '../styles/Graph.css';
+import React, { useState, useRef, useEffect } from "react";
+import "../styles/Graph.css";
 
 const GraphVisualizer = () => {
+  class SimplePriorityQueue {
+    constructor() {
+      this.elements = [];
+    }
+    enqueue(element, priority) {
+      this.elements.push({ element, priority });
+      this.elements.sort((a, b) => a.priority - b.priority);
+    }
+    dequeue() {
+      return this.elements.shift().element;
+    }
+    isEmpty() {
+      return this.elements.length === 0;
+    }
+  }
   const [nodes, setNodes] = useState([]);
   const [edges, setEdges] = useState([]);
   const [isAddingNode, setIsAddingNode] = useState(false);
   const [isAddingEdge, setIsAddingEdge] = useState(false);
-  const [startNode, setStartNode] = useState(null);
+  const [edgeStartNode, setEdgeStartNode] = useState(null);
   const canvasRef = useRef(null);
+  const [dijkstraStart, setDijkstraStart] = useState(null);
+  const [dijkstraEnd, setDijkstraEnd] = useState(null);
+  const [isVisualizing, setIsVisualizing] = useState(false);
+  const [visualState, setVisualState] = useState({
+    visited: new Set(),
+    path: [],
+  });
+  const [message, setMessage] = useState(
+    "Build your graph or select an algorithm."
+  );
+  const [result, setResult] = useState(null);
 
   useEffect(() => {
     const canvas = canvasRef.current;
-    const ctx = canvas.getContext('2d');
+    const ctx = canvas.getContext("2d");
     drawGraph(ctx);
-  }, [nodes, edges]);
+  }, [nodes, edges, visualState, dijkstraStart, dijkstraEnd]);
 
   const drawGraph = (ctx) => {
     ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
 
     // Draw edges
-    edges.forEach(edge => {
+    edges.forEach((edge) => {
       const start = nodes[edge.start];
       const end = nodes[edge.end];
       if (start && end) {
         ctx.beginPath();
         ctx.moveTo(start.x, start.y);
         ctx.lineTo(end.x, end.y);
-        ctx.strokeStyle = '#66ccff';
-        ctx.lineWidth = 2;
+        const isPathEdge = visualState.path.some(
+          (p) =>
+            (p.start === edge.start && p.end === edge.end) ||
+            (p.start === edge.end && p.end === edge.start)
+        );
+        ctx.strokeStyle = isPathEdge ? "#4ade80" : "#66ccff"; // Green for path
+        ctx.lineWidth = isPathEdge ? 4 : 2;
+
         ctx.stroke();
+        // Draw edge weight
+        const midX = (start.x + end.x) / 2;
+        const midY = (start.y + end.y) / 2;
+        ctx.fillStyle = "#e0e6ed";
+        ctx.font = "14px Arial";
+        ctx.textAlign = "center";
+        ctx.fillText(edge.weight, midX, midY - 10);
       }
     });
 
@@ -36,12 +75,24 @@ const GraphVisualizer = () => {
     nodes.forEach((node, index) => {
       ctx.beginPath();
       ctx.arc(node.x, node.y, 20, 0, 2 * Math.PI);
-      ctx.fillStyle = '#66ccff';
+
+      if (visualState.visited.has(index)) {
+        ctx.fillStyle = "#ffd93d"; // Yellow for visited
+      } else if (
+        index === parseInt(dijkstraStart) ||
+        index === parseInt(dijkstraEnd)
+      ) {
+        ctx.fillStyle = "#ff6b6b"; // Red for start/end points
+      } else {
+        ctx.fillStyle = "#66ccff"; // Default blue
+      }
       ctx.fill();
-      ctx.fillStyle = '#0f3460';
-      ctx.font = '16px Arial';
-      ctx.textAlign = 'center';
-      ctx.textBaseline = 'middle';
+
+      // This now draws the node number in a visible white color
+      ctx.fillStyle = "#FFFFFF";
+      ctx.font = "16px Arial";
+      ctx.textAlign = "center";
+      ctx.textBaseline = "middle";
       ctx.fillText(index, node.x, node.y);
     });
   };
@@ -56,35 +107,219 @@ const GraphVisualizer = () => {
       setNodes([...nodes, { x, y }]);
       setIsAddingNode(false);
     } else if (isAddingEdge) {
-      const clickedNodeIndex = nodes.findIndex(node => 
-        Math.sqrt((node.x - x)**2 + (node.y - y)**2) < 20
+      const clickedNodeIndex = nodes.findIndex(
+        (node) => Math.sqrt((node.x - x) ** 2 + (node.y - y) ** 2) < 20
       );
 
       if (clickedNodeIndex !== -1) {
-        if (startNode === null) {
-          setStartNode(clickedNodeIndex);
+        if (edgeStartNode === null) {
+          setEdgeStartNode(clickedNodeIndex);
+          setMessage(
+            `Selected node ${clickedNodeIndex}. Click another node to form an edge.`
+          );
         } else {
-          setEdges([...edges, { start: startNode, end: clickedNodeIndex }]);
-          setStartNode(null);
-          setIsAddingEdge(false);
+          const weight = parseInt(
+            prompt("Enter edge weight (positive number):", "1"),
+            10
+          );
+          if (!isNaN(weight) && weight > 0) {
+            setEdges([
+              ...edges,
+              { start: edgeStartNode, end: clickedNodeIndex, weight },
+            ]);
+            setEdgeStartNode(null);
+            setIsAddingEdge(false); // Or manage mode differently
+            setMessage("Edge added successfully!");
+          } else {
+            alert("Invalid weight. Please enter a positive number.");
+            setEdgeStartNode(null); // Reset on invalid input
+          }
         }
       }
     }
   };
 
+  const runDijkstra = () => {
+    if (dijkstraStart === null || dijkstraEnd === null) {
+      alert("Please select a start and end node first.");
+      return;
+    }
+
+    setIsVisualizing(true);
+    setVisualState({ visited: new Set(), path: [] }); // Reset previous visualization
+    setMessage(`Running Dijkstra's from ${dijkstraStart} to ${dijkstraEnd}...`);
+
+    const numNodes = nodes.length;
+    const distances = Array(numNodes).fill(Infinity);
+    const prev = Array(numNodes).fill(null);
+    const pq = new SimplePriorityQueue();
+    const visualizationSteps = [];
+
+    distances[dijkstraStart] = 0;
+    pq.enqueue(dijkstraStart, 0);
+
+    while (!pq.isEmpty()) {
+      const u = pq.dequeue();
+      visualizationSteps.push({ type: "visit", node: u });
+      if (u === dijkstraEnd) break;
+
+      edges.forEach((edge) => {
+        let v = -1;
+        if (edge.start === u) v = edge.end;
+        if (edge.end === u) v = edge.start;
+        if (v !== -1) {
+          const newDist = distances[u] + edge.weight;
+          if (newDist < distances[v]) {
+            distances[v] = newDist;
+            prev[v] = u;
+            pq.enqueue(v, newDist);
+          }
+        }
+      });
+    }
+
+    const path = [];
+    let current = dijkstraEnd;
+    while (current !== null) {
+      const p = prev[current];
+      if (p !== null) path.unshift({ start: p, end: current });
+      current = p;
+    }
+    visualizationSteps.push({ type: "path", path });
+    animateVisualization(visualizationSteps, distances, path);
+  };
+
+  const animateVisualization = (steps, distances, path) => {
+    let stepIndex = 0;
+    const interval = setInterval(() => {
+      if (stepIndex >= steps.length) {
+        clearInterval(interval);
+        setIsVisualizing(false);
+        setMessage("Visualization complete!");
+        const totalWeight = distances[dijkstraEnd];
+        if (totalWeight === Infinity) {
+          setResult({ path: "No path found", weight: "N/A" });
+        } else {
+          const nodePath = [dijkstraStart];
+          path.forEach((edge) => nodePath.push(edge.end));
+          setResult({ path: nodePath.join(" → "), weight: totalWeight });
+        }
+
+        return;
+      }
+      const step = steps[stepIndex];
+      if (step.type === "visit") {
+        setVisualState((prev) => ({
+          ...prev,
+          visited: new Set(prev.visited).add(step.node),
+        }));
+      } else if (step.type === "path") {
+        setVisualState((prev) => ({ ...prev, path: step.path }));
+      }
+      stepIndex++;
+    }, 300); // Animation speed
+  };
+
+  const handleClear = () => {
+    setNodes([]);
+    setEdges([]);
+    setDijkstraStart(null);
+    setDijkstraEnd(null);
+    setVisualState({ visited: new Set(), path: [] });
+    setMessage("Graph cleared. Ready to start again.");
+    setResult(null);
+  };
+
   return (
     <div className="graph-visualizer-container">
       <div className="graph-controls">
-        <button className="btn" onClick={() => setIsAddingNode(true)} disabled={isAddingNode || isAddingEdge}>
+        <button
+          className="btn"
+          onClick={() => setIsAddingNode(true)}
+          disabled={isAddingNode || isAddingEdge}
+        >
           Add Node
         </button>
-        <button className="btn" onClick={() => setIsAddingEdge(true)} disabled={isAddingNode || isAddingEdge || nodes.length < 2}>
+        <button
+          className="btn"
+          onClick={() => setIsAddingEdge(true)}
+          disabled={isAddingNode || isAddingEdge || nodes.length < 2}
+        >
           Add Edge
         </button>
-        <button className="btn btn-secondary" onClick={() => { setNodes([]); setEdges([]); }}>
+        <button
+          className="btn btn-secondary"
+          onClick={handleClear}
+          disabled={isVisualizing}
+        >
           Clear
         </button>
       </div>
+      <div className="algorithm-controls">
+        {/* Left side for the controls */}
+        <div className="controls-left">
+          <div className="control-group">
+            <label>Start Node:</label>
+            <select
+              value={dijkstraStart ?? ""}
+              onChange={(e) =>
+                setDijkstraStart(
+                  e.target.value === "" ? null : parseInt(e.target.value)
+                )
+              }
+              disabled={isVisualizing}
+            >
+              <option value="">Select</option>
+              {nodes.map((_, i) => (
+                <option key={i} value={i}>
+                  {i}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="control-group">
+            <label>End Node:</label>
+            <select
+              value={dijkstraEnd ?? ""}
+              onChange={(e) =>
+                setDijkstraEnd(
+                  e.target.value === "" ? null : parseInt(e.target.value)
+                )
+              }
+              disabled={isVisualizing}
+            >
+              <option value="">Select</option>
+              {nodes.map((_, i) => (
+                <option key={i} value={i}>
+                  {i}
+                </option>
+              ))}
+            </select>
+          </div>
+          <button
+            className="btn"
+            onClick={runDijkstra}
+            disabled={isVisualizing || nodes.length < 2}
+          >
+            Run Dijkstra
+          </button>
+        </div>
+
+        {/* Right side for the result, appears only when result is set */}
+        {result && (
+          <div className="result-box">
+            <h4>Shortest Path Result</h4>
+            <p>
+              <strong>Path:</strong> {result.path}
+            </p>
+            <p>
+              <strong>Total Weight:</strong> {result.weight}
+            </p>
+          </div>
+        )}
+      </div>
+      <p className="message-bar">{message}</p>
+
       <canvas
         ref={canvasRef}
         width={800}

--- a/src/pages/Graph.js
+++ b/src/pages/Graph.js
@@ -1,34 +1,63 @@
-import React from 'react';
-import GraphVisualizer from '../components/GraphVisualizer';
-import '../styles/pages.css';
+import React from "react";
+import GraphVisualizer from "../components/GraphVisualizer";
+import "../styles/pages.css";
 
 const Graph = () => {
   return (
-    <div className="page-container" style={{ maxWidth: '1200px', margin: '0 auto', padding: '20px' }}>
+    <div
+      className="page-container"
+      style={{ maxWidth: "1200px", margin: "0 auto", padding: "20px" }}
+    >
       <h1 className="page-title">Graph Algorithms Visualization</h1>
-      <p style={{ textAlign: 'center', color: '#e0e6ed', marginBottom: '30px' }}>
-        Create your own graph by adding nodes and edges, and visualize graph traversal algorithms.
+      <p
+        style={{ textAlign: "center", color: "#e0e6ed", marginBottom: "30px" }}
+      >
+        Create your own graph by adding nodes and edges, and visualize graph
+        traversal algorithms.
       </p>
 
       {/* Informative Description Section */}
-      <div className="algorithm-info" style={{ marginBottom: '30px' }}>
-        <h3 style={{ color: '#66ccff' }}>What is a Graph?</h3>
-        <p style={{ color: '#e0e6ed' }}>
-          A graph is a non-linear data structure consisting of a set of vertices (or nodes) and a set of edges connecting these vertices. Graphs are used to model relationships between objects and are fundamental in computer science for solving a wide variety of problems.
+      <div className="algorithm-info" style={{ marginBottom: "30px" }}>
+        <h3 style={{ color: "#66ccff" }}>What is a Graph?</h3>
+        <p style={{ color: "#e0e6ed" }}>
+          A graph is a non-linear data structure consisting of a set of vertices
+          (or nodes) and a set of edges connecting these vertices. Graphs are
+          used to model relationships between objects and are fundamental in
+          computer science for solving a wide variety of problems.
         </p>
         <div className="complexity-grid">
           <div className="complexity-row">
             <span className="complexity-label">Vertices (Nodes):</span>
-            <span style={{ color: '#e0e6ed' }}>The fundamental units of which graphs are formed.</span>
+            <span style={{ color: "#e0e6ed" }}>
+              The fundamental units of which graphs are formed.
+            </span>
           </div>
           <div className="complexity-row">
             <span className="complexity-label">Edges:</span>
-            <span style={{ color: '#e0e6ed' }}>The connections between pairs of vertices.</span>
+            <span style={{ color: "#e0e6ed" }}>
+              The connections between pairs of vertices.
+            </span>
           </div>
         </div>
-        <p style={{ color: '#e0e6ed', marginTop: '15px' }}>
-          <strong>Real-world applications:</strong> Social networks, GPS and mapping systems, computer networks, and recommendation engines all rely on graph structures to represent and analyze data.
+        <p style={{ color: "#e0e6ed", marginTop: "15px" }}>
+          <strong>Real-world applications:</strong> Social networks, GPS and
+          mapping systems, computer networks, and recommendation engines all
+          rely on graph structures to represent and analyze data.
         </p>
+      </div>
+      <div className="algorithm-info" style={{ marginBottom: "30px" }}>
+        <h3 style={{ color: "#66ccff" }}>Dijkstra's Shortest Path Algorithm</h3>
+        <p style={{ color: "#e0e6ed" }}>
+          Dijkstra's algorithm finds the shortest path between two nodes in a
+          weighted graph. It works by visiting nodes and greedily selecting the
+          unvisited node with the smallest known distance.
+        </p>
+        <div className="complexity-grid">
+          <div className="complexity-row">
+            <span className="complexity-label">Time Complexity:</span>
+            <span style={{ color: "#e0e6ed" }}>O(E + V log V)</span>
+          </div>
+        </div>
       </div>
 
       <GraphVisualizer />

--- a/src/styles/Graph.css
+++ b/src/styles/Graph.css
@@ -1,18 +1,85 @@
 .graph-visualizer-container {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 20px;
-  }
-  
-  .graph-controls {
-    display: flex;
-    gap: 12px;
-  }
-  
-  .graph-canvas {
-    background: rgba(15, 52, 96, 0.1);
-    border-radius: 15px;
-    border: 1px solid rgba(102, 204, 255, 0.2);
-    cursor: crosshair;
-  }
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+}
+
+.graph-controls {
+  display: flex;
+  gap: 12px;
+}
+
+.graph-canvas {
+  background: rgba(15, 52, 96, 0.1);
+  border-radius: 15px;
+  border: 1px solid rgba(102, 204, 255, 0.2);
+  cursor: crosshair;
+}
+
+.algorithm-controls {
+  display: flex;
+  justify-content: space-between; /* This pushes items to the sides */
+  align-items: flex-start;
+  gap: 20px;
+  padding: 15px;
+  background-color: rgba(15, 52, 96, 0.1);
+  border: 1px solid rgba(102, 204, 255, 0.2);
+  border-radius: 12px;
+  margin-bottom: 10px;
+  min-height: 100px;
+}
+
+.controls-left {
+  display: flex;
+  align-items: center;
+  gap: 15px;
+  flex-wrap: wrap;
+}
+
+.control-group {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.algorithm-controls label {
+  color: #b8c5d1;
+  font-weight: 600;
+}
+
+.algorithm-controls select {
+  background-color: #0f3460;
+  color: #e0e6ed;
+  border: 1px solid #66ccff;
+  border-radius: 8px;
+  padding: 8px 12px;
+  min-width: 100px;
+}
+
+.result-box {
+  background-color: rgba(102, 204, 255, 0.1);
+  border: 1px solid rgba(102, 204, 255, 0.3);
+  border-radius: 8px;
+  padding: 10px 15px;
+  color: #e0e6ed;
+  min-width: 250px;
+}
+
+.result-box h4 {
+  margin: 0 0 8px 0;
+  color: #66ccff;
+  font-size: 16px;
+}
+
+.result-box p {
+  margin: 4px 0;
+  font-size: 14px;
+}
+
+.message-bar {
+  text-align: center;
+  color: #66ccff;
+  font-weight: 600;
+  min-height: 24px;
+}


### PR DESCRIPTION
Issue id : #188 
Preview :
[Recording 2025-08-27 164031.zip](https://github.com/user-attachments/files/22005796/Recording.2025-08-27.164031.zip)

This PR introduces a visualization for Dijkstra's shortest path algorithm on the graph page.

## Key Changes:
- Users can now add weights to edges when creating a graph.
- Added UI controls to select a start and end node for the algorithm.
- The visualization animates the process by highlighting visited nodes and shows the final shortest path.
- A result box displays the node path and its total weight upon completion.

## How to Test:
- Navigate to the Graph page.
- Create a weighted graph with several nodes and edges.
- Select a Start Node and End Node from the dropdowns.
- Click "Run Dijkstra" to view the animation and the final result.