### PR TITLE
Fix: auto scroll-to-top on route change + clean routing 

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,57 +1,55 @@
-import React from 'react';
-import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
-import { Analytics } from '@vercel/analytics/react';
-import Sidebar from './components/Sidebar';
-import Footer from './components/Footer';
-import Home from './pages/Home';
-import Sorting from './pages/Sorting';
-import Searching from './pages/Searching';
-import DataStructures from './pages/DataStructures';
-import Graph from './pages/Graph'; // <-- Import the new Graph component
-import Quiz from './pages/Quiz';
-import Settings from './pages/Settings';
-import Contributors from './components/Contributors';
-import ScrollToTop from './ScrollToTop';
-import About from './components/about';
-import Contact from './components/contact';
-import PrivacyPolicy from './components/Privacy';
-import TermsOfService from './components/terms';
-import Doubt from './components/Doubt';
-import AlgorithmDocumentation from './pages/Documentation';
-import './styles/components.css';
-import { ThemeProvider } from './ThemeContext'; // ← import ThemeProvider
+// src/App.jsx
+import React from "react";
+import { Route, Routes } from "react-router-dom";
+import Sidebar from "./components/Sidebar";
+import Footer from "./components/Footer";
+import Home from "./pages/Home";
+import Sorting from "./pages/Sorting";
+import Searching from "./pages/Searching";
+import DataStructures from "./pages/DataStructures";
+import Graph from "./pages/Graph";
+import Quiz from "./pages/Quiz";
+import Settings from "./pages/Settings";
+import Contributors from "./components/Contributors";
+import ScrollToTop from "./ScrollToTop";
+import About from "./components/about";
+import Contact from "./components/contact";
+import PrivacyPolicy from "./components/Privacy";
+import TermsOfService from "./components/terms";
+import Doubt from "./components/Doubt";
+import AlgorithmDocumentation from "./pages/Documentation";
+import "./styles/components.css";
 
 const App = () => {
-    return (
-        <ThemeProvider> {/* ← Wrap entire app with ThemeProvider */}
-            <Router>
-                <div className="app-container">
-                    <Sidebar />
-                    <main className="main-content main-content-with-sidebar">
-                        <Routes>
-                            <Route path="/" element={<Home />} />
-                            <Route path="/sorting" element={<Sorting />} />
-                            <Route path="/searching" element={<Searching />} />
-                            <Route path="/data-structures" element={<DataStructures />} />
-                            <Route path="/graph" element={<Graph />} /> {/* <-- Add the new route */}
-                            <Route path="/quiz" element={<Quiz />} />
-                            <Route path="/settings" element={<Settings />} />
-                            <Route path="/contributors" element={<Contributors />} />
-                            <Route path="/about" element={<About />} />
-                            <Route path="/contact" element={<Contact />} />
-                            <Route path="/terms" element={<TermsOfService />} />
-                            <Route path="/privacy" element={<PrivacyPolicy />} />
-                            <Route path="/documentation" element={<AlgorithmDocumentation />} />
-                        </Routes>
-                    </main>
-                    <Doubt />
-                    <Footer />
-                    <ScrollToTop />
-                    <Analytics />
-                </div>
-            </Router>
-        </ThemeProvider>
-    );
+  return (
+    <div className="app-container">
+      {/* This runs on every route change (Router is provided in index.jsx) */}
+      <ScrollToTop />
+
+      <Sidebar />
+
+      <main className="main-content main-content-with-sidebar">
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/sorting" element={<Sorting />} />
+          <Route path="/searching" element={<Searching />} />
+          <Route path="/data-structures" element={<DataStructures />} />
+          <Route path="/graph" element={<Graph />} />
+          <Route path="/quiz" element={<Quiz />} />
+          <Route path="/settings" element={<Settings />} />
+          <Route path="/contributors" element={<Contributors />} />
+          <Route path="/about" element={<About />} />
+          <Route path="/contact" element={<Contact />} />
+          <Route path="/terms" element={<TermsOfService />} />
+          <Route path="/privacy" element={<PrivacyPolicy />} />
+          <Route path="/documentation" element={<AlgorithmDocumentation />} />
+        </Routes>
+      </main>
+
+      <Doubt />
+      <Footer />
+    </div>
+  );
 };
 
 export default App;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,9 +1,18 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import App from './App';
-import './styles/components.css';
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import "./styles/components.css";
+import { ThemeProvider } from "./ThemeContext";
+import { BrowserRouter } from "react-router-dom";
+import { Analytics } from "@vercel/analytics/react";
 
-ReactDOM.render(
-    <App />,
-    document.getElementById('root')
+ReactDOM.createRoot(document.getElementById("root")).render(
+  <React.StrictMode>
+    <ThemeProvider>
+      <BrowserRouter>
+        <App />
+        <Analytics />
+      </BrowserRouter>
+    </ThemeProvider>
+  </React.StrictMode>
 );

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -12,6 +12,8 @@
 /* =========================
    Theme Variables
 ========================= */
+html { scroll-behavior: smooth; }
+
 :root {
     --bg-gradient: #0d1117;
     --container-bg: rgba(33, 38, 45, 0.95);


### PR DESCRIPTION
### Context
When I raised Issue #130, my goal was to improve the UX by making the page
auto-scroll to the visualization section after selecting a sorting algorithm.
Since then, the UI has been redesigned and that specific page flow has changed.

### Problem
Even with the new UI, the scroll issue was still present:  
navigating between routes (e.g., Privacy, Terms, About) would leave the user at the old scroll position instead of showing the top of the new page.

### Fix
- Implemented a `ScrollToTop` component that runs on every route change.
- Moved `BrowserRouter` setup to `index.jsx` (React 18 `createRoot`).
- Cleaned up duplicate Routers in `App.jsx`.
- Disabled browser’s default scroll restoration to avoid jumping back.
- Verified smooth scroll-to-top works across all pages.

### Outcome
Now whenever a user navigates to a new page, the viewport resets to the top,
making the UX consistent and intuitive across the app.

Closes #130
