### PR TITLE
ComplexityBox correction

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,39 +1,48 @@
 // src/App.jsx
-import React from 'react';
-import { Route, Routes, useLocation } from 'react-router-dom';
-import { Analytics } from '@vercel/analytics/react';
-import Navbar from './components/Navbar';
-import Footer from './components/Footer';
-import Home from './pages/Home';
-import Sorting from './pages/Sorting';
-import Searching from './pages/Searching';
-import DataStructures from './pages/DataStructures';
-import Graph from './pages/Graph';
-import GraphBFS from './pages/GraphBFS';
-import GraphDFS from './pages/GraphDFS';
-import GraphDijkstra from './pages/GraphDijkstra';
-import GraphComparison from './components/GraphComparison';
-import Quiz from './pages/Quiz';
-import Settings from './pages/Settings';
-import Contributors from './components/Contributors';
-import ScrollToTop from './ScrollToTop';
-import About from './components/about';
-import Contact from './components/contact';
-import PrivacyPolicy from './components/Privacy';
-import TermsOfService from './components/terms';
-import CookiePolicy from './components/cookie-policy';
-import Doubt from './components/Doubt';
-import AlgorithmDocumentation from './pages/Documentation';
-import ComplexityBox from './components/ComplexityBox';
-import ThemeToggle from './components/ThemeToggle';
-import ContributorLeaderboard from './pages/ContributorLeaderboard';
-import LinkedListPage from './components/pages/LinkedListPage';
-import AlgorithmComparison from './components/AlgorithmComparison';
-import './styles/components.css';
+import React from "react";
+import { Route, Routes, useLocation } from "react-router-dom";
+import { Analytics } from "@vercel/analytics/react";
+import Navbar from "./components/Navbar";
+import Footer from "./components/Footer";
+import Home from "./pages/Home";
+import Sorting from "./pages/Sorting";
+import Searching from "./pages/Searching";
+import DataStructures from "./pages/DataStructures";
+import Graph from "./pages/Graph";
+import GraphBFS from "./pages/GraphBFS";
+import GraphDFS from "./pages/GraphDFS";
+import GraphDijkstra from "./pages/GraphDijkstra";
+import GraphComparison from "./components/GraphComparison";
+import Quiz from "./pages/Quiz";
+import Settings from "./pages/Settings";
+import Contributors from "./components/Contributors";
+import ScrollToTop from "./ScrollToTop";
+import About from "./components/about";
+import Contact from "./components/contact";
+import PrivacyPolicy from "./components/Privacy";
+import TermsOfService from "./components/terms";
+import CookiePolicy from "./components/cookie-policy";
+import Doubt from "./components/Doubt";
+import AlgorithmDocumentation from "./pages/Documentation";
+import ComplexityBox from "./components/ComplexityBox";
+import ThemeToggle from "./components/ThemeToggle";
+import ContributorLeaderboard from "./pages/ContributorLeaderboard";
+import LinkedListPage from "./components/pages/LinkedListPage";
+import AlgorithmComparison from "./components/AlgorithmComparison";
+import "./styles/components.css";
 
 const App = () => {
   const selectedAlgorithm = "bubbleSort"; // Default algorithm
   const location = useLocation();
+  const showComplexityBoxOn = [
+    "/sorting",
+    "/searching",
+    "/data-structures",
+    "/graph",
+    "/graph/bfs",
+    "/graph/dfs",
+    "/graph/dijkstra",
+  ];
 
   return (
     <div className="app-container">
@@ -48,15 +57,24 @@ const App = () => {
 
           {/* Sorting */}
           <Route path="/sorting" element={<Sorting />} />
-          <Route path="/components/AlgorithmComparison" element={<AlgorithmComparison />} /> 
+          <Route
+            path="/components/AlgorithmComparison"
+            element={<AlgorithmComparison />}
+          />
 
           {/* Searching */}
           <Route path="/searching" element={<Searching />} />
-          <Route path="/searching/comparison" element={<AlgorithmComparison />} /> 
+          <Route
+            path="/searching/comparison"
+            element={<AlgorithmComparison />}
+          />
 
           {/* Data Structures */}
           <Route path="/data-structures" element={<DataStructures />} />
-          <Route path="/data-structures/linked-list" element={<LinkedListPage />} />
+          <Route
+            path="/data-structures/linked-list"
+            element={<LinkedListPage />}
+          />
 
           {/* Graph */}
           <Route path="/graph" element={<Graph />} />
@@ -75,11 +93,13 @@ const App = () => {
           <Route path="/privacy" element={<PrivacyPolicy />} />
           <Route path="/cookies" element={<CookiePolicy />} />
           <Route path="/documentation" element={<AlgorithmDocumentation />} />
-          <Route path="/ContributorLeaderboard" element={<ContributorLeaderboard />} />
+          <Route
+            path="/ContributorLeaderboard"
+            element={<ContributorLeaderboard />}
+          />
         </Routes>
 
-        {/* Complexity Info Box - hide on GraphComparison */}
-        {location.pathname !== "/graph/comparison" && (
+        {showComplexityBoxOn.includes(location.pathname) && (
           <div style={{ marginTop: "2rem" }}>
             <ComplexityBox algorithm={selectedAlgorithm} />
           </div>


### PR DESCRIPTION
Which issue does this PR close?

Closes #371 

Rationale for this change
The ComplexityBox component was being rendered on all pages by default, even on pages where algorithm complexity details are not required (like Home, About, Contact, etc.).
This created unnecessary clutter and confusion for users.
Removing it from unrelated pages improves the UI/UX and keeps the interface clean.

<img width="1896" height="855" alt="image" src="https://github.com/user-attachments/assets/692f05f0-7ef2-4b76-8880-c3c7df1cc8ae" />


What changes are included in this PR?
Removed the unconditional rendering of ComplexityBox from App.jsx.
Updated the logic to render ComplexityBox only on algorithm-related pages (Sorting, Searching, Data Structures, and Graph pages).
Ensured ComplexityBox no longer appears on general pages like Home, About, Contact, Quiz, Settings, etc.
Are these changes tested?

✅ Yes, changes have been tested locally by navigating to different pages and confirming:
ComplexityBox is visible only on algorithm-related pages.
ComplexityBox is not visible on unrelated pages.

Are there any user-facing changes?
✅ Yes
Users will no longer see the complexity analysis box on all pages, only where analysis is required.
It will now only appear on relevant algorithm visualization pages, reducing visual noise.