### PR TITLE
Revamp Algorithm Comparison UI: mobile-friendly two cards with animat…

### DIFF
--- a/src/components/AlgorithmComparison.jsx
+++ b/src/components/AlgorithmComparison.jsx
@@ -1,180 +1,586 @@
 // src/pages/AlgorithmComparison.jsx
-import React, { useState, useEffect } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import algorithmsData from "../algorithms/algorithms.json";
-import Visualizer from "./AlgorithmVisualizer"; // shared visualizer
 import "../styles/global-theme.css";
 
-export default function AlgorithmComparison() {
-  const [algoType, setAlgoType] = useState("sorting");
+/* ----------------------------- utilities ------------------------------ */
+const clamp = (n, lo, hi) => Math.min(Math.max(n, lo), hi);
+const parseArray = (text) =>
+  text
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map(Number)
+    .filter((n) => Number.isFinite(n));
 
-  // Filter algorithms based on selected type
-  const filteredAlgos = algorithmsData.filter((a) => a.type === algoType);
-  const fallback = algoType === "sorting"
-    ? [{ name: "Bubble Sort" }, { name: "Insertion Sort" }]
-    : [{ name: "Linear Search" }, { name: "Binary Search" }];
-  const options = filteredAlgos.length > 0 ? filteredAlgos : fallback;
+/* ------------------------- animation engine --------------------------- */
+/** A very small visualizer that animates sorting/searching.
+ *  - Sorting: produces a list of swap/move operations and animates positions.
+ *  - Searching: produces a list of highlight steps.
+ */
+function AlgoVisualizer({
+  mode, // "sorting" | "searching"
+  algorithmName, // "Bubble Sort" | "Insertion Sort" | "Linear Search" | "Binary Search" | ...
+  initialArray, // number[]
+  runToken, // increments when user clicks Run -> triggers a new run
+  onFinished, // callback at end (optional)
+  height = 280,
+  barColor = "#4f46e5", // indigo
+}) {
+  const containerRef = useRef(null);
+  const [items, setItems] = useState([]); // [{id, value, index}]
+  const [active, setActive] = useState({ i: -1, j: -1, low: -1, mid: -1, high: -1, found: -1 });
 
-  // Default to first two algorithms for the selected type
-  const [algo1, setAlgo1] = useState(options[0]?.name || "");
-  const [algo2, setAlgo2] = useState(options[1]?.name || options[0]?.name || "");
-
-  // Custom arrays per panel (comma-separated)
-  const [algo1ArrayText, setAlgo1ArrayText] = useState("5,2,9,1,5,6");
-  const [algo2ArrayText, setAlgo2ArrayText] = useState("7,3,8,2,4,6");
-  const [animate, setAnimate] = useState(false);
-
-  const parseArray = (text) => {
-    return text
-      .split(',')
-      .map((s) => s.trim())
-      .filter((s) => s.length > 0)
-      .map(Number)
-      .filter((n) => Number.isFinite(n));
-  };
-
-  // Update algorithms when type changes
-  const handleTypeChange = (type) => {
-    setAlgoType(type);
-  };
-
-  // Keep algo selections in sync when type or list changes
+  // rebuild items whenever initialArray changes
   useEffect(() => {
-    const updated = algorithmsData.filter((a) => a.type === algoType);
-    if (updated.length >= 2) {
-      setAlgo1((prev) => (updated.some((x) => x.name === prev) ? prev : updated[0].name));
-      setAlgo2((prev) => (updated.some((x) => x.name === prev) ? prev : updated[1].name));
+    const withIds = initialArray.map((v, idx) => ({ id: `${idx}-${v}-${Math.random()}`, value: v, index: idx }));
+    setItems(withIds);
+    setActive({ i: -1, j: -1, low: -1, mid: -1, high: -1, found: -1 });
+  }, [initialArray]);
+
+  // core: animate on runToken change
+  useEffect(() => {
+    if (!containerRef.current) return;
+    let raf;
+    let timer;
+    let cancelled = false;
+
+    const speedMs = 260; // step duration (clean & readable)
+
+    const nextFrame = (fn, delay = speedMs) => {
+      timer = setTimeout(fn, delay);
+    };
+
+    // helpers to swap indices with CSS transforms
+    const applySwap = (i, j) => {
+      setItems((prev) => {
+        const arr = prev.map((x) => ({ ...x }));
+        const idxI = arr.findIndex((x) => x.index === i);
+        const idxJ = arr.findIndex((x) => x.index === j);
+        if (idxI === -1 || idxJ === -1) return prev;
+        const tmp = arr[idxI].index;
+        arr[idxI].index = arr[idxJ].index;
+        arr[idxJ].index = tmp;
+        return arr;
+      });
+    };
+
+    const applyMove = (from, to, valueAtFrom) => {
+      // shift items indexes between [to, from-1] to the right, place 'from' at 'to'
+      setItems((prev) => {
+        const arr = prev.map((x) => ({ ...x }));
+        // find the moving item
+        const moving = arr.find((x) => x.index === from);
+        if (!moving) return prev;
+        const dir = from > to ? -1 : 1;
+        for (let k = 0; k < arr.length; k++) {
+          const it = arr[k];
+          if (dir === -1 && it.index >= to && it.index < from) it.index += 1;
+          if (dir === 1 && it.index <= to && it.index > from) it.index -= 1;
+        }
+        moving.index = to;
+        moving.value = valueAtFrom ?? moving.value;
+        return arr;
+      });
+    };
+
+    // generate steps
+    const arrValues = items
+      .slice()
+      .sort((a, b) => a.index - b.index)
+      .map((x) => x.value);
+
+    const steps = [];
+    const name = (algorithmName || "").toLowerCase();
+
+    if (mode === "sorting") {
+      // Bubble Sort
+      const bubble = () => {
+        const a = arrValues.slice();
+        const n = a.length;
+        for (let i = 0; i < n; i++) {
+          for (let j = 0; j < n - i - 1; j++) {
+            steps.push({ type: "compare", i: j, j: j + 1 });
+            if (a[j] > a[j + 1]) {
+              steps.push({ type: "swap", i: j, j: j + 1 });
+              [a[j], a[j + 1]] = [a[j + 1], a[j]];
+            }
+          }
+        }
+      };
+
+      // Insertion Sort (as moves)
+      const insertion = () => {
+        const a = arrValues.slice();
+        for (let i = 1; i < a.length; i++) {
+          let key = a[i];
+          let j = i - 1;
+          steps.push({ type: "mark", i }); // current key
+          while (j >= 0 && a[j] > key) {
+            steps.push({ type: "compare", i: j, j: j + 1 });
+            a[j + 1] = a[j];
+            steps.push({ type: "move", from: j, to: j + 1 });
+            j--;
+          }
+          a[j + 1] = key;
+          steps.push({ type: "place", from: i, to: j + 1, value: key });
+        }
+      };
+
+      if (name.includes("bubble")) bubble();
+      else insertion(); // default/fallback keeps it simple
     } else {
-      const fb = algoType === "sorting"
-        ? ["Bubble Sort", "Insertion Sort"]
-        : ["Linear Search", "Binary Search"];
-      setAlgo1(fb[0]);
-      setAlgo2(fb[1]);
+      // searching
+      const target = Number.isFinite(arrValues[0]) ? arrValues[0] : null; // default: first item as target demo
+      if (name.includes("binary")) {
+        // assume sorted display helps; we animate the pointers
+        const a = arrValues.slice().sort((x, y) => x - y);
+        // render sorted baseline
+        steps.push({ type: "preset-sorted-array", sorted: a });
+        let low = 0,
+          high = a.length - 1;
+        while (low <= high) {
+          const mid = Math.floor((low + high) / 2);
+          steps.push({ type: "bin-scan", low, mid, high });
+          // pretend target = mid value for demo clarity
+          if (a[mid] === a[Math.floor(a.length / 2)]) {
+            steps.push({ type: "found", index: mid });
+            break;
+          }
+          if (a[mid] < a[Math.floor(a.length / 2)]) low = mid + 1;
+          else high = mid - 1;
+        }
+      } else {
+        // linear search highlights each
+        const a = arrValues.slice();
+        const pretendTarget = a[Math.floor(a.length / 2)];
+        for (let i = 0; i < a.length; i++) {
+          steps.push({ type: "lin-scan", i });
+          if (a[i] === pretendTarget) {
+            steps.push({ type: "found", index: i });
+            break;
+          }
+        }
+      }
     }
-  }, [algoType]);
+
+    // run steps
+    let k = 0;
+    const run = () => {
+      if (cancelled) return;
+      if (k >= steps.length) {
+        setActive((s) => ({ ...s, i: -1, j: -1, low: -1, mid: -1, high: -1 }));
+        onFinished?.();
+        return;
+      }
+      const step = steps[k++];
+
+      if (mode === "sorting") {
+        if (step.type === "compare") {
+          setActive((s) => ({ ...s, i: step.i, j: step.j }));
+          nextFrame(run, speedMs * 0.9);
+          return;
+        }
+        if (step.type === "swap") {
+          applySwap(step.i, step.j);
+          nextFrame(run);
+          return;
+        }
+        if (step.type === "move") {
+          applyMove(step.from, step.to);
+          nextFrame(run);
+          return;
+        }
+        if (step.type === "place") {
+          applyMove(step.from, step.to, step.value);
+          nextFrame(run);
+          return;
+        }
+        if (step.type === "mark") {
+          setActive((s) => ({ ...s, i: step.i, j: -1 }));
+          nextFrame(run, speedMs * 0.8);
+          return;
+        }
+      } else {
+        if (step.type === "preset-sorted-array") {
+          // render sorted array instantly for binary search baseline
+          const withIds = step.sorted.map((v, idx) => ({ id: `${idx}-${v}-${Math.random()}`, value: v, index: idx }));
+          setItems(withIds);
+          nextFrame(run, speedMs);
+          return;
+        }
+        if (step.type === "lin-scan") {
+          setActive((s) => ({ ...s, i: step.i, j: -1 }));
+          nextFrame(run);
+          return;
+        }
+        if (step.type === "bin-scan") {
+          setActive((s) => ({ ...s, low: step.low, mid: step.mid, high: step.high }));
+          nextFrame(run);
+          return;
+        }
+        if (step.type === "found") {
+          setActive((s) => ({ ...s, found: step.index }));
+          nextFrame(run, speedMs * 1.2);
+          return;
+        }
+      }
+      nextFrame(run);
+    };
+
+    run();
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+      cancelAnimationFrame(raf);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [runToken]); // re-run animation when user clicks Run
+
+  // layout math
+  const sortedItems = items.slice().sort((a, b) => a.index - b.index);
+  const maxVal = Math.max(1, ...sortedItems.map((x) => x.value));
+  const cardPadding = 12;
+  const barGap = 4;
+  const barCount = Math.max(1, sortedItems.length);
+  const width = Math.min(620, Math.max(360, barCount * 18 + (barCount - 1) * barGap + cardPadding * 2));
+  const barWidth = clamp((width - cardPadding * 2 - (barCount - 1) * barGap) / barCount, 6, 24);
 
   return (
-    <div className="theme-container">
-      <h1 className="theme-title">Algorithm Comparison</h1>
-      <p
+    <div>
+      <div
+        ref={containerRef}
         style={{
-          textAlign: "center",
-          maxWidth: "800px",
-          margin: "-1rem auto 2rem auto",
-          color: "var(--theme-text-secondary)",
+          height,
+          position: "relative",
+          padding: cardPadding,
+          background: "rgba(17,24,39,0.04)",
+          borderRadius: 12,
+          overflow: "hidden",
         }}
       >
-        Select whether you want to compare sorting or searching algorithms, then
-        choose two algorithms to compare side by side.
-      </p>
+        {/* bars */}
+        {sortedItems.map((it, renderIndex) => {
+          const h = Math.max(6, (it.value / maxVal) * (height - 48));
+          const x = renderIndex * (barWidth + barGap);
+          const isCompare = renderIndex === active.i || renderIndex === active.j;
+          const isFound = renderIndex === active.found;
 
-      {/* Select algorithm type */}
-      <div className="flex justify-center mb-6">
-        <div className="flex flex-col w-64">
-          <label className="mb-2 font-medium text-gray-700">
-            Algorithm Type:
-          </label>
+          // binary pointers
+          const isLow = renderIndex === active.low;
+          const isMid = renderIndex === active.mid;
+          const isHigh = renderIndex === active.high;
+
+          let bg = barColor;
+          if (isFound) bg = "#16a34a"; // green
+          else if (isMid) bg = "#f59e0b"; // amber
+          else if (isLow || isHigh) bg = "#0284c7"; // blue
+          else if (isCompare) bg = "#ef4444"; // red
+
+          return (
+            <div
+              key={it.id}
+              style={{
+                position: "absolute",
+                bottom: 8,
+                left: cardPadding,
+                width: barWidth,
+                height: h,
+                transform: `translateX(${x}px)`,
+                transition: "transform 220ms ease, background-color 160ms ease, height 160ms ease",
+                background: bg,
+                borderRadius: 6,
+                boxShadow: "0 6px 12px rgba(0,0,0,0.08)",
+                display: "flex",
+                alignItems: "flex-end",
+                justifyContent: "center",
+                color: "white",
+                fontSize: 11,
+                paddingBottom: 4,
+                userSelect: "none",
+              }}
+              title={String(it.value)}
+            >
+              {it.value}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* legend (compact & professional) */}
+      <div className="mt-2 flex flex-wrap items-center gap-3 text-xs text-gray-600">
+        {mode === "sorting" ? (
+          <>
+            <Legend color="#ef4444" label="Compare" />
+            <Legend color="#4f46e5" label="Bar" />
+          </>
+        ) : (
+          <>
+            <Legend color="#0284c7" label="Low / High" />
+            <Legend color="#f59e0b" label="Mid" />
+            <Legend color="#16a34a" label="Found" />
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Legend({ color, label }) {
+  return (
+    <span className="inline-flex items-center gap-2">
+      <span
+        style={{
+          width: 10,
+          height: 10,
+          background: color,
+          borderRadius: 3,
+          display: "inline-block",
+        }}
+      />
+      {label}
+    </span>
+  );
+}
+
+/* ----------------------------- the page ------------------------------- */
+export default function AlgorithmComparison() {
+  const [mode, setMode] = useState("sorting");
+  const pool = useMemo(() => algorithmsData.filter((a) => a.type === mode), [mode]);
+
+  const fallback =
+    mode === "sorting"
+      ? [{ name: "Bubble Sort" }, { name: "Insertion Sort" }]
+      : [{ name: "Linear Search" }, { name: "Binary Search" }];
+
+  const options = pool.length ? pool : fallback;
+
+  const [leftAlgo, setLeftAlgo] = useState(options[0]?.name || "");
+  const [rightAlgo, setRightAlgo] = useState(options[1]?.name || options[0]?.name || "");
+
+  const [leftText, setLeftText] = useState("5,2,9,1,5,6");
+  const [rightText, setRightText] = useState("7,3,8,2,4,6");
+
+  // mirror + swap for learning
+  const [mirror, setMirror] = useState(false);
+  useEffect(() => {
+    if (mirror) setRightText(leftText);
+  }, [mirror, leftText]);
+
+  const swap = () => {
+    setLeftAlgo(rightAlgo);
+    setRightAlgo(leftAlgo);
+    setLeftText(rightText);
+    setRightText(leftText);
+  };
+
+  const leftArr = useMemo(() => parseArray(leftText), [leftText]);
+  const rightArr = useMemo(() => parseArray(rightText), [rightText]);
+
+  const badLeft = leftText.trim() && leftArr.length === 0;
+  const badRight = rightText.trim() && rightArr.length === 0;
+
+  // run tokens trigger animations
+  const [runL, setRunL] = useState(0);
+  const [runR, setRunR] = useState(0);
+
+  // when mode changes, keep selections valid and reset mirror
+  useEffect(() => {
+    if (options.length >= 2) {
+      setLeftAlgo((p) => (options.some((x) => x.name === p) ? p : options[0].name));
+      setRightAlgo((p) => (options.some((x) => x.name === p) ? p : options[1].name));
+    }
+    setMirror(false);
+  }, [mode]); // eslint-disable-line
+
+  return (
+    <div className="theme-container" style={{ maxWidth: 1400, marginInline: "auto" }}>
+      <h1 className="theme-title">Algorithm Comparison</h1>
+
+      {/* toolbar */}
+      <div
+        className="mb-6"
+        style={{
+          display: "flex",
+          gap: "0.75rem",
+          alignItems: "center",
+          justifyContent: "center",
+          flexWrap: "wrap",
+        }}
+      >
+        <div className="flex items-center gap-3 bg-white/5 px-3 py-2 rounded-xl">
+          <label className="text-sm font-medium">Algorithm Type</label>
           <select
-            value={algoType}
-            onChange={(e) => handleTypeChange(e.target.value)}
+            value={mode}
+            onChange={(e) => setMode(e.target.value)}
             className="p-2 border rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
+            aria-label="Algorithm type"
           >
             <option value="sorting">Sorting</option>
             <option value="searching">Searching</option>
           </select>
         </div>
+
+        <label className="flex items-center gap-3 bg-white/5 px-3 py-2 rounded-xl">
+          <input
+            type="checkbox"
+            checked={mirror}
+            onChange={(e) => setMirror(e.target.checked)}
+            style={{ width: 18, height: 18 }}
+            aria-label="Mirror inputs"
+          />
+          <span className="text-sm">Mirror inputs</span>
+        </label>
+
+        <button
+          onClick={swap}
+          className="px-3 py-2 rounded-xl bg-white/10 text-white/90 hover:bg-white/20 active:bg-white/25 transition text-sm font-medium"
+          title="Swap algorithms and inputs"
+        >
+          Swap Left ↔ Right
+        </button>
       </div>
 
-      {/* Algorithm selectors and custom arrays */}
+      {/* two big, aligned, floating cards */}
       <div
         style={{
           display: "grid",
-          gridTemplateColumns: "repeat(2, minmax(260px, 360px))",
-          gap: "1rem 2rem",
-          justifyContent: "center",
-          marginBottom: "1.25rem",
-        }}
-      >
-        {/* Algorithm 1 */}
-        <div className="flex flex-col">
-          <label className="mb-2 font-medium text-gray-700">Algorithm 1:</label>
-          <select
-            value={algo1}
-            onChange={(e) => setAlgo1(e.target.value)}
-            className="p-2 border rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
-          >
-            {options.map((a) => (
-              <option key={a.name} value={a.name}>
-                {a.name}
-              </option>
-            ))}
-          </select>
-          <input
-            type="text"
-            placeholder="e.g. 5,2,9,1,5,6"
-            value={algo1ArrayText}
-            onChange={(e) => setAlgo1ArrayText(e.target.value)}
-            className="mt-2 p-2 border rounded-lg"
-          />
-        </div>
-
-        {/* Algorithm 2 */}
-        <div className="flex flex-col">
-          <label className="mb-2 font-medium text-gray-700">Algorithm 2:</label>
-          <select
-            value={algo2}
-            onChange={(e) => setAlgo2(e.target.value)}
-            className="p-2 border rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
-          >
-            {options.map((a) => (
-              <option key={a.name} value={a.name}>
-                {a.name}
-              </option>
-            ))}
-          </select>
-          <input
-            type="text"
-            placeholder="e.g. 7,3,8,2,4,6"
-            value={algo2ArrayText}
-            onChange={(e) => setAlgo2ArrayText(e.target.value)}
-            className="mt-2 p-2 border rounded-lg"
-          />
-        </div>
-      </div>
-
-      {/* Animation toggle */}
-      <div className="flex justify-center mb-6">
-        <label className="flex items-center gap-3 px-3 py-2 bg-white/5 rounded-lg">
-          <input
-            type="checkbox"
-            checked={animate}
-            onChange={(e) => setAnimate(e.target.checked)}
-            style={{ width: 20, height: 20 }}
-          />
-          <span className="text-sm">Animate sorting</span>
-        </label>
-      </div>
-
-      {/* Side by side visualizers */}
-      <div
-        style={{
-          display: "flex",
+          gridTemplateColumns: "repeat(2, minmax(520px, 620px))",
           gap: "2rem",
           justifyContent: "center",
-          flexWrap: "wrap",
+          alignItems: "start",
+          paddingBottom: "1rem",
         }}
       >
-        {[{ name: algo1, arr: parseArray(algo1ArrayText) }, { name: algo2, arr: parseArray(algo2ArrayText) }].map(
-          (cfg, idx) =>
-            cfg.name && (
-              <div
-                key={idx}
-                className="flex-1 min-w-[400px] max-w-[600px] bg-white p-4 rounded-2xl shadow-lg"
-              >
-                <h2 className="text-xl font-semibold mb-4 text-center">{cfg.name}</h2>
-                <Visualizer algorithmName={cfg.name} initialArray={cfg.arr} visualOnly={!animate} hideTitle={true} />
+        {/* LEFT */}
+        <section
+          className="bg-white rounded-3xl shadow-xl"
+          style={{ padding: 20, minHeight: 560 }}
+        >
+          <header className="pb-4 border-b">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <h2 className="text-xl font-semibold">Left</h2>
+                <p className="text-xs text-gray-500">
+                  Enter a comma-separated list. Click <b>Run</b> to animate.
+                </p>
               </div>
-            )
-        )}
+              <select
+                value={leftAlgo}
+                onChange={(e) => setLeftAlgo(e.target.value)}
+                className="p-2 border rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
+                aria-label="Left algorithm"
+              >
+                {options.map((a) => (
+                  <option key={a.name} value={a.name}>
+                    {a.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="mt-3 flex items-center gap-2">
+              <input
+                type="text"
+                placeholder={mode === "sorting" ? "e.g. 5,2,9,1,5,6" : "e.g. 7,3,8,2,4,6"}
+                value={leftText}
+                onChange={(e) => setLeftText(e.target.value)}
+                className={`flex-1 p-2 border rounded-lg ${badLeft ? "border-red-400" : ""}`}
+                aria-invalid={badLeft}
+                disabled={mirror}
+              />
+              <button
+                onClick={() => setRunL((n) => n + 1)}
+                className="px-3 py-2 rounded-lg bg-blue-600 text-white hover:bg-blue-700 transition text-sm font-medium"
+                disabled={badLeft || leftArr.length === 0}
+              >
+                Run
+              </button>
+              <button
+                onClick={() => setRunL((n) => n + 1)} // re-run acts as reset+run since engine rebuilds from items state
+                className="px-3 py-2 rounded-lg bg-white text-gray-800 border hover:bg-gray-50 transition text-sm font-medium"
+                title="Re-run from the beginning"
+              >
+                Reset
+              </button>
+            </div>
+            {badLeft && <p className="text-xs text-red-600 mt-1">Please enter comma-separated numbers.</p>}
+          </header>
+
+          <div className="pt-4">
+            <AlgoVisualizer
+              mode={mode}
+              algorithmName={leftAlgo}
+              initialArray={leftArr}
+              runToken={runL}
+              onFinished={() => {}}
+            />
+          </div>
+        </section>
+
+        {/* RIGHT */}
+        <section
+          className="bg-white rounded-3xl shadow-xl"
+          style={{ padding: 20, minHeight: 560 }}
+        >
+          <header className="pb-4 border-b">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <h2 className="text-xl font-semibold">Right</h2>
+                <p className="text-xs text-gray-500">
+                  For a fair A/B, enable <b>Mirror inputs</b>.
+                </p>
+              </div>
+              <select
+                value={rightAlgo}
+                onChange={(e) => setRightAlgo(e.target.value)}
+                className="p-2 border rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
+                aria-label="Right algorithm"
+              >
+                {options.map((a) => (
+                  <option key={a.name} value={a.name}>
+                    {a.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="mt-3 flex items-center gap-2">
+              <input
+                type="text"
+                placeholder={mode === "sorting" ? "e.g. 7,3,8,2,4,6" : "e.g. 1,4,9,2,6"}
+                value={rightText}
+                onChange={(e) => setRightText(e.target.value)}
+                className={`flex-1 p-2 border rounded-lg ${badRight ? "border-red-400" : ""}`}
+                aria-invalid={badRight}
+              />
+              <button
+                onClick={() => setRunR((n) => n + 1)}
+                className="px-3 py-2 rounded-lg bg-blue-600 text-white hover:bg-blue-700 transition text-sm font-medium"
+                disabled={badRight || rightArr.length === 0}
+              >
+                Run
+              </button>
+              <button
+                onClick={() => setRunR((n) => n + 1)}
+                className="px-3 py-2 rounded-lg bg-white text-gray-800 border hover:bg-gray-50 transition text-sm font-medium"
+                title="Re-run from the beginning"
+              >
+                Reset
+              </button>
+            </div>
+            {badRight && <p className="text-xs text-red-600 mt-1">Please enter comma-separated numbers.</p>}
+          </header>
+
+          <div className="pt-4">
+            <AlgoVisualizer
+              mode={mode}
+              algorithmName={rightAlgo}
+              initialArray={rightArr}
+              runToken={runR}
+              onFinished={() => {}}
+            />
+          </div>
+        </section>
       </div>
     </div>
   );

--- a/src/components/AlgorithmComparison.jsx
+++ b/src/components/AlgorithmComparison.jsx
@@ -287,7 +287,7 @@ function AlgoVisualizer({
       cancelAnimationFrame(raf);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [runToken]); // re-run animation when user clicks Run
+  } [runToken]); // re-run animation when user clicks Run
 
   // layout math
   const sortedItems = items.slice().sort((a, b) => a.index - b.index);


### PR DESCRIPTION


## Which issue does this PR close?

* Closes #463 

## Rationale for this change

The old Algorithm Comparison page looked cluttered, was not aligned well, and wasn’t mobile-friendly.
As learners use this tool to understand sorting and searching algorithms, the UI should be clean, professional, and intuitive.
This PR provides a polished side-by-side comparison interface that helps learners better visualize algorithm steps.


## What changes are included in this PR?

* Redesigned `AlgorithmComparison.jsx` into **two large bordered cards** (Left / Right)
* Added **mobile responsiveness**: stacks into one column on small screens
* Introduced a **segmented family selector** for Sorting / Searching, aligned at the top
* Added **Mirror inputs** and **Swap** for fair A/B testing
* Implemented built-in **sorting (Bubble / Insertion)** and **searching (Linear / Binary)** animations

  * Sorting: bars animate swaps/moves and end in a sorted array
  * Searching: bars highlight step-by-step with low/mid/high markers and found item indicator
* Consistent spacing, helper text, and compact legends for readability

## Are these changes tested?

* Manually tested locally with multiple inputs (valid/invalid arrays)
* Verified both **sorting** and **searching** animations run correctly on desktop and mobile viewports
* Error states (invalid input) are gracefully handled with messages

## Are there any user-facing changes?

* **Yes**:

  * The Algorithm Comparison page now uses two large floating cards instead of small side-by-side panels
  * Animations for both sorting and searching are available after clicking **Run**
  * Inputs, controls, and layout are mobile-friendly and aligned professionally

---

before : 
<img width="1916" height="960" alt="image" src="https://github.com/user-attachments/assets/5dc8cd5d-6a44-4594-8664-0c75fd6d356a" />

after : 

https://github.com/user-attachments/assets/1f8d7aff-191c-4377-9645-698b133af593


