### PR TITLE
Made graph visualizer options visible based on theme

### DIFF
--- a/src/styles/global-theme.css
+++ b/src/styles/global-theme.css
@@ -165,7 +165,7 @@ body {
 
 .btn-secondary:hover:not(:disabled) {
   background: var(--theme-accent); 
-  color: var(--theme-btn-primary-text); 
+  color: white; 
   border-color: var(--theme-accent);
   transform: translateY(-2px);
 }
@@ -175,7 +175,10 @@ body {
   cursor: not-allowed;
   transform: none;
   box-shadow: none;
+  background: #555 !important; /* or var(--theme-disabled-bg) if you want theme-based */
+  color: white !important;     /* force white text */
 }
+
 
 /* -----------------
    5. Forms
@@ -532,6 +535,20 @@ body {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+}
+/* Base select style */
+.algorithm-controls select {
+  background-color: var(--theme-input-bg);
+  color: var(--theme-input-text);
+  border: 1px solid var(--theme-input-border);
+  border-radius: 6px;
+  padding: 6px 10px;
+}
+
+/* Options (inside the dropdown) */
+.algorithm-controls select option {
+  background-color: var(--theme-input-bg);
+  color: var(--theme-input-text);
 }
 
 .algorithm-controls label {


### PR DESCRIPTION
## Which issue does this PR close?
- Closes #405 

## Rationale for this change
Made the options on graph visualizer change according to theme to increase user visibility.

## What changes are included in this PR?
Changed the styling of graph option controls to maintain theme consistency and visibility.

## Are these changes tested?
Changes are tested locally.

## Image for reference, after fix:
<img width="1366" height="768" alt="Screenshot (435)" src="https://github.com/user-attachments/assets/465cab7d-50fa-4476-828a-342a0e383768" />
<img width="1366" height="768" alt="Screenshot (436)" src="https://github.com/user-attachments/assets/0a25cbd3-9200-4fff-87e8-2f18d660a9aa" />
