### PR TITLE
added sorting docs

### DIFF
--- a/src/pages/SortingDoc.jsx
+++ b/src/pages/SortingDoc.jsx
@@ -1,42 +1,38 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { useParams, Link } from "react-router-dom";
 import { ALGORITHM_INFO } from "../data/algorithmInfo";
 import { ALGORITHM_PSEUDOCODE as PSEUDO } from "../data/pseudocode";
+import { sortingAlgorithms as CODE } from "../data/allCodes";
 import "../styles/SortingDoc.css";
 
+function normalizeStable(v) {
+  if (typeof v === "boolean") return v ? "Yes" : "No";
+  if (typeof v === "string") return v;
+  return String(v ?? "Unknown");
+}
+
 export default function SortingDoc() {
-  const { algoId } = useParams();
+  const { algoId = "" } = useParams();
 
-  // Only support Bubble Sort for now
-  if (algoId !== "bubbleSort") {
-    return (
-      <div className="doc-page">
-        <header className="doc-hero">
-          <h1 className="doc-title">Documentation not available</h1>
-          <p className="muted">
-            Only Bubble Sort docs are implemented right now.
-          </p>
-          <div className="cta-row">
-            <Link className="btn" to="/data-structures">Back to Overview</Link>
-            <Link className="btn primary" to="/sorting">Open Visualizer</Link>
-          </div>
-        </header>
-      </div>
-    );
-  }
+  const info = ALGORITHM_INFO?.[algoId];
+  const pseudo = PSEUDO?.[algoId]; // your pseudocode keys are camelCase (e.g., bubbleSort)
+  const code = CODE?.[algoId];
 
-  const info = ALGORITHM_INFO?.bubbleSort;
-  const pseudocode = PSEUDO?.["Bubble Sort"];
+  const title = useMemo(() => {
+    // turn "bubbleSort" -> "Bubble Sort"
+    return algoId
+      .replace(/([A-Z])/g, " $1")
+      .replace(/^./, (s) => s.toUpperCase());
+  }, [algoId]);
 
   if (!info) {
     return (
       <div className="doc-page">
         <header className="doc-hero">
-          <h1 className="doc-title">Bubble Sort — Documentation</h1>
-          <p className="muted">
-            Info not found in ALGORITHM_INFO. You can still try the visualizer.
-          </p>
+          <h1 className="doc-title">Documentation not available</h1>
+          <p className="muted">No docs found for “{algoId}”.</p>
           <div className="cta-row">
+            <Link className="btn" to="/data-structures">Back to Overview</Link>
             <Link className="btn primary" to="/sorting">Open Visualizer</Link>
           </div>
         </header>
@@ -49,116 +45,76 @@ export default function SortingDoc() {
       <header className="doc-hero">
         <div className="hero-text">
           <h1 className="doc-title">
-            Bubble Sort <span className="tag">docs</span>
+            {title} <span className="tag">docs</span>
           </h1>
-          <p className="muted">
-            {info?.description ?? "No description available."}
-          </p>
+          <p className="muted">{info.description ?? "No description available."}</p>
 
           <nav className="cta-row" aria-label="Quick links">
             <Link to="/sorting" className="btn primary">Open Visualizer</Link>
-            {pseudocode && (
-              <a className="btn" href="#pseudocode">Pseudocode</a>
-            )}
-            <a className="btn" href="#walkthrough">Walkthrough</a>
+            {pseudo?.length ? <a className="btn" href="#pseudocode">Pseudocode</a> : null}
+            {code ? <a className="btn" href="#reference">Reference</a> : null}
           </nav>
         </div>
       </header>
 
       <section className="stats-grid" aria-label="Key properties">
-        <article className="stat-card" role="article">
+        <article className="stat-card">
           <h3>Time Complexity</h3>
           <p><strong>Avg/Worst:</strong> {info.timeComplexity}</p>
           <p><strong>Best:</strong> {info.bestCase}</p>
         </article>
-        <article className="stat-card" role="article">
+
+        <article className="stat-card">
           <h3>Space</h3>
-          <p>
-            <strong>{info.spaceComplexity}</strong>
-            {info.inPlace ? " (in-place)" : ""}
-          </p>
+          <p><strong>{info.spaceComplexity}</strong></p>
         </article>
-        <article className="stat-card" role="article">
+
+        <article className="stat-card">
           <h3>Stable</h3>
-          <p>
-            <strong>
-              {info.stable === true ? "Yes" : info.stable === false ? "No" : String(info.stable)}
-            </strong>
-          </p>
-        </article>
-        <article className="stat-card" role="article">
-          <h3>Pattern</h3>
-          <p>Adjacent compare &amp; swap</p>
+          <p><strong>{normalizeStable(info.stable)}</strong></p>
         </article>
       </section>
 
-      <section className="callout success" role="note">
-        <h3>Intuition</h3>
-        <p>
-          Compare adjacent items and swap if out of order. After each pass, the largest
-          unsorted element “bubbles” to the end. Stop early when a pass makes no swaps.
-        </p>
-      </section>
-
-      {pseudocode && (
+      {pseudo?.length ? (
         <section id="pseudocode" className="doc-section">
           <h2>Pseudocode</h2>
-          <pre aria-label="Bubble Sort pseudocode" tabIndex={0}>
-            <code>{pseudocode}</code>
-          </pre>
-          <details className="tip">
-            <summary>Optimization tip</summary>
-            <p>Track last swap index to shrink the next pass range.</p>
-          </details>
+          <div className="pseudo-steps">
+            {pseudo.map((step, i) => (
+              <div className="pseudo-step" key={i}>
+                <pre><code>{step.code}</code></pre>
+                {step.explain ? <p className="muted">{step.explain}</p> : null}
+              </div>
+            ))}
+          </div>
         </section>
-      )}
+      ) : null}
 
-      <section id="walkthrough" className="doc-section">
-        <h2>Step-by-step walkthrough</h2>
-        <p className="muted">Example: <code>[5, 1, 4, 2, 8]</code></p>
+      {code ? (
+        <section id="reference" className="doc-section">
+          <h2>Reference implementation</h2>
 
-        <ol className="steps" role="list">
-          <li className="step">
-            <div className="step-no">1</div>
-            <div className="step-body">
-              <p><strong>Pass 1</strong>: bubble <code>8</code> to the end.</p>
-            </div>
-          </li>
-          <li className="step">
-            <div className="step-no">2</div>
-            <div className="step-body">
-              <p><strong>Pass 2</strong>: bubble next largest (<code>5</code>).</p>
-            </div>
-          </li>
-          <li className="step">
-            <div className="step-no">3</div>
-            <div className="step-body">
-              <p><strong>Stop early</strong> if no swaps in a pass.</p>
-            </div>
-          </li>
-        </ol>
-      </section>
+          {code.java && (
+            <>
+              <h3>Java</h3>
+              <pre><code>{code.java}</code></pre>
+            </>
+          )}
 
-      <section className="doc-section">
-        <h2>Reference implementation</h2>
-        <h3>JavaScript</h3>
-        <pre>
-          <code>{`function bubbleSort(arr) {
-  const a = arr.slice();
-  for (let i = 0; i < a.length - 1; i++) {
-    let swapped = false;
-    for (let j = 0; j < a.length - 1 - i; j++) {
-      if (a[j] > a[j + 1]) {
-        [a[j], a[j + 1]] = [a[j + 1], a[j]];
-        swapped = true;
-      }
-    }
-    if (!swapped) break;
-  }
-  return a;
-}`}</code>
-        </pre>
-      </section>
+          {code.python && (
+            <>
+              <h3>Python</h3>
+              <pre><code>{code.python}</code></pre>
+            </>
+          )}
+
+          {code.cpp && (
+            <>
+              <h3>C++</h3>
+              <pre><code>{code.cpp}</code></pre>
+            </>
+          )}
+        </section>
+      ) : null}
 
       <section className="doc-section center">
         <Link to="/sorting" className="btn primary lg">Try in Visualizer</Link>


### PR DESCRIPTION
## Which issue does this PR close?


- Closes  #522 , #523  .

## Rationale for this change

added documentations for sorting algorithms so , now they have algorithm documentation page , tehy dont redirect to doubts section

## What changes are included in this PR?
added documentations for sorting algorithms, and closed 3 issues.
<img width="1918" height="972" alt="image" src="https://github.com/user-attachments/assets/0de86a56-99d2-4d65-97d3-33607be83fad" />
<img width="1918" height="975" alt="image" src="https://github.com/user-attachments/assets/3a336155-814b-4510-a84d-3f6ef9d70bcc" />

## Are these changes tested?

yes 

## Are there any user-facing changes?

yes 
