### PR TITLE
fix overflowing

### DIFF
--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -53,6 +53,7 @@ const Settings = () => {
               style={{
                 display: 'flex',
                 alignItems: 'center',
+                width: 'fit-content',
                 gap: '0.5rem',
                 padding: '0.75rem 1rem',
                 background: 'var(--accent-color, #58a6ff)',


### PR DESCRIPTION
Fix the overflowing text in the settings tab

fixes #250

before:
<img width="1168" height="541" alt="Screenshot 2025-08-29 185124" src="https://github.com/user-attachments/assets/79c7a561-2290-4cbc-a9e1-75d5cd13ce37" />
after:
<img width="1173" height="549" alt="image" src="https://github.com/user-attachments/assets/aebfa4b3-57ba-40f2-a3af-0e597389c865" />

