### PR TITLE
Fixed footer links formatting misalignment when centered

### DIFF
--- a/src/styles/footer.css
+++ b/src/styles/footer.css
@@ -186,7 +186,7 @@
   margin: 0;
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: flex-start;
 }
 
 .footer-links li {
@@ -201,7 +201,7 @@
   font-size: 15px;
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   transition: all 0.3s ease;
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #349 

## Rationale for this change

The footer links along with the arrows were previously aligned in the center which made them look misaligned. This PR aligns the links to the left to give the website a more professional look.

## What changes are included in this PR?

Changes in the footer.css

## Are these changes tested?

Yes.

## Additional Info
Kindly review and merge this PR @RhythmPahwa14 