### PR TITLE
Add Bubble Sort documentation page and route (#512)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -32,6 +32,8 @@ import AlgorithmComparison from "./components/AlgorithmComparison";
 import Blog from "./pages/Blog";
 import CommunityLanding from "./pages/CommunityLanding";
 import "./styles/components.css";
+import SortingDoc from "./pages/SortingDoc.jsx"; // adjust path if your structure differs
+
 
 const App = () => {
   const selectedAlgorithm = "bubbleSort"; // Default algorithm
@@ -77,6 +79,8 @@ const App = () => {
             path="/data-structures/linked-list"
             element={<LinkedListPage />}
           />
+      
+           <Route path="/sorting/:algoId/docs" element={<SortingDoc />} />
 
           {/* Graph */}
           <Route path="/graph" element={<Graph />} />

--- a/src/pages/DataStructures.jsx
+++ b/src/pages/DataStructures.jsx
@@ -221,7 +221,7 @@ function AlgorithmCard({ algorithm }) {
       if (algorithm.category === 'dataStructures' && algorithm.id === 'linkedList') {
         navigate('/data-structures/linked-list');
       } else if (algorithm.category === 'sorting') {
-        navigate(`/sorting/${algorithm.id}`);
+        navigate(`/sorting/${algorithm.id}/docs`);
       } else if (algorithm.category === 'searching') {
         navigate(`/searching/${algorithm.id}`);
       } else if (algorithm.category === 'dataStructures') {

--- a/src/pages/DataStructures.jsx
+++ b/src/pages/DataStructures.jsx
@@ -1,17 +1,7 @@
 import React, { useState, useEffect, useCallback, useMemo } from "react";
-import {
-  Search,
-  Clock,
-  Database,
-  BookOpen,
-  Zap,
-  Users,
-  Star,
-  X,
-} from "lucide-react";
-import { useTheme } from "../ThemeContext";
+import { Search, Database, BookOpen, Users } from "lucide-react";
 import { useNavigate } from "react-router-dom";
-import "../styles/Documentation.css"; // keep your linkedlist styles
+import "../styles/Documentation.css";
 
 // ============================================================================
 // 1. STATIC DATA & HELPERS
@@ -234,8 +224,7 @@ const algorithmDatabase = {
       {
         name: "Linked List",
         id: "linkedList",
-        description:
-          "Linear data structure where elements are stored in nodes.",
+        description: "Linear data structure where elements are stored in nodes.",
         timeComplexity: {
           insertion: "O(1)",
           deletion: "O(1)",
@@ -289,18 +278,6 @@ const algorithmDatabase = {
   },
 };
 
-const getComplexityColor = (complexity) => {
-  const colors = {
-    "O(1)": "#4ade80",
-    "O(log n)": "#66ccff",
-    "O(n)": "#ffd93d",
-    "O(n log n)": "#ff9500",
-    "O(n²)": "#ff6b6b",
-    "O(√n)": "#a78bfa",
-  };
-  return colors[complexity] || "#e0e6ed";
-};
-
 // ============================================================================
 // 2. SUB-COMPONENTS
 // ============================================================================
@@ -309,27 +286,30 @@ function AlgorithmCard({ algorithm }) {
   const navigate = useNavigate();
 
   const handleCardClick = () => {
-    if (algorithm.implemented) {
+    if (!algorithm.implemented) return;
 
-      if (algorithm.category === 'dataStructures' && algorithm.id === 'linkedList') {
-        navigate('/data-structures/linked-list');
-      } else if (algorithm.category === 'sorting') {
-        navigate(`/sorting/${algorithm.id}/docs`);
-      } else if (algorithm.category === 'searching') {
-
-      if (
-        algorithm.category === "dataStructures" &&
-        algorithm.id === "linkedList"
-      ) {
+    // Route by category
+    if (algorithm.category === "dataStructures") {
+      if (algorithm.id === "linkedList") {
         navigate("/data-structures/linked-list");
-      } else if (algorithm.category === "sorting") {
-        navigate(`/sorting/${algorithm.id}`);
-      } else if (algorithm.category === "searching") {
-
-        navigate(`/searching/${algorithm.id}`);
-      } else if (algorithm.category === "dataStructures") {
+      } else {
         navigate(`/data-structures/${algorithm.id}`);
       }
+      return;
+    }
+
+    if (algorithm.category === "sorting") {
+      // Choose one: with docs suffix, or plain.
+      // If you want docs pages, use the next line:
+      navigate(`/sorting/${algorithm.id}/docs`);
+      // Otherwise:
+      // navigate(`/sorting/${algorithm.id}`);
+      return;
+    }
+
+    if (algorithm.category === "searching") {
+      navigate(`/searching/${algorithm.id}`);
+      return;
     }
   };
 
@@ -367,7 +347,7 @@ function DataStructuresPage() {
   const [filteredAlgorithms, setFilteredAlgorithms] = useState([]);
 
   const getAllAlgorithms = useCallback(() => {
-    let allAlgos = [];
+    const allAlgos = [];
     Object.entries(algorithmDatabase).forEach(([categoryKey, category]) => {
       category.algorithms.forEach((algo) => {
         allAlgos.push({
@@ -384,18 +364,22 @@ function DataStructuresPage() {
 
   useEffect(() => {
     let allAlgorithms = getAllAlgorithms();
+
     if (selectedCategory !== "all") {
       allAlgorithms = allAlgorithms.filter(
         (algo) => algo.category === selectedCategory
       );
     }
+
     if (searchTerm) {
+      const q = searchTerm.toLowerCase();
       allAlgorithms = allAlgorithms.filter(
         (algo) =>
-          algo.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-          algo.description.toLowerCase().includes(searchTerm.toLowerCase())
+          algo.name.toLowerCase().includes(q) ||
+          algo.description.toLowerCase().includes(q)
       );
     }
+
     setFilteredAlgorithms(allAlgorithms);
   }, [searchTerm, selectedCategory, getAllAlgorithms]);
 

--- a/src/pages/DataStructures.jsx
+++ b/src/pages/DataStructures.jsx
@@ -1,7 +1,17 @@
 import React, { useState, useEffect, useCallback, useMemo } from "react";
-import { Search, Database, BookOpen, Users } from "lucide-react";
+import {
+  Search,
+  Clock,
+  Database,
+  BookOpen,
+  Zap,
+  Users,
+  Star,
+  X,
+} from "lucide-react";
+import { useTheme } from "../ThemeContext";
 import { useNavigate } from "react-router-dom";
-import "../styles/Documentation.css";
+import "../styles/Documentation.css"; // keep your linkedlist styles
 
 // ============================================================================
 // 1. STATIC DATA & HELPERS
@@ -224,7 +234,8 @@ const algorithmDatabase = {
       {
         name: "Linked List",
         id: "linkedList",
-        description: "Linear data structure where elements are stored in nodes.",
+        description:
+          "Linear data structure where elements are stored in nodes.",
         timeComplexity: {
           insertion: "O(1)",
           deletion: "O(1)",
@@ -278,6 +289,18 @@ const algorithmDatabase = {
   },
 };
 
+const getComplexityColor = (complexity) => {
+  const colors = {
+    "O(1)": "#4ade80",
+    "O(log n)": "#66ccff",
+    "O(n)": "#ffd93d",
+    "O(n log n)": "#ff9500",
+    "O(n²)": "#ff6b6b",
+    "O(√n)": "#a78bfa",
+  };
+  return colors[complexity] || "#e0e6ed";
+};
+
 // ============================================================================
 // 2. SUB-COMPONENTS
 // ============================================================================
@@ -286,30 +309,19 @@ function AlgorithmCard({ algorithm }) {
   const navigate = useNavigate();
 
   const handleCardClick = () => {
-    if (!algorithm.implemented) return;
-
-    // Route by category
-    if (algorithm.category === "dataStructures") {
-      if (algorithm.id === "linkedList") {
+    if (algorithm.implemented) {
+      if (
+        algorithm.category === "dataStructures" &&
+        algorithm.id === "linkedList"
+      ) {
         navigate("/data-structures/linked-list");
-      } else {
+      } else if (algorithm.category === "sorting") {
+        navigate(`/sorting/${algorithm.id}/docs`);
+      } else if (algorithm.category === "searching") {
+        navigate(`/searching/${algorithm.id}`);
+      } else if (algorithm.category === "dataStructures") {
         navigate(`/data-structures/${algorithm.id}`);
       }
-      return;
-    }
-
-    if (algorithm.category === "sorting") {
-      // Choose one: with docs suffix, or plain.
-      // If you want docs pages, use the next line:
-      navigate(`/sorting/${algorithm.id}/docs`);
-      // Otherwise:
-      // navigate(`/sorting/${algorithm.id}`);
-      return;
-    }
-
-    if (algorithm.category === "searching") {
-      navigate(`/searching/${algorithm.id}`);
-      return;
     }
   };
 
@@ -347,7 +359,7 @@ function DataStructuresPage() {
   const [filteredAlgorithms, setFilteredAlgorithms] = useState([]);
 
   const getAllAlgorithms = useCallback(() => {
-    const allAlgos = [];
+    let allAlgos = [];
     Object.entries(algorithmDatabase).forEach(([categoryKey, category]) => {
       category.algorithms.forEach((algo) => {
         allAlgos.push({
@@ -364,22 +376,18 @@ function DataStructuresPage() {
 
   useEffect(() => {
     let allAlgorithms = getAllAlgorithms();
-
     if (selectedCategory !== "all") {
       allAlgorithms = allAlgorithms.filter(
         (algo) => algo.category === selectedCategory
       );
     }
-
     if (searchTerm) {
-      const q = searchTerm.toLowerCase();
       allAlgorithms = allAlgorithms.filter(
         (algo) =>
-          algo.name.toLowerCase().includes(q) ||
-          algo.description.toLowerCase().includes(q)
+          algo.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
+          algo.description.toLowerCase().includes(searchTerm.toLowerCase())
       );
     }
-
     setFilteredAlgorithms(allAlgorithms);
   }, [searchTerm, selectedCategory, getAllAlgorithms]);
 

--- a/src/pages/SortingDoc.jsx
+++ b/src/pages/SortingDoc.jsx
@@ -1,0 +1,148 @@
+import React from "react";
+import { useParams, Link, Navigate } from "react-router-dom";
+import { ALGORITHM_INFO } from "../data/algorithmInfo";
+import { ALGORITHM_PSEUDOCODE as PSEUDO } from "../data/pseudocode";
+import "../styles/SortingDoc.css";
+
+export default function SortingDoc() {
+  const { algoId } = useParams();
+
+  // Only support Bubble Sort for now
+  if (algoId !== "bubbleSort") {
+    return (
+      <main className="doc-page">
+        <header className="doc-hero">
+          <h1>Documentation not available</h1>
+          <p className="muted">
+            Only Bubble Sort docs are implemented right now.
+          </p>
+          <div className="cta-row">
+            <Link className="btn" to="/data-structures">Back to Overview</Link>
+            <Link className="btn primary" to="/sorting">Open Visualizer</Link>
+          </div>
+        </header>
+      </main>
+    );
+  }
+
+  const info = ALGORITHM_INFO?.bubbleSort;
+  const pseudocode = PSEUDO?.["Bubble Sort"];
+
+  if (!info) {
+    // If repo data is missing, still show a friendly page
+    return (
+      <main className="doc-page">
+        <header className="doc-hero">
+          <h1>Bubble Sort — Documentation</h1>
+          <p className="muted">Info not found in ALGORITHM_INFO. You can still try the visualizer.</p>
+          <div className="cta-row">
+            <Link className="btn primary" to="/sorting">Open Visualizer</Link>
+          </div>
+        </header>
+      </main>
+    );
+  }
+
+  return (
+    <main className="doc-page">
+      <header className="doc-hero">
+        <div className="hero-text">
+          <h1>Bubble Sort <span className="tag">docs</span></h1>
+          <p className="muted">{info.description}</p>
+          <div className="cta-row">
+            <Link to="/sorting" className="btn primary">Open Visualizer</Link>
+            <a className="btn" href="#pseudocode">Pseudocode</a>
+            <a className="btn" href="#walkthrough">Walkthrough</a>
+          </div>
+        </div>
+      </header>
+
+      <section className="stats-grid" aria-label="Key properties">
+        <article className="stat-card">
+          <h3>Time Complexity</h3>
+          <p><strong>Avg/Worst:</strong> {info.timeComplexity}</p>
+          <p><strong>Best:</strong> {info.bestCase}</p>
+        </article>
+        <article className="stat-card">
+          <h3>Space</h3>
+          <p><strong>{info.spaceComplexity}</strong> (in-place)</p>
+        </article>
+        <article className="stat-card">
+          <h3>Stable</h3>
+          <p><strong>{String(info.stable) === "true" ? "Yes" : info.stable}</strong></p>
+        </article>
+        <article className="stat-card">
+          <h3>Pattern</h3>
+          <p>Adjacent compare &amp; swap</p>
+        </article>
+      </section>
+
+      <section className="callout success" role="note">
+        <h3>Intuition</h3>
+        <p>
+          Compare adjacent items and swap if out of order. After each pass, the largest
+          unsorted element “bubbles” to the end. Stop early when a pass makes no swaps.
+        </p>
+      </section>
+
+      {pseudocode && (
+        <section id="pseudocode" className="doc-section">
+          <h2>Pseudocode</h2>
+          <pre aria-label="Bubble Sort pseudocode"><code>{pseudocode}</code></pre>
+          <details className="tip">
+            <summary>Optimization tip</summary>
+            <p>Track last swap index to shrink the next pass range.</p>
+          </details>
+        </section>
+      )}
+
+      <section id="walkthrough" className="doc-section">
+        <h2>Step-by-step walkthrough</h2>
+        <p className="muted">Example: <code>[5, 1, 4, 2, 8]</code></p>
+        <div className="steps">
+          <div className="step">
+            <div className="step-no">1</div>
+            <div className="step-body">
+              <p><strong>Pass 1</strong>: bubble <code>8</code> to the end.</p>
+            </div>
+          </div>
+          <div className="step">
+            <div className="step-no">2</div>
+            <div className="step-body">
+              <p><strong>Pass 2</strong>: bubble next largest (<code>5</code>).</p>
+            </div>
+          </div>
+          <div className="step">
+            <div className="step-no">3</div>
+            <div className="step-body">
+              <p><strong>Stop early</strong> if no swaps in a pass.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="doc-section">
+        <h2>Reference implementation</h2>
+        <h3>JavaScript</h3>
+        <pre><code>{`function bubbleSort(arr) {
+  const a = arr.slice();
+  for (let i = 0; i < a.length - 1; i++) {
+    let swapped = false;
+    for (let j = 0; j < a.length - 1 - i; j++) {
+      if (a[j] > a[j + 1]) {
+        [a[j], a[j + 1]] = [a[j + 1], a[j]];
+        swapped = true;
+      }
+    }
+    if (!swapped) break;
+  }
+  return a;
+}`}</code></pre>
+      </section>
+
+      <section className="doc-section center">
+        <Link to="/sorting" className="btn primary lg">Try in Visualizer</Link>
+      </section>
+    </main>
+  );
+}

--- a/src/pages/SortingDoc.jsx
+++ b/src/pages/SortingDoc.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useParams, Link, Navigate } from "react-router-dom";
+import { useParams, Link } from "react-router-dom";
 import { ALGORITHM_INFO } from "../data/algorithmInfo";
 import { ALGORITHM_PSEUDOCODE as PSEUDO } from "../data/pseudocode";
 import "../styles/SortingDoc.css";
@@ -10,7 +10,7 @@ export default function SortingDoc() {
   // Only support Bubble Sort for now
   if (algoId !== "bubbleSort") {
     return (
-      <main className="doc-page">
+      <div className="doc-page">
         <header className="doc-hero">
           <h1>Documentation not available</h1>
           <p className="muted">
@@ -21,7 +21,7 @@ export default function SortingDoc() {
             <Link className="btn primary" to="/sorting">Open Visualizer</Link>
           </div>
         </header>
-      </main>
+      </div>
     );
   }
 
@@ -31,7 +31,7 @@ export default function SortingDoc() {
   if (!info) {
     // If repo data is missing, still show a friendly page
     return (
-      <main className="doc-page">
+      <div className="doc-page">
         <header className="doc-hero">
           <h1>Bubble Sort — Documentation</h1>
           <p className="muted">Info not found in ALGORITHM_INFO. You can still try the visualizer.</p>
@@ -39,19 +39,21 @@ export default function SortingDoc() {
             <Link className="btn primary" to="/sorting">Open Visualizer</Link>
           </div>
         </header>
-      </main>
+      </div>
     );
   }
 
   return (
-    <main className="doc-page">
+    <div className="doc-page">
       <header className="doc-hero">
         <div className="hero-text">
-          <h1>Bubble Sort <span className="tag">docs</span></h1>
-          <p className="muted">{info.description}</p>
+          <h1>
+            Bubble Sort <span className="tag">docs</span>
+          </h1>
+          <p className="muted">{info?.description ?? "No description available."}</p>
           <div className="cta-row">
             <Link to="/sorting" className="btn primary">Open Visualizer</Link>
-            <a className="btn" href="#pseudocode">Pseudocode</a>
+            {pseudocode && <a className="btn" href="#pseudocode">Pseudocode</a>}
             <a className="btn" href="#walkthrough">Walkthrough</a>
           </div>
         </div>
@@ -65,11 +67,18 @@ export default function SortingDoc() {
         </article>
         <article className="stat-card">
           <h3>Space</h3>
-          <p><strong>{info.spaceComplexity}</strong> (in-place)</p>
+          <p>
+            <strong>{info.spaceComplexity}</strong>
+            {info.inPlace ? " (in-place)" : ""}
+          </p>
         </article>
         <article className="stat-card">
           <h3>Stable</h3>
-          <p><strong>{String(info.stable) === "true" ? "Yes" : info.stable}</strong></p>
+          <p>
+            <strong>
+              {info.stable === true ? "Yes" : info.stable === false ? "No" : String(info.stable)}
+            </strong>
+          </p>
         </article>
         <article className="stat-card">
           <h3>Pattern</h3>
@@ -88,7 +97,9 @@ export default function SortingDoc() {
       {pseudocode && (
         <section id="pseudocode" className="doc-section">
           <h2>Pseudocode</h2>
-          <pre aria-label="Bubble Sort pseudocode"><code>{pseudocode}</code></pre>
+          <pre aria-label="Bubble Sort pseudocode" tabIndex="0">
+            <code>{pseudocode}</code>
+          </pre>
           <details className="tip">
             <summary>Optimization tip</summary>
             <p>Track last swap index to shrink the next pass range.</p>
@@ -143,6 +154,6 @@ export default function SortingDoc() {
       <section className="doc-section center">
         <Link to="/sorting" className="btn primary lg">Try in Visualizer</Link>
       </section>
-    </main>
+    </div>
   );
 }

--- a/src/pages/SortingDoc.jsx
+++ b/src/pages/SortingDoc.jsx
@@ -12,7 +12,7 @@ export default function SortingDoc() {
     return (
       <div className="doc-page">
         <header className="doc-hero">
-          <h1>Documentation not available</h1>
+          <h1 className="doc-title">Documentation not available</h1>
           <p className="muted">
             Only Bubble Sort docs are implemented right now.
           </p>
@@ -29,12 +29,13 @@ export default function SortingDoc() {
   const pseudocode = PSEUDO?.["Bubble Sort"];
 
   if (!info) {
-    // If repo data is missing, still show a friendly page
     return (
       <div className="doc-page">
         <header className="doc-hero">
-          <h1>Bubble Sort — Documentation</h1>
-          <p className="muted">Info not found in ALGORITHM_INFO. You can still try the visualizer.</p>
+          <h1 className="doc-title">Bubble Sort — Documentation</h1>
+          <p className="muted">
+            Info not found in ALGORITHM_INFO. You can still try the visualizer.
+          </p>
           <div className="cta-row">
             <Link className="btn primary" to="/sorting">Open Visualizer</Link>
           </div>
@@ -47,32 +48,37 @@ export default function SortingDoc() {
     <div className="doc-page">
       <header className="doc-hero">
         <div className="hero-text">
-          <h1>
+          <h1 className="doc-title">
             Bubble Sort <span className="tag">docs</span>
           </h1>
-          <p className="muted">{info?.description ?? "No description available."}</p>
-          <div className="cta-row">
+          <p className="muted">
+            {info?.description ?? "No description available."}
+          </p>
+
+          <nav className="cta-row" aria-label="Quick links">
             <Link to="/sorting" className="btn primary">Open Visualizer</Link>
-            {pseudocode && <a className="btn" href="#pseudocode">Pseudocode</a>}
+            {pseudocode && (
+              <a className="btn" href="#pseudocode">Pseudocode</a>
+            )}
             <a className="btn" href="#walkthrough">Walkthrough</a>
-          </div>
+          </nav>
         </div>
       </header>
 
       <section className="stats-grid" aria-label="Key properties">
-        <article className="stat-card">
+        <article className="stat-card" role="article">
           <h3>Time Complexity</h3>
           <p><strong>Avg/Worst:</strong> {info.timeComplexity}</p>
           <p><strong>Best:</strong> {info.bestCase}</p>
         </article>
-        <article className="stat-card">
+        <article className="stat-card" role="article">
           <h3>Space</h3>
           <p>
             <strong>{info.spaceComplexity}</strong>
             {info.inPlace ? " (in-place)" : ""}
           </p>
         </article>
-        <article className="stat-card">
+        <article className="stat-card" role="article">
           <h3>Stable</h3>
           <p>
             <strong>
@@ -80,7 +86,7 @@ export default function SortingDoc() {
             </strong>
           </p>
         </article>
-        <article className="stat-card">
+        <article className="stat-card" role="article">
           <h3>Pattern</h3>
           <p>Adjacent compare &amp; swap</p>
         </article>
@@ -97,7 +103,7 @@ export default function SortingDoc() {
       {pseudocode && (
         <section id="pseudocode" className="doc-section">
           <h2>Pseudocode</h2>
-          <pre aria-label="Bubble Sort pseudocode" tabIndex="0">
+          <pre aria-label="Bubble Sort pseudocode" tabIndex={0}>
             <code>{pseudocode}</code>
           </pre>
           <details className="tip">
@@ -110,32 +116,34 @@ export default function SortingDoc() {
       <section id="walkthrough" className="doc-section">
         <h2>Step-by-step walkthrough</h2>
         <p className="muted">Example: <code>[5, 1, 4, 2, 8]</code></p>
-        <div className="steps">
-          <div className="step">
+
+        <ol className="steps" role="list">
+          <li className="step">
             <div className="step-no">1</div>
             <div className="step-body">
               <p><strong>Pass 1</strong>: bubble <code>8</code> to the end.</p>
             </div>
-          </div>
-          <div className="step">
+          </li>
+          <li className="step">
             <div className="step-no">2</div>
             <div className="step-body">
               <p><strong>Pass 2</strong>: bubble next largest (<code>5</code>).</p>
             </div>
-          </div>
-          <div className="step">
+          </li>
+          <li className="step">
             <div className="step-no">3</div>
             <div className="step-body">
               <p><strong>Stop early</strong> if no swaps in a pass.</p>
             </div>
-          </div>
-        </div>
+          </li>
+        </ol>
       </section>
 
       <section className="doc-section">
         <h2>Reference implementation</h2>
         <h3>JavaScript</h3>
-        <pre><code>{`function bubbleSort(arr) {
+        <pre>
+          <code>{`function bubbleSort(arr) {
   const a = arr.slice();
   for (let i = 0; i < a.length - 1; i++) {
     let swapped = false;
@@ -148,7 +156,8 @@ export default function SortingDoc() {
     if (!swapped) break;
   }
   return a;
-}`}</code></pre>
+}`}</code>
+        </pre>
       </section>
 
       <section className="doc-section center">

--- a/src/styles/SortingDoc.css
+++ b/src/styles/SortingDoc.css
@@ -1,121 +1,298 @@
+/* ================================
+   Theme tokens (light / dark)
+   ================================ */
 
-/* src/pages/SortingDoc.css */
-
-/* scope variables to the wrapper only */
-.doc-page {
-  --bg: #0b0f14;
-  --panel: #121822;
-  --panel-2: #0f1420;
-  --text: #e6edf3;
-  --muted: #9fb2c8;
-  --brand: #6aa8ff;
-  --brand-2: #4f8df0;
-  --ok: #3ecf8e;
-  --warn: #ffcc66;
-  --border: #223048;
-  --code-bg: #0b1320;
-  --code-border: #1b2a44;
-  --shadow: 0 10px 30px rgba(0,0,0,.35);
-
-  width: 100%;
-  padding: clamp(16px, 2.5vw, 32px);
-  color: var(--text);
+:root {
+  --bg: #ffffff;
+  --surface: #f8fafc;
+  --surface-2: #eef2f7;
+  --text: #0f172a;
+  --text-muted: #475569;
+  --primary: #5b8cff;
+  --primary-contrast: #ffffff;
+  --border: #e2e8f0;
+  --success-bg: #e7f7ef;
+  --success-text: #176c3a;
+  --code-bg: #0b1020;
+  --code-text: #e5e7eb;
+  --shadow: 0 8px 22px rgba(2, 6, 23, 0.08);
 }
 
-/* everything else is prefixed with .doc-page */
-.doc-page .doc-hero{
-  background: linear-gradient(180deg, var(--panel) 0%, var(--panel-2) 100%);
-  border:1px solid var(--border);
-  border-radius:16px;
-  padding: clamp(16px, 3vw, 32px);
+/* If your app sets data-theme on <html> or a top wrapper */
+[data-theme="dark"] {
+  --bg: #0b1220;
+  --surface: #0f172a;
+  --surface-2: #131c2f;
+  --text: #e5e7eb;
+  --text-muted: #94a3b8;
+  --primary: #8ab4ff;
+  --primary-contrast: #0b1220;
+  --border: #243049;
+  --success-bg: #0d2a1a;
+  --success-text: #77d39a;
+  --code-bg: #0b1020;
+  --code-text: #e5e7eb;
+  --shadow: 0 8px 22px rgba(0, 0, 0, 0.4);
+}
+
+/* Fallback to OS preference if no data-theme is set */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]):not([data-theme="dark"]) {
+    --bg: #0b1220;
+    --surface: #0f172a;
+    --surface-2: #131c2f;
+    --text: #e5e7eb;
+    --text-muted: #94a3b8;
+    --primary: #8ab4ff;
+    --primary-contrast: #0b1220;
+    --border: #243049;
+    --success-bg: #0d2a1a;
+    --success-text: #77d39a;
+    --code-bg: #0b1020;
+    --code-text: #e5e7eb;
+    --shadow: 0 8px 22px rgba(0, 0, 0, 0.4);
+  }
+}
+
+/* ================================
+   Global layout
+   ================================ */
+
+.doc-page {
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 24px 16px;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+}
+
+.doc-title {
+  font-size: clamp(1.5rem, 2vw + 1rem, 2.25rem);
+  margin: 0 0 8px;
+}
+
+/* ================================
+   Hero
+   ================================ */
+
+.doc-hero {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: clamp(16px, 3vw, 28px);
+  box-shadow: var(--shadow);
+  margin-bottom: 20px;
+}
+
+.hero-text {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.tag {
+  display: inline-block;
+  margin-left: 8px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  font-size: 0.85rem;
+}
+
+/* ================================
+   Buttons
+   ================================ */
+
+.cta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 8px;
+}
+
+.btn {
+  appearance: none;
+  border: 1px solid var(--border);
+  background: var(--surface-2);
+  color: var(--text);
+  padding: 10px 14px;
+  border-radius: 10px;
+  font-weight: 600;
+  text-decoration: none;
+  transition: transform 0.08s ease, background 0.2s ease, border-color 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+  border-color: var(--text-muted);
+}
+
+.btn.primary {
+  background: var(--primary);
+  color: var(--primary-contrast);
+  border-color: transparent;
+}
+
+.btn.lg {
+  padding: 12px 18px;
+  font-size: 1.05rem;
+}
+
+/* ================================
+   Text styles
+   ================================ */
+
+.muted {
+  color: var(--text-muted);
+}
+
+.center {
+  text-align: center;
+}
+
+/* ================================
+   Stats grid (responsive)
+   ================================ */
+
+.stats-grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: 1fr 1fr;
+  margin: 16px 0 20px;
+}
+
+@media (min-width: 768px) {
+  .stats-grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+.stat-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 14px;
   box-shadow: var(--shadow);
 }
 
-.doc-page .hero-text h1{
-  margin:0 0 8px;
-  font-size: clamp(24px, 3.5vw, 40px);
-  line-height:1.1;
-  letter-spacing:.2px;
-}
-.doc-page .tag{
-  display:inline-block;
-  margin-left:.5rem;
-  font-size:.6em;
-  padding:.25em .55em;
-  border:1px solid var(--border);
-  border-radius:999px;
-  color:var(--muted);
-  vertical-align: middle;
-}
-.doc-page .muted{ color:var(--muted); }
-
-.doc-page .cta-row{
-  display:flex; gap:10px; margin-top:14px; flex-wrap:wrap;
-}
-.doc-page .btn{
-  display:inline-flex; align-items:center; justify-content:center;
-  padding:.55rem .9rem; border-radius:10px; border:1px solid var(--border);
-  background:transparent; color:inherit; text-decoration:none; font-weight:600;
-  transition:.2s ease;
-}
-.doc-page .btn:hover{ transform: translateY(-1px); border-color: var(--brand); }
-.doc-page .btn.primary{
-  background: linear-gradient(180deg, var(--brand) 0%, var(--brand-2) 100%);
-  color:#071224; border-color:transparent;
-}
-.doc-page .btn.primary:hover{ filter:brightness(1.05); }
-.doc-page .btn.lg{ padding:.8rem 1.2rem; font-size:1.05rem; }
-
-.doc-page .stats-grid{
-  display:grid; grid-template-columns: 1fr; gap:12px; margin:18px 0;
-}
-@media (min-width: 800px){
-  .doc-page .stats-grid{ grid-template-columns: repeat(4, 1fr); }
-}
-.doc-page .stat-card{
-  background: var(--panel); border:1px solid var(--border);
-  border-radius:14px; padding:16px;
+.stat-card h3 {
+  margin-top: 0;
+  font-size: 1rem;
 }
 
-.doc-page .callout{
-  margin:18px 0; padding:16px; border-radius:14px;
-  border:1px solid var(--border); background:rgba(62,207,142,.08);
-}
-.doc-page .callout.success h3{ margin-top:0; }
+/* ================================
+   Callouts
+   ================================ */
 
-.doc-page .doc-section{
-  margin:26px 0; padding:18px; background:var(--panel);
-  border:1px solid var(--border); border-radius:14px;
-}
-.doc-page pre{
-  background: var(--code-bg); border:1px solid var(--code-border);
-  border-radius:12px; padding:14px; overflow:auto; line-height:1.45;
-}
-.doc-page code{
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-  font-size:.95em;
+.callout {
+  border-radius: 14px;
+  padding: 14px;
+  border: 1px solid var(--border);
+  margin: 16px 0 20px;
+  background: var(--surface);
+  box-shadow: var(--shadow);
 }
 
-.doc-page .steps{ display:flex; flex-direction: column; gap:12px; }
-.doc-page .step{
-  display:grid; grid-template-columns: auto 1fr; gap:12px;
-  background: #0d1524; border:1px solid var(--border);
-  border-radius:12px; padding:12px;
+.callout.success {
+  background: var(--success-bg);
+  color: var(--success-text);
+  border-color: transparent;
 }
-.doc-page .step-no{
-  width:32px; height:32px; border-radius:50%;
-  display:flex; align-items:center; justify-content:center;
-  font-weight:800; background: var(--brand); color:#061021;
-}
-.doc-page .step-body p{ margin:.1rem 0; }
 
-.doc-page .tip{
-  margin-top:10px; background:#0e1828; border:1px dashed var(--border);
-  border-radius:12px; padding:10px 12px;
-}
-.doc-page .tip summary{ cursor:pointer; font-weight:600; color:var(--brand); }
+/* ================================
+   Sections & code blocks
+   ================================ */
 
-.doc-page .checklist{ padding-left: 1rem; margin: .4rem 0; }
-.doc-page .checklist li{ margin: .35rem 0; }
-.doc-page .checklist li.not{ color:#f5a97f; }
-.doc-page .center{ text-align:center; }
+.doc-section {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: clamp(14px, 2.5vw, 20px);
+  margin: 16px 0 20px;
+  box-shadow: var(--shadow);
+}
+
+.doc-section h2 {
+  margin-top: 0;
+}
+
+pre {
+  background: var(--code-bg);
+  color: var(--code-text);
+  border-radius: 12px;
+  padding: 12px;
+  overflow: auto;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  border: 1px solid #1b2238;
+}
+
+code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, "Courier New",
+    monospace;
+}
+
+/* ================================
+   Walkthrough steps (responsive)
+   ================================ */
+
+.steps {
+  display: grid;
+  gap: 10px;
+}
+
+.step {
+  display: grid;
+  grid-template-columns: 36px 1fr;
+  gap: 10px;
+  align-items: start;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 10px;
+}
+
+.step-no {
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  display: grid;
+  place-items: center;
+  background: var(--primary);
+  color: var(--primary-contrast);
+  font-weight: 700;
+}
+
+.step-body p {
+  margin: 6px 0 0;
+}
+
+/* ================================
+   Accessibility & mobile polish
+   ================================ */
+
+@media (max-width: 480px) {
+  .doc-page {
+    padding: 16px 12px;
+  }
+  .btn {
+    width: 100%;
+  }
+  .doc-section, .doc-hero {
+    padding: 14px;
+  }
+}
+
+/* Focus styles for keyboard users */
+.btn:focus,
+a:focus,
+summary:focus {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+  border-radius: 10px;
+}

--- a/src/styles/SortingDoc.css
+++ b/src/styles/SortingDoc.css
@@ -1,0 +1,121 @@
+
+/* src/pages/SortingDoc.css */
+
+/* scope variables to the wrapper only */
+.doc-page {
+  --bg: #0b0f14;
+  --panel: #121822;
+  --panel-2: #0f1420;
+  --text: #e6edf3;
+  --muted: #9fb2c8;
+  --brand: #6aa8ff;
+  --brand-2: #4f8df0;
+  --ok: #3ecf8e;
+  --warn: #ffcc66;
+  --border: #223048;
+  --code-bg: #0b1320;
+  --code-border: #1b2a44;
+  --shadow: 0 10px 30px rgba(0,0,0,.35);
+
+  width: 100%;
+  padding: clamp(16px, 2.5vw, 32px);
+  color: var(--text);
+}
+
+/* everything else is prefixed with .doc-page */
+.doc-page .doc-hero{
+  background: linear-gradient(180deg, var(--panel) 0%, var(--panel-2) 100%);
+  border:1px solid var(--border);
+  border-radius:16px;
+  padding: clamp(16px, 3vw, 32px);
+  box-shadow: var(--shadow);
+}
+
+.doc-page .hero-text h1{
+  margin:0 0 8px;
+  font-size: clamp(24px, 3.5vw, 40px);
+  line-height:1.1;
+  letter-spacing:.2px;
+}
+.doc-page .tag{
+  display:inline-block;
+  margin-left:.5rem;
+  font-size:.6em;
+  padding:.25em .55em;
+  border:1px solid var(--border);
+  border-radius:999px;
+  color:var(--muted);
+  vertical-align: middle;
+}
+.doc-page .muted{ color:var(--muted); }
+
+.doc-page .cta-row{
+  display:flex; gap:10px; margin-top:14px; flex-wrap:wrap;
+}
+.doc-page .btn{
+  display:inline-flex; align-items:center; justify-content:center;
+  padding:.55rem .9rem; border-radius:10px; border:1px solid var(--border);
+  background:transparent; color:inherit; text-decoration:none; font-weight:600;
+  transition:.2s ease;
+}
+.doc-page .btn:hover{ transform: translateY(-1px); border-color: var(--brand); }
+.doc-page .btn.primary{
+  background: linear-gradient(180deg, var(--brand) 0%, var(--brand-2) 100%);
+  color:#071224; border-color:transparent;
+}
+.doc-page .btn.primary:hover{ filter:brightness(1.05); }
+.doc-page .btn.lg{ padding:.8rem 1.2rem; font-size:1.05rem; }
+
+.doc-page .stats-grid{
+  display:grid; grid-template-columns: 1fr; gap:12px; margin:18px 0;
+}
+@media (min-width: 800px){
+  .doc-page .stats-grid{ grid-template-columns: repeat(4, 1fr); }
+}
+.doc-page .stat-card{
+  background: var(--panel); border:1px solid var(--border);
+  border-radius:14px; padding:16px;
+}
+
+.doc-page .callout{
+  margin:18px 0; padding:16px; border-radius:14px;
+  border:1px solid var(--border); background:rgba(62,207,142,.08);
+}
+.doc-page .callout.success h3{ margin-top:0; }
+
+.doc-page .doc-section{
+  margin:26px 0; padding:18px; background:var(--panel);
+  border:1px solid var(--border); border-radius:14px;
+}
+.doc-page pre{
+  background: var(--code-bg); border:1px solid var(--code-border);
+  border-radius:12px; padding:14px; overflow:auto; line-height:1.45;
+}
+.doc-page code{
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size:.95em;
+}
+
+.doc-page .steps{ display:flex; flex-direction: column; gap:12px; }
+.doc-page .step{
+  display:grid; grid-template-columns: auto 1fr; gap:12px;
+  background: #0d1524; border:1px solid var(--border);
+  border-radius:12px; padding:12px;
+}
+.doc-page .step-no{
+  width:32px; height:32px; border-radius:50%;
+  display:flex; align-items:center; justify-content:center;
+  font-weight:800; background: var(--brand); color:#061021;
+}
+.doc-page .step-body p{ margin:.1rem 0; }
+
+.doc-page .tip{
+  margin-top:10px; background:#0e1828; border:1px dashed var(--border);
+  border-radius:12px; padding:10px 12px;
+}
+.doc-page .tip summary{ cursor:pointer; font-weight:600; color:var(--brand); }
+
+.doc-page .checklist{ padding-left: 1rem; margin: .4rem 0; }
+.doc-page .checklist li{ margin: .35rem 0; }
+.doc-page .checklist li.not{ color:#f5a97f; }
+.doc-page .center{ text-align:center; }

--- a/ter
+++ b/ter
@@ -1,0 +1,314 @@
+
+                   SSUUMMMMAARRYY OOFF LLEESSSS CCOOMMMMAANNDDSS
+
+      Commands marked with * may be preceded by a number, _N.
+      Notes in parentheses indicate the behavior if _N is given.
+      A key preceded by a caret indicates the Ctrl key; thus ^K is ctrl-K.
+
+  h  H                 Display this help.
+  q  :q  Q  :Q  ZZ     Exit.
+ ---------------------------------------------------------------------------
+
+                           MMOOVVIINNGG
+
+  e  ^E  j  ^N  CR  *  Forward  one line   (or _N lines).
+  y  ^Y  k  ^K  ^P  *  Backward one line   (or _N lines).
+  f  ^F  ^V  SPACE  *  Forward  one window (or _N lines).
+  b  ^B  ESC-v      *  Backward one window (or _N lines).
+  z                 *  Forward  one window (and set window to _N).
+  w                 *  Backward one window (and set window to _N).
+  ESC-SPACE         *  Forward  one window, but don't stop at end-of-file.
+  d  ^D             *  Forward  one half-window (and set half-window to _N).
+  u  ^U             *  Backward one half-window (and set half-window to _N).
+  ESC-)  RightArrow *  Right one half screen width (or _N positions).
+  ESC-(  LeftArrow  *  Left  one half screen width (or _N positions).
+  ESC-}  ^RightArrow   Right to last column displayed.
+  ESC-{  ^LeftArrow    Left  to first column.
+  F                    Forward forever; like "tail -f".
+  ESC-F                Like F but stop when search pattern is found.
+  r  ^R  ^L            Repaint screen.
+  R                    Repaint screen, discarding buffered input.
+        ---------------------------------------------------
+        Default "window" is the screen height.
+        Default "half-window" is half of the screen height.
+ ---------------------------------------------------------------------------
+
+                          SSEEAARRCCHHIINNGG
+
+  /_p_a_t_t_e_r_n          *  Search forward for (_N-th) matching line.
+  ?_p_a_t_t_e_r_n          *  Search backward for (_N-th) matching line.
+  n                 *  Repeat previous search (for _N-th occurrence).
+  N                 *  Repeat previous search in reverse direction.
+  ESC-n             *  Repeat previous search, spanning files.
+  ESC-N             *  Repeat previous search, reverse dir. & spanning files.
+  ^O^N  ^On         *  Search forward for (_N-th) OSC8 hyperlink.
+  ^O^P  ^Op         *  Search backward for (_N-th) OSC8 hyperlink.
+  ^O^L  ^Ol            Jump to the currently selected OSC8 hyperlink.
+  ESC-u                Undo (toggle) search highlighting.
+  ESC-U                Clear search highlighting.
+  &_p_a_t_t_e_r_n          *  Display only matching lines.
+        ---------------------------------------------------
+        A search pattern may begin with one or more of:
+        ^N or !  Search for NON-matching lines.
+        ^E or *  Search multiple files (pass thru END OF FILE).
+        ^F or @  Start search at FIRST file (for /) or last file (for ?).
+        ^K       Highlight matches, but don't move (KEEP position).
+        ^R       Don't use REGULAR EXPRESSIONS.
+        ^S _n     Search for match in _n-th parenthesized subpattern.
+        ^W       WRAP search if no match found.
+        ^L       Enter next character literally into pattern.
+ ---------------------------------------------------------------------------
+
+                           JJUUMMPPIINNGG
+
+  g  <  ESC-<       *  Go to first line in file (or line _N).
+  G  >  ESC->       *  Go to last line in file (or line _N).
+  p  %              *  Go to beginning of file (or _N percent into file).
+  t                 *  Go to the (_N-th) next tag.
+  T                 *  Go to the (_N-th) previous tag.
+  {  (  [           *  Find close bracket } ) ].
+  }  )  ]           *  Find open bracket { ( [.
+  ESC-^F _<_c_1_> _<_c_2_>  *  Find close bracket _<_c_2_>.
+  ESC-^B _<_c_1_> _<_c_2_>  *  Find open bracket _<_c_1_>.
+        ---------------------------------------------------
+        Each "find close bracket" command goes forward to the close bracket 
+          matching the (_N-th) open bracket in the top line.
+        Each "find open bracket" command goes backward to the open bracket 
+          matching the (_N-th) close bracket in the bottom line.
+
+  m_<_l_e_t_t_e_r_>            Mark the current top line with <letter>.
+  M_<_l_e_t_t_e_r_>            Mark the current bottom line with <letter>.
+  '_<_l_e_t_t_e_r_>            Go to a previously marked position.
+  ''                   Go to the previous position.
+  ^X^X                 Same as '.
+  ESC-m_<_l_e_t_t_e_r_>        Clear a mark.
+        ---------------------------------------------------
+        A mark is any upper-case or lower-case letter.
+        Certain marks are predefined:
+             ^  means  beginning of the file
+             $  means  end of the file
+ ---------------------------------------------------------------------------
+
+                        CCHHAANNGGIINNGG FFIILLEESS
+
+  :e [_f_i_l_e]            Examine a new file.
+  ^X^V                 Same as :e.
+  :n                *  Examine the (_N-th) next file from the command line.
+  :p                *  Examine the (_N-th) previous file from the command line.
+  :x                *  Examine the first (or _N-th) file from the command line.
+  ^O^O                 Open the currently selected OSC8 hyperlink.
+  :d                   Delete the current file from the command line list.
+  =  ^G  :f            Print current file name.
+ ---------------------------------------------------------------------------
+
+                    MMIISSCCEELLLLAANNEEOOUUSS CCOOMMMMAANNDDSS
+
+  -_<_f_l_a_g_>              Toggle a command line option [see OPTIONS below].
+  --_<_n_a_m_e_>             Toggle a command line option, by name.
+  __<_f_l_a_g_>              Display the setting of a command line option.
+  ___<_n_a_m_e_>             Display the setting of an option, by name.
+  +_c_m_d                 Execute the less cmd each time a new file is examined.
+
+  !_c_o_m_m_a_n_d             Execute the shell command with $SHELL.
+  #_c_o_m_m_a_n_d             Execute the shell command, expanded like a prompt.
+  |XX_c_o_m_m_a_n_d            Pipe file between current pos & mark XX to shell command.
+  s _f_i_l_e               Save input to a file.
+  v                    Edit the current file with $VISUAL or $EDITOR.
+  V                    Print version number of "less".
+ ---------------------------------------------------------------------------
+
+                           OOPPTTIIOONNSS
+
+        Most options may be changed either on the command line,
+        or from within less by using the - or -- command.
+        Options may be given in one of two forms: either a single
+        character preceded by a -, or a name preceded by --.
+
+  -?  ........  --help
+                  Display help (from command line).
+  -a  ........  --search-skip-screen
+                  Search skips current screen.
+  -A  ........  --SEARCH-SKIP-SCREEN
+                  Search starts just after target line.
+  -b [_N]  ....  --buffers=[_N]
+                  Number of buffers.
+  -B  ........  --auto-buffers
+                  Don't automatically allocate buffers for pipes.
+  -c  ........  --clear-screen
+                  Repaint by clearing rather than scrolling.
+  -d  ........  --dumb
+                  Dumb terminal.
+  -D xx_c_o_l_o_r  .  --color=xx_c_o_l_o_r
+                  Set screen colors.
+  -e  -E  ....  --quit-at-eof  --QUIT-AT-EOF
+                  Quit at end of file.
+  -f  ........  --force
+                  Force open non-regular files.
+  -F  ........  --quit-if-one-screen
+                  Quit if entire file fits on first screen.
+  -g  ........  --hilite-search
+                  Highlight only last match for searches.
+  -G  ........  --HILITE-SEARCH
+                  Don't highlight any matches for searches.
+  -h [_N]  ....  --max-back-scroll=[_N]
+                  Backward scroll limit.
+  -i  ........  --ignore-case
+                  Ignore case in searches that do not contain uppercase.
+  -I  ........  --IGNORE-CASE
+                  Ignore case in all searches.
+  -j [_N]  ....  --jump-target=[_N]
+                  Screen position of target lines.
+  -J  ........  --status-column
+                  Display a status column at left edge of screen.
+  -k _f_i_l_e  ...  --lesskey-file=_f_i_l_e
+                  Use a compiled lesskey file.
+  -K  ........  --quit-on-intr
+                  Exit less in response to ctrl-C.
+  -L  ........  --no-lessopen
+                  Ignore the LESSOPEN environment variable.
+  -m  -M  ....  --long-prompt  --LONG-PROMPT
+                  Set prompt style.
+  -n .........  --line-numbers
+                  Suppress line numbers in prompts and messages.
+  -N .........  --LINE-NUMBERS
+                  Display line number at start of each line.
+  -o [_f_i_l_e] ..  --log-file=[_f_i_l_e]
+                  Copy to log file (standard input only).
+  -O [_f_i_l_e] ..  --LOG-FILE=[_f_i_l_e]
+                  Copy to log file (unconditionally overwrite).
+  -p _p_a_t_t_e_r_n .  --pattern=[_p_a_t_t_e_r_n]
+                  Start at pattern (from command line).
+  -P [_p_r_o_m_p_t]   --prompt=[_p_r_o_m_p_t]
+                  Define new prompt.
+  -q  -Q  ....  --quiet  --QUIET  --silent --SILENT
+                  Quiet the terminal bell.
+  -r  -R  ....  --raw-control-chars  --RAW-CONTROL-CHARS
+                  Output "raw" control characters.
+  -s  ........  --squeeze-blank-lines
+                  Squeeze multiple blank lines.
+  -S  ........  --chop-long-lines
+                  Chop (truncate) long lines rather than wrapping.
+  -t _t_a_g  ....  --tag=[_t_a_g]
+                  Find a tag.
+  -T [_t_a_g_s_f_i_l_e] --tag-file=[_t_a_g_s_f_i_l_e]
+                  Use an alternate tags file.
+  -u  -U  ....  --underline-special  --UNDERLINE-SPECIAL
+                  Change handling of backspaces, tabs and carriage returns.
+  -V  ........  --version
+                  Display the version number of "less".
+  -w  ........  --hilite-unread
+                  Highlight first new line after forward-screen.
+  -W  ........  --HILITE-UNREAD
+                  Highlight first new line after any forward movement.
+  -x [_N[,...]]  --tabs=[_N[,...]]
+                  Set tab stops.
+  -X  ........  --no-init
+                  Don't use termcap init/deinit strings.
+  -y [_N]  ....  --max-forw-scroll=[_N]
+                  Forward scroll limit.
+  -z [_N]  ....  --window=[_N]
+                  Set size of window.
+  -" [_c[_c]]  .  --quotes=[_c[_c]]
+                  Set shell quote characters.
+  -~  ........  --tilde
+                  Don't display tildes after end of file.
+  -# [_N]  ....  --shift=[_N]
+                  Set horizontal scroll amount (0 = one half screen width).
+
+                --exit-follow-on-close
+                  Exit F command on a pipe when writer closes pipe.
+                --file-size
+                  Automatically determine the size of the input file.
+                --follow-name
+                  The F command changes files if the input file is renamed.
+                --header=[_L[,_C[,_N]]]
+                  Use _L lines (starting at line _N) and _C columns as headers.
+                --incsearch
+                  Search file as each pattern character is typed in.
+                --intr=[_C]
+                  Use _C instead of ^X to interrupt a read.
+                --lesskey-context=_t_e_x_t
+                  Use lesskey source file contents.
+                --lesskey-src=_f_i_l_e
+                  Use a lesskey source file.
+                --line-num-width=[_N]
+                  Set the width of the -N line number field to _N characters.
+                --match-shift=[_N]
+                  Show at least _N characters to the left of a search match.
+                --modelines=[_N]
+                  Read _N lines from the input file and look for vim modelines.
+                --mouse
+                  Enable mouse input.
+                --no-keypad
+                  Don't send termcap keypad init/deinit strings.
+                --no-histdups
+                  Remove duplicates from command history.
+                --no-number-headers
+                  Don't give line numbers to header lines.
+                --no-search-header-lines
+                  Searches do not include header lines.
+                --no-search-header-columns
+                  Searches do not include header columns.
+                --no-search-headers
+                  Searches do not include header lines or columns.
+                --no-vbell
+                  Disable the terminal's visual bell.
+                --redraw-on-quit
+                  Redraw final screen when quitting.
+                --rscroll=[_C]
+                  Set the character used to mark truncated lines.
+                --save-marks
+                  Retain marks across invocations of less.
+                --search-options=[EFKNRW-]
+                  Set default options for every search.
+                --show-preproc-errors
+                  Display a message if preprocessor exits with an error status.
+                --proc-backspace
+                  Process backspaces for bold/underline.
+                --PROC-BACKSPACE
+                  Treat backspaces as control characters.
+                --proc-return
+                  Delete carriage returns before newline.
+                --PROC-RETURN
+                  Treat carriage returns as control characters.
+                --proc-tab
+                  Expand tabs to spaces.
+                --PROC-TAB
+                  Treat tabs as control characters.
+                --status-col-width=[_N]
+                  Set the width of the -J status column to _N characters.
+                --status-line
+                  Highlight or color the entire line containing a mark.
+                --use-backslash
+                  Subsequent options use backslash as escape char.
+                --use-color
+                  Enables colored text.
+                --wheel-lines=[_N]
+                  Each click of the mouse wheel moves _N lines.
+                --wordwrap
+                  Wrap lines at spaces.
+
+
+ ---------------------------------------------------------------------------
+
+                          LLIINNEE EEDDIITTIINNGG
+
+        These keys can be used to edit text being entered 
+        on the "command line" at the bottom of the screen.
+
+ RightArrow ..................... ESC-l ... Move cursor right one character.
+ LeftArrow ...................... ESC-h ... Move cursor left one character.
+ ctrl-RightArrow  ESC-RightArrow  ESC-w ... Move cursor right one word.
+ ctrl-LeftArrow   ESC-LeftArrow   ESC-b ... Move cursor left one word.
+ HOME ........................... ESC-0 ... Move cursor to start of line.
+ END ............................ ESC-$ ... Move cursor to end of line.
+ BACKSPACE ................................ Delete char to left of cursor.
+ DELETE ......................... ESC-x ... Delete char under cursor.
+ ctrl-BACKSPACE   ESC-BACKSPACE ........... Delete word to left of cursor.
+ ctrl-DELETE .... ESC-DELETE .... ESC-X ... Delete word under cursor.
+ ctrl-U ......... ESC (MS-DOS only) ....... Delete entire line.
+ UpArrow ........................ ESC-k ... Retrieve previous command line.
+ DownArrow ...................... ESC-j ... Retrieve next command line.
+ TAB ...................................... Complete filename & cycle.
+ SHIFT-TAB ...................... ESC-TAB   Complete filename & reverse cycle.
+ ctrl-L ................................... Complete filename, list all.


### PR DESCRIPTION

## Which issue does this PR close?

* Closes #512 

## Rationale for this change

Currently, clicking **Data Structures → Overview → Bubble Sort** redirects to the *Doubts* page because there was no Bubble Sort documentation route. This PR adds a dedicated documentation page for Bubble Sort so learners can access algorithm details alongside the visualizer.

## What changes are included in this PR?

* Added new `SortingDoc.jsx` + `SortingDoc.css` components for the Bubble Sort documentation page
* Registered new route: `/sorting/bubbleSort/docs` in `App.jsx`
* Updated **Data Structures → Overview** to send Bubble Sort card clicks to `/sorting/bubbleSort/docs`
* Scoped CSS to `.doc-page` so styles don’t leak into other pages
* Added CTA link back to `/sorting` visualizer from docs page
* Included Bubble Sort overview, complexity, pseudocode, walkthrough, and reference code snippets

## Are these changes tested?

* Verified manually by navigating to **Data Structures → Overview → Bubble Sort**
* Confirmed that docs page loads correctly, is mobile-friendly, and that “Try in Visualizer” button links to `/sorting`
* Other algorithms still behave as before (open the visualizer directly)

## Are there any user-facing changes?

Yes:

* Bubble Sort now opens a proper documentation page instead of redirecting to the Doubts page.
* The new docs page contains explanation, pseudocode, walkthrough, and code samples.
* Other algorithm cards remain unchanged.

---

## before : 

https://github.com/user-attachments/assets/5f127b0c-39c7-4448-83f7-aa7d3db0d287

## after 

https://github.com/user-attachments/assets/831e462d-eff1-448f-a249-bd9db2b66b32


