### PR TITLE
Fix: Dark/Light Mode Support for ComplexityBox Component

### DIFF
--- a/src/components/ComplexityBox.jsx
+++ b/src/components/ComplexityBox.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import {
   BarChart,
   Bar,
@@ -10,7 +10,7 @@ import {
 } from "recharts";
 import "./complexityBox.css";
 
-// Data for famous algorithms
+// ===================== DATA =====================
 const dataMap = {
   BubbleSort: {
     Time: [
@@ -138,8 +138,8 @@ const dataMap = {
   },
 };
 
-// Neon colors
-const COLORS = {
+// ===================== COLORS =====================
+const COLORS_LIGHT = {
   Best: "#06b6d4",
   Average: "#8b5cf6",
   Worst: "#ec4899",
@@ -147,68 +147,101 @@ const COLORS = {
   "All Cases": "#f59e0b",
 };
 
-// Custom Tooltip
+const COLORS_DARK = {
+  Best: "#22d3ee",
+  Average: "#a78bfa",
+  Worst: "#f472b6",
+  Memory: "#a3e635",
+  "All Cases": "#fbbf24",
+};
+
+// ===================== TOOLTIP =====================
 const CustomTooltip = ({ active, payload }) => {
   if (active && payload && payload.length) {
     const { name, complexity } = payload[0].payload;
+    // Use data-theme attribute for theme detection
+    const isDarkMode =
+      document.documentElement.getAttribute("data-theme") === "dark";
     return (
       <div
         style={{
-          backgroundColor: "#1f2235",
+          backgroundColor: isDarkMode ? "#1f2937" : "#ffffff",
           padding: "10px 14px",
           borderRadius: "8px",
-          border: "1px solid #2a2d45",
-          color: "#fff",
+          border: `1px solid ${isDarkMode ? "#374151" : "#e5e7eb"}`,
+          color: isDarkMode ? "#e4e6ef" : "#1f2937",
           fontSize: "0.9rem",
           fontWeight: "500",
+          boxShadow: "0 4px 6px rgba(0, 0, 0, 0.1)",
         }}
       >
         <p style={{ margin: 0, fontWeight: "600", color: "#38bdf8" }}>
           {name} Case
         </p>
-        <p style={{ margin: 0 }}>⏱ Complexity: <b>{complexity}</b></p>
+        <p style={{ margin: 0 }}>
+          ⏱ Complexity: <b>{complexity}</b>
+        </p>
       </div>
     );
   }
   return null;
 };
 
+// ===================== COMPONENT =====================
 const ComplexityBox = () => {
   const [algo, setAlgo] = useState("BubbleSort");
   const [metric, setMetric] = useState("Time");
+  const [isDarkMode, setIsDarkMode] = useState(
+    document.documentElement.getAttribute("data-theme") === "dark"
+  );
+
+  useEffect(() => {
+    // Listen for changes to data-theme attribute
+    const observer = new MutationObserver(() => {
+      setIsDarkMode(
+        document.documentElement.getAttribute("data-theme") === "dark"
+      );
+    });
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["data-theme"],
+    });
+    return () => observer.disconnect();
+  }, []);
 
   const chartData = dataMap[algo][metric];
+  const colors = isDarkMode ? COLORS_DARK : COLORS_LIGHT;
 
   return (
-    <div className="complexity-container">
+    <div className={`complexity-container${isDarkMode ? " force-dark" : ""}`}>
       <h2 className="complexity-title">⚡ Complexity Analysis</h2>
-      <p className="complexity-subtitle">Big-O Notation for Famous Algorithms</p>
-
-      {/* Dropdowns */}
+      <p className="complexity-subtitle">
+        Big-O Notation for Famous Algorithms
+      </p>
       <div className="dropdown-container">
         <select value={algo} onChange={(e) => setAlgo(e.target.value)}>
           {Object.keys(dataMap).map((key) => (
-            <option key={key}>{key}</option>
+            <option key={key} value={key}>
+              {key}
+            </option>
           ))}
         </select>
         <select value={metric} onChange={(e) => setMetric(e.target.value)}>
-          <option>Time</option>
-          <option>Space</option>
+          <option value="Time">Time</option>
+          <option value="Space">Space</option>
         </select>
       </div>
-
-      {/* Chart */}
       <div className="chart-wrapper">
         <ResponsiveContainer width="100%" height={300}>
           <BarChart data={chartData} barSize={60}>
-            <XAxis dataKey="name" stroke="#aaa" />
-            <YAxis stroke="#aaa" />
+            <XAxis dataKey="name" stroke={isDarkMode ? "#9ca3af" : "#6b7280"} />
+            <YAxis stroke={isDarkMode ? "#9ca3af" : "#6b7280"} />
             <Tooltip content={<CustomTooltip />} />
             <Bar dataKey="value" radius={[10, 10, 0, 0]}>
               {chartData.map((entry, index) => (
                 <Cell
                   key={`cell-${index}`}
-                  fill={COLORS[entry.name] || "#06b6d4"}
+                  fill={colors[entry.name] || "#06b6d4"}
                 />
               ))}
             </Bar>

--- a/src/components/complexityBox.css
+++ b/src/components/complexityBox.css
@@ -1,33 +1,39 @@
-complexity-container {
-  background: linear-gradient(145deg, #1a1c2c, #101220);
+/* Force light mode as default - no media queries */
+.complexity-container {
+  width: 100%;
+  max-width: 800px;
+  margin: 40px auto;
+  padding: 24px;
   border-radius: 20px;
-  padding: 2rem;
-  margin: 2rem auto;
-  max-width: 900px;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.6),
-              0 0 20px rgba(91, 134, 229, 0.2);
-  color: #e4e6ef;
-  text-align: center;
   transition: all 0.3s ease;
+
+  /* LIGHT MODE - DEFAULT */
+  background: linear-gradient(145deg, #ffffff, #f8fafc);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.08),
+    0 0 20px rgba(59, 130, 246, 0.05);
+  color: #1f2937;
+  border: 1px solid rgba(226, 232, 240, 0.8);
 }
 
 .complexity-container:hover {
-  box-shadow: 0 6px 25px rgba(0, 0, 0, 0.7),
-              0 0 30px rgba(61, 83, 130, 0.35);
   transform: translateY(-4px);
+  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.12),
+    0 0 30px rgba(59, 130, 246, 0.1);
 }
 
 .complexity-title {
+  text-align: center;
   font-size: 1.8rem;
-  font-weight: bold;
-  margin-bottom: 0.5rem;
-  color: #ffffff;
+  font-weight: 700;
+  margin-bottom: 6px;
+  color: #1f2937;
 }
 
 .complexity-subtitle {
+  text-align: center;
   font-size: 1rem;
-  color: #9ca3af;
-  margin-bottom: 1.5rem;
+  margin-bottom: 20px;
+  color: #6b7280;
 }
 
 .dropdown-container {
@@ -43,83 +49,106 @@ complexity-container {
   min-width: 180px;
   padding: 0.6rem;
   border-radius: 10px;
-  background: #1f2235;
-  border: 1px solid #2a2d45;
-  color: #e4e6ef;
   font-size: 1rem;
   transition: all 0.3s ease;
+  background: #ffffff;
+  border: 1px solid #d1d5db;
+  color: #1f2937;
 }
 
 .dropdown-container select:hover {
-  border-color: #5b86e5;
-  box-shadow: 0 0 8px rgba(91, 134, 229, 0.3);
+  border-color: #3b82f6;
+  box-shadow: 0 0 8px rgba(59, 130, 246, 0.3);
+}
+
+.dropdown-container select option {
+  background-color: #ffffff;
+  color: #1f2937;
+}
+
+.dropdown-container select option:hover {
+  background-color: #f3f4f6;
 }
 
 .chart-wrapper {
-  background: rgba(255, 255, 255, 0.05);
-  border-radius: 15px;
-  padding: 1rem;
+  margin-top: 10px;
+  border-radius: 16px;
+  padding: 16px;
+  background: #f9fafb;
+  border: 1px solid #e5e7eb;
 }
+
+/* Chart bar effects */
 .recharts-bar-rectangle path {
-  filter: drop-shadow(0px 0px 6px rgba(255, 255, 255, 0.2));
+  filter: drop-shadow(0px 0px 6px rgba(59, 130, 246, 0.2));
   transition: all 0.3s ease;
 }
 
 .recharts-bar-rectangle path:hover {
-  filter: drop-shadow(0px 0px 10px rgba(255, 255, 255, 0.4));
+  filter: drop-shadow(0px 0px 10px rgba(59, 130, 246, 0.4));
 }
-.complexity-container {
-  width: 100%;
-  max-width: 800px;
-  margin: 40px auto;   /* equal spacing above & below */
+
+/* DARK MODE - Applied when .force-dark class is present */
+.complexity-container.force-dark {
   background: linear-gradient(145deg, #141824, #1c1f2e);
-  padding: 24px;
-  border-radius: 20px;
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4),
+    0 0 20px rgba(91, 134, 229, 0.2);
+  color: #e4e6ef;
+  border: 1px solid rgba(45, 55, 72, 0.6);
 }
 
-
-
-.complexity-title {
-  text-align: center;
-  font-size: 1.8rem;
-  font-weight: 700;
-  color: #ffffff !important;   /* force white */
-  margin-bottom: 6px;
+.complexity-container.force-dark:hover {
+  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.6),
+    0 0 30px rgba(91, 134, 229, 0.3);
 }
 
-.complexity-subtitle {
-  text-align: center;
-  font-size: 1rem;
-  color: #ffffff !important;   /* force white */
-  margin-bottom: 20px;
-}
-/* Dropdown container */
-/* Target the select box */
-select {
-  background-color: #1f2937; /* dark background, adjust for your theme */
-  color: #ffffff; /* text color */
-  border: 1px solid #ccc; /* optional border */
-  padding: 0.5rem;
-  border-radius: 0.375rem;
-}
-
-/* Target the dropdown options */
-select option {
-  background-color: #1f2937; /* match select box or desired color */
-  color: #ffffff; /* visible text */
-}
-
-/* Optional: hover effect for options */
-select option:hover {
-  background-color: #374151; /* slightly lighter/darker shade */
+.complexity-container.force-dark .complexity-title {
   color: #ffffff;
 }
 
+.complexity-container.force-dark .complexity-subtitle {
+  color: #9ca3af;
+}
 
-.chart-wrapper {
-  margin-top: 10px;
+.complexity-container.force-dark .dropdown-container select {
+  background: #1f2235;
+  border: 1px solid #2a2d45;
+  color: #e4e6ef;
+}
+
+.complexity-container.force-dark .dropdown-container select:hover {
+  border-color: #5b86e5;
+  box-shadow: 0 0 8px rgba(91, 134, 229, 0.3);
+}
+
+.complexity-container.force-dark .dropdown-container select option {
+  background-color: #1f2937;
+  color: #ffffff;
+}
+
+.complexity-container.force-dark .dropdown-container select option:hover {
+  background-color: #374151;
+}
+
+.complexity-container.force-dark .chart-wrapper {
   background: #1a1d2b;
-  border-radius: 16px;
-  padding: 16px;
+  border: 1px solid #374151;
+}
+
+/* Recharts axis labels and ticks */
+.complexity-container.force-dark .recharts-cartesian-axis-tick text {
+  fill: #9ca3af;
+}
+
+.complexity-container.force-dark .recharts-cartesian-axis-line,
+.complexity-container.force-dark .recharts-cartesian-axis-tick line {
+  stroke: #9ca3af;
+}
+
+.complexity-container.force-dark .recharts-bar-rectangle path {
+  filter: drop-shadow(0px 0px 6px rgba(255, 255, 255, 0.2));
+}
+
+.complexity-container.force-dark .recharts-bar-rectangle path:hover {
+  filter: drop-shadow(0px 0px 10px rgba(255, 255, 255, 0.4));
 }


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #409 

### Description
This pull request fixes the dark/light mode styling issues in the **ComplexityBox** component.

### Changes Made
- Added `complexityBox.css` with theme-aware styles.
- Implemented `force-dark` class to switch between dark and light themes.
- Synced chart axes, dropdowns, and tooltip colors with the active theme.
- Improved responsiveness for smaller screens.


Screenshots:

light mode - 
<img width="1896" height="912" alt="image" src="https://github.com/user-attachments/assets/3ce56a5c-8cb8-4166-b281-b3cfb44b49e0" />

dark mode - 
<img width="1919" height="903" alt="image" src="https://github.com/user-attachments/assets/881db18c-f317-4593-91fa-3e2746bc938f" />
