### PR TITLE
Update FAQ chatbot UI (color scheme, fixes & polish)

### DIFF
--- a/src/components/FaqChatbot.jsx
+++ b/src/components/FaqChatbot.jsx
@@ -64,7 +64,7 @@ const FaqChatbot = () => {
         </div>
       )}
       <button className="chat-toggle-btn" onClick={handleToggle}>
-        {isOpen ? <X size={24} /> : <MessageSquare size={24} />}
+        <MessageSquare size={24} />
       </button>
     </div>
   );

--- a/src/styles/faq-chatbot.css
+++ b/src/styles/faq-chatbot.css
@@ -1,169 +1,151 @@
-/* Styling for the FAQ Chatbot */
+/* FAQ Chatbot Styling */
 .chatbot-container {
-    position: fixed;
-    bottom: 80px;
-    right: 25px;
-    z-index: 1000;
-  }
-  
-  .chat-toggle-btn {
-    background-color: #ff4b5c; 
-    color: white;
-    border: none;
-    width: 60px;
-    height: 60px;
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
-    transition: all 0.3s ease;
-  }
-  
-  .chat-toggle-btn:hover {
-    transform: scale(1.1);
-    background-color: #ff1e1e;
-  }
-  
-  .chat-window {
-    width: 350px;
-    height: 500px;
-    background: white;
-    border-radius: 15px;
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
-    display: flex;
-    flex-direction: column;
-    overflow: hidden;
-    border: 1px solid #eee;
-  }
-  
-  .chat-header {
-    background: #f7f7f7;
-    padding: 15px;
-    border-bottom: 1px solid #e0e0e0;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    color: #ff4b5c;
-  }
-  
-  .chat-header h3 {
-    margin: 0;
-    font-size: 1rem;
-    font-weight: 600;
-  }
-  
-  .close-btn {
-    background: none;
-    border: none;
-    cursor: pointer;
-    color: #ff4b5c;
-  }
-  
-  .chat-body {
-    flex-grow: 1;
-    padding: 15px;
-    overflow-y: auto;
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-  }
-  
-  .chat-message {
-    padding: 10px 15px;
-    border-radius: 18px;
-    max-width: 80%;
-    line-height: 1.5;
-    font-size: 0.9rem;
-    
-  }
-  
-  .chat-message.bot {
-    background-color: #f1f0f0;
-    color: #333;
-    align-self: flex-start;
-    border-bottom-left-radius: 4px;
-  }
-  
-  .chat-message.user {
-    background-color: #ff4b5c;
-    color: white;
-    align-self: flex-end;
-    border-bottom-right-radius: 4px;
-    
-  }
-  
-  .chat-footer {
-    padding: 10px;
-    border-top: 1px solid #e0e0e0;
-    display: flex;
-    gap: 10px;
-  }
-  
-  .chat-footer input {
-    flex-grow: 1;
-    border: 1px solid #ccc;
-    border-radius: 20px;
-    padding: 10px 15px;
-    font-size: 0.9rem;
-    outline: none;
-    color: #ff4b5c;
-  }
-  
-  .chat-footer button {
-    background: #ff4b5c;
-    color: white;
-    border: none;
-    border-radius: 50%;
-    width: 40px;
-    height: 40px;
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
-
-  /* 📱 Mobile Responsiveness */
-@media (max-width: 600px) {
-  .chat-window {
-    width: 90vw;       /* Take most of the screen width */
-    height: 70vh;      /* Adjust height for mobile */
-    right: 5%;         /* Small margin from right */
-    bottom: 100px;     /* Lift above toggle button */
-  }
-
-  .chat-toggle-btn {
-    width: 50px;
-    height: 50px;
-    bottom: 20px;
-    right: 20px;
-  }
-
-  .chat-header h3 {
-    font-size: 0.9rem;
-  }
-
-  .chat-message {
-    font-size: 0.8rem;
-    max-width: 90%;
-  }
-
-  .chat-footer input {
-    font-size: 0.8rem;
-    padding: 8px 12px;
-  }
-
-  .chat-footer button {
-    width: 36px;
-    height: 36px;
-  }
+  position: fixed;
+  bottom: 110px; /* avoid overlap with back-to-top */
+  right: 30px;
+  z-index: 1000;
 }
 
-@media (max-width: 400px) {
-  .chat-window {
-    width: 95vw;
-    height: 65vh;
-    right: 2.5%;
-  }
+/* Floating toggle button */
+.chat-toggle-btn {
+  background-color: #004aad;
+  color: white !important;
+  border: none;
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);
+  transition: all 0.25s ease;
+  font-size: 1.2rem;
+}
+
+.chat-toggle-btn:hover {
+  transform: scale(1.08);
+  background-color: #0066cc; /* lighter blue hover */
+}
+
+/* Chat window */
+.chat-window {
+  bottom: 150px;
+  max-height: 70vh;
+  width: 320px;
+  height: 460px;
+  background: #ffffff;
+  border-radius: 14px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.15);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid #e6eaf0;
+  font-family: "Inter", sans-serif;
+}
+
+/* Header */
+.chat-header {
+  background: #f5f8fc;
+  padding: 12px 16px;
+  border-bottom: 1px solid #e0e6f1;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: #004aad;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.close-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #004aad;
+  font-size: 1.2rem;
+  transition: color 0.25s ease;
+}
+
+.close-btn:hover {
+  background-color: #0066cc;
+  color:#f5f8fc
+}
+
+/* Chat body */
+.chat-body {
+  flex-grow: 1;
+  padding: 12px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.chat-message {
+  padding: 8px 12px;
+  border-radius: 14px;
+  max-width: 75%;
+  font-size: 0.88rem;
+  line-height: 1.4;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  white-space: pre-wrap;
+}
+
+/* Bot message */
+.chat-message.bot {
+  background-color: #f0f4fa;
+  color: #222;
+  align-self: flex-start;
+  border-bottom-left-radius: 4px;
+}
+
+/* User message */
+.chat-message.user {
+  background-color: #004aad;
+  color: white;
+  align-self: flex-end;
+  border-bottom-right-radius: 4px;
+}
+
+/* Footer */
+.chat-footer {
+  padding: 10px;
+  border-top: 1px solid #e0e6f1;
+  display: flex;
+  gap: 8px;
+}
+
+.chat-footer input {
+  flex-grow: 1;
+  border: 1px solid #cfd8e6;
+  border-radius: 18px;
+  padding: 8px 12px;
+  font-size: 0.88rem;
+  outline: none;
+  color: #004aad;
+}
+
+.chat-footer input:focus {
+  border-color: #0066cc;
+  box-shadow: 0 0 0 2px rgba(0, 102, 204, 0.15);
+}
+
+.chat-footer button {
+  background: #004aad;
+  color: white;
+  border: none;
+  border-radius: 50%;
+  width: 36px;
+  height: 36px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+  transition: background 0.25s ease;
+}
+
+.chat-footer button:hover {
+  background: #0066cc;
 }


### PR DESCRIPTION
addresses issue #219 

## Changes from task
- Updated color scheme: red → blue (#004aad)
- Fixed text overflow in chat messages
- Ensured UI consistency with white/blue site theme
- Fixed overlapping of FAQ toggle button and back-to-top button

##  Additional improvements
- Removed duplicate close button for a cleaner interface and improved the ui on hover 
- Adjusted chat window height for better desktop view
- Improved spacing and alignment for a more polished look

##  Before & After

*Before:*  
<img width="208" height="152" alt="Screenshot 2025-08-27 220324" src="https://github.com/user-attachments/assets/78148b79-0d37-4d39-a52a-d5ac45330e16" />

<img width="497" height="445" alt="Screenshot 2025-08-27 220308" src="https://github.com/user-attachments/assets/a1a68983-7c4d-4018-9454-bad4d242b66f" />

*After:*  
<img width="201" height="153" alt="Screenshot 2025-08-27 224221" src="https://github.com/user-attachments/assets/5ced5e84-9dd7-4e67-8017-75f8a66e0c7c" />

<img width="399" height="443" alt="Screenshot 2025-08-27 224324" src="https://github.com/user-attachments/assets/f1238900-c9da-40cf-92a1-071c82cb8a28" />

