### PR TITLE
fix(leaderboard): fetch merged PRs via search API and compute level points (#553)

### DIFF
--- a/src/pages/ContributorLeaderboard.jsx
+++ b/src/pages/ContributorLeaderboard.jsx
@@ -1,65 +1,43 @@
 import { useEffect, useState } from "react";
 import { motion } from "framer-motion";
-import {
-  FaTrophy,
-  FaStar,
-  FaCode,
-  FaUsers,
-  FaGithub,
-  FaSearch,
-  FaBook,
-  FaBookOpen,
-} from "react-icons/fa";
+import { FaStar, FaCode, FaUsers, FaGithub, FaSearch } from "react-icons/fa";
 import { ChevronRight, ChevronLeft } from "lucide-react";
-import { useTheme } from "../ThemeContext"; // Theme context
-import { useNavigate } from "react-router-dom";
+import { useTheme } from "../ThemeContext";
 import "../styles/leaderboard.css";
 
 const GITHUB_REPO = "RhythmPahwa14/AlgoVisualizer";
 const token = import.meta.env.VITE_GITHUB_TOKEN;
 
-// Points configuration for different PR levels
-const POINTS = {
-  "level-1": 3, // Easy
-  "level-2": 7, // Medium
-  "level-3": 10, // Hard/Feature
+// Points for levels
+const POINTS = { "level-1": 3, "level-2": 7, "level-3": 10 };
+
+// --- helpers ---
+const normalize = (s) => (s || "").toLowerCase().replace(/[’‘`]/g, "'").trim();
+const canonicalLevel = (label) => {
+  const n = normalize(label).replace(/\s*[:\-_]\s*/g, "-"); // "level 1" / "level:1" → "level-1"
+  const m = n.match(/^level-(1|2|3)$/);
+  return m ? `level-${m[1]}` : null;
 };
 
-// Badge component for PR counts
+// small badge
 const Badge = ({ count, label, color }) => (
   <div className="badge" style={color}>
     <FaCode style={{ marginRight: 6, fontSize: 12 }} />
-    <span>
-      {count} {label}
-    </span>
+    <span>{count} {label}</span>
     <style jsx>{`
       .badge {
-        display: flex;
-        align-items: center;
-        padding: 4px 12px;
-        border-radius: 9999px;
-        font-size: 13px;
-        font-weight: 500;
-        background: rgba(0, 0, 0, 0.04);
+        display: flex; align-items: center; padding: 4px 12px;
+        border-radius: 9999px; font-size: 13px; font-weight: 500;
+        background: rgba(0,0,0,0.04);
       }
     `}</style>
   </div>
 );
 
-// Skeleton Loader Component
+// skeleton
 const SkeletonLoader = ({ isDark }) => (
-  <div
-    className="skeleton-loader"
-    style={{
-      background: isDark ? "#23272f" : "#fff",
-      border: `1px solid ${isDark ? "#444" : "#eee"}`,
-    }}
-  >
-    <div className="skeleton-header">
-      <div>#</div>
-      <div>Contributor</div>
-      <div>Contributions</div>
-    </div>
+  <div className="skeleton-loader" style={{ background: isDark ? "#23272f" : "#fff", border: `1px solid ${isDark ? "#444" : "#eee"}` }}>
+    <div className="skeleton-header"><div>#</div><div>Contributor</div><div>Contributions</div></div>
     <div>
       {[...Array(10)].map((_, i) => (
         <div key={i} className="skeleton-row">
@@ -67,217 +45,138 @@ const SkeletonLoader = ({ isDark }) => (
           <div className="skeleton-avatar" style={{ width: 40, height: 40 }} />
           <div className="skeleton-info">
             <div className="skeleton-bar" style={{ width: 96 }} />
-            <div className="skeleton-badges">
-              <div className="skeleton-badge" />
-              <div className="skeleton-badge" />
-            </div>
+            <div className="skeleton-badges"><div className="skeleton-badge" /><div className="skeleton-badge" /></div>
           </div>
         </div>
       ))}
     </div>
     <style jsx>{`
-      .skeleton-loader {
-        border-radius: 16px;
-        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
-        overflow: hidden;
-        margin-bottom: 24px;
-      }
-      .skeleton-header {
-        display: flex;
-        justify-content: space-between;
-        padding: 16px;
-        font-size: 15px;
-        font-weight: 500;
-        background: #f6f6f6;
-        border-bottom: 1px solid #eee;
-      }
-      .skeleton-row {
-        display: flex;
-        align-items: center;
-        padding: 16px;
-        gap: 16px;
-      }
-      .skeleton-avatar {
-        width: 32px;
-        height: 32px;
-        border-radius: 50%;
-        background: #e5e7eb;
-        animation: pulse 1.5s infinite;
-      }
-      .skeleton-info {
-        flex: 1;
-        display: flex;
-        flex-direction: column;
-        gap: 8px;
-      }
-      .skeleton-bar {
-        height: 16px;
-        border-radius: 8px;
-        background: #e5e7eb;
-        animation: pulse 1.5s infinite;
-      }
-      .skeleton-badges {
-        display: flex;
-        gap: 8px;
-      }
-      .skeleton-badge {
-        width: 48px;
-        height: 24px;
-        border-radius: 9999px;
-        background: #e5e7eb;
-        animation: pulse 1.5s infinite;
-      }
-      @keyframes pulse {
-        0% {
-          opacity: 1;
-        }
-        50% {
-          opacity: 0.5;
-        }
-        100% {
-          opacity: 1;
-        }
-      }
+      .skeleton-loader{ border-radius:16px; box-shadow:0 2px 8px rgba(0,0,0,0.04); overflow:hidden; margin-bottom:24px; }
+      .skeleton-header{ display:flex; justify-content:space-between; padding:16px; font-size:15px; font-weight:500; background:#f6f6f6; border-bottom:1px solid #eee; }
+      .skeleton-row{ display:flex; align-items:center; padding:16px; gap:16px; }
+      .skeleton-avatar{ width:32px; height:32px; border-radius:50%; background:#e5e7eb; animation:pulse 1.5s infinite; }
+      .skeleton-info{ flex:1; display:flex; flex-direction:column; gap:8px; }
+      .skeleton-bar{ height:16px; border-radius:8px; background:#e5e7eb; animation:pulse 1.5s infinite; }
+      .skeleton-badges{ display:flex; gap:8px; }
+      .skeleton-badge{ width:48px; height:24px; border-radius:9999px; background:#e5e7eb; animation:pulse 1.5s infinite; }
+      @keyframes pulse{0%{opacity:1}50%{opacity:.5}100%{opacity:1}}
     `}</style>
   </div>
 );
 
-export default function LeaderBoard() {
+export default function ContributorsLeaderboard() {
   const [contributors, setContributors] = useState([]);
   const [loading, setLoading] = useState(true);
-  const [stats, setStats] = useState({
-    totalPRs: 0,
-    totalContributors: 0,
-    totalPoints: 0,
-  });
+  const [errorMsg, setErrorMsg] = useState("");
+  const [stats, setStats] = useState({ flooredTotalPRs: 0, totalContributors: 0, flooredTotalPoints: 0 });
   const [searchTerm, setSearchTerm] = useState("");
   const { theme } = useTheme();
   const isDark = theme === "dark";
-  const navigate = useNavigate();
 
   useEffect(() => {
-    const fetchContributorsWithPoints = async () => {
+    const fetchMergedPRsAndScore = async () => {
+      setLoading(true);
+      setErrorMsg("");
       try {
-        let contributorsMap = {};
-        let page = 1;
-        const MAX_PAGES = 10;
-        let keepFetching = true;
+        const contributorsMap = {};
+        const PER_PAGE = 100;
+        const MAX_PAGES = 10; // Search API caps at 1000
 
-        while (keepFetching && page <= MAX_PAGES) {
-          const res = await fetch(
-            `https://api.github.com/repos/${GITHUB_REPO}/pulls?state=closed&per_page=100&page=${page}`,
-            {
-              headers: {
-                Accept: "application/vnd.github.v3+json",
-                ...(token ? { Authorization: `Bearer ${token}` } : {}),
-              },
-            }
-          );
-          const prs = await res.json();
+        // We fetch ALL merged PRs, then compute points locally from labels.
+        // (We don't depend on a GSSoC label; if level labels are missing, points will be 0 but PRs still count.)
+        const baseQ = `repo:${GITHUB_REPO}+is:pr+is:merged`;
 
-          if (
-            !Array.isArray(prs) ||
-            prs.length === 0 ||
-            (prs.length === 1 && prs[0].message)
-          ) {
-            keepFetching = false;
+        for (let page = 1; page <= MAX_PAGES; page++) {
+          const url = `https://api.github.com/search/issues?q=${baseQ}&per_page=${PER_PAGE}&page=${page}`;
+          const res = await fetch(url, {
+            headers: {
+              Accept: "application/vnd.github+json",
+              ...(token ? { Authorization: `Bearer ${token}` } : {}),
+            },
+          });
+          if (!res.ok) {
+            const err = await res.json().catch(() => ({}));
+            setErrorMsg(err?.message || `GitHub API error (status ${res.status})`);
             break;
           }
+          const data = await res.json();
+          const items = Array.isArray(data.items) ? data.items : [];
+          if (items.length === 0) break;
 
-          prs.forEach((pr) => {
-            if (!pr.merged_at) return;
-            const labels = pr.labels.map((l) => l.name.toLowerCase());
-            if (!labels.includes("gssoc'25")) return;
+          items.forEach((item) => {
+            const author = item?.user?.login;
+            if (!author) return;
 
-            const author = pr.user.login;
+            // compute points from any level-* labels present on the PR
+            const levelLabels = (item.labels || [])
+              .map((l) => canonicalLevel(l.name))
+              .filter(Boolean);
+
             let points = 0;
-            labels.forEach((label) => {
-              if (POINTS[label]) points += POINTS[label];
-            });
+            levelLabels.forEach((lvl) => { if (POINTS[lvl]) points += POINTS[lvl]; });
 
             if (!contributorsMap[author]) {
               contributorsMap[author] = {
                 username: author,
-                avatar: pr.user.avatar_url,
-                profile: pr.user.html_url,
+                avatar: `https://github.com/${author}.png`,
+                profile: `https://github.com/${author}`,
                 points: 0,
                 prs: 0,
               };
             }
-
-            contributorsMap[author].points += points;
-            contributorsMap[author].prs += 1;
+            contributorsMap[author].prs += 1;      // always count merged PR
+            contributorsMap[author].points += points; // points may be 0 if no level labels
           });
 
-          page += 1;
+          if (items.length < PER_PAGE) break;
         }
-        const contributorsArray = Object.values(contributorsMap);
-        const sorted = contributorsArray.sort((a, b) => b.points - a.points);
-        const rankedContributers = sorted.map((c, index) => ({
-          ...c,
-          rank: index + 1,
-        }));
-        setContributors(rankedContributers);
-      } catch (error) {
-        console.error("Error fetching contributors:", error);
+
+        const arr = Object.values(contributorsMap);
+        // sort by points, then by PR count, then by username
+        const sorted = arr.sort(
+          (a, b) =>
+            b.points - a.points ||
+            b.prs - a.prs ||
+            a.username.localeCompare(b.username)
+        );
+        const ranked = sorted.map((c, i) => ({ ...c, rank: i + 1 }));
+        setContributors(ranked);
+
+        // stats
+        const totalPRs = ranked.reduce((s, c) => s + c.prs, 0);
+        const totalPoints = ranked.reduce((s, c) => s + c.points, 0);
+        setStats({
+          flooredTotalPRs: Math.floor(totalPRs / 10) * 10,
+          totalContributors: Math.floor(ranked.length / 10) * 10,
+          flooredTotalPoints: Math.floor(totalPoints / 10) * 10,
+        });
+
+        if (!errorMsg && ranked.length === 0) {
+          setErrorMsg("No merged PRs found in this repository.");
+        }
+      } catch (e) {
+        setErrorMsg(e?.message || "Unexpected error while fetching data.");
       } finally {
         setLoading(false);
       }
     };
 
-    fetchContributorsWithPoints();
-  }, []);
+    fetchMergedPRsAndScore();
+  }, []); // run once
 
-  useEffect(() => {
-    if (contributors.length > 0) {
-      const totalPRs = contributors.reduce((sum, c) => sum + Number(c.prs), 0);
-      const totalPoints = contributors.reduce(
-        (sum, c) => sum + Number(c.points),
-        0
-      );
-
-      const flooredTotalPRs = Math.floor(totalPRs / 10) * 10;
-      const flooredTotalPoints = Math.floor(totalPoints / 10) * 10;
-      const flooredContributorsCount =
-        Math.floor(contributors.length / 10) * 10;
-
-      setStats({
-        flooredTotalPRs,
-        totalContributors: flooredContributorsCount,
-        flooredTotalPoints,
-      });
-    }
-  }, [contributors]);
-
-  // Filter contributors by search term (username)
-  const filteredContributors = contributors.filter((c) =>
+  // search filter
+  const filtered = contributors.filter((c) =>
     c.username.toLowerCase().includes(searchTerm.toLowerCase())
   );
 
-  // Pagination variables and states
+  // pagination
   const PAGE_SIZE = 10;
   const [currentPage, setCurrentPage] = useState(1);
-
-  // Calculate which contributors to show on current page
   const indexOfLast = currentPage * PAGE_SIZE;
   const indexOfFirst = indexOfLast - PAGE_SIZE;
-  const currentContributors = filteredContributors.slice(
-    indexOfFirst,
-    indexOfLast
-  );
+  const pageRows = filtered.slice(indexOfFirst, indexOfLast);
+  const totalPages = Math.ceil(filtered.length / PAGE_SIZE);
 
-  const totalPages = Math.ceil(filteredContributors.length / PAGE_SIZE);
-
-  // Gradient backgrounds from Footer.jsx theme
-  const gradientBg = isDark
-    ? "bg-gradient-to-br from-dark-bg-primary to-dark-bg-secondary"
-    : "bg-gradient-to-br from-blue-50 to-indigo-50 backdrop-blur-xl";
-
-  const cardBg = isDark
-    ? "bg-dark-bg-tertiary border-dark-border"
-    : "bg-light-bg-tertiary border-light-border";
-
-  // Button styles
   const buttonStyle = {
     padding: "8px 16px",
     borderRadius: "8px",
@@ -290,224 +189,78 @@ export default function LeaderBoard() {
     opacity: 1,
     transition: "opacity 0.2s",
   };
-  const buttonActiveStyle = {
-    ...buttonStyle,
-    background: isDark ? "#3b82f6" : "#2563eb",
-    color: "#fff",
-  };
-  const buttonDisabledStyle = {
-    ...buttonStyle,
-    opacity: 0.5,
-    cursor: "not-allowed",
-  };
+  const buttonActiveStyle = { ...buttonStyle, background: isDark ? "#3b82f6" : "#2563eb", color: "#fff" };
+  const buttonDisabledStyle = { ...buttonStyle, opacity: 0.5, cursor: "not-allowed" };
 
   return (
-    <div
-      style={{
-        background: isDark ? "#23272f" : "#f6f6f6",
-        minHeight: "100vh",
-        padding: "32px 8px",
-      }}
-    >
+    <div style={{ background: isDark ? "#23272f" : "#f6f6f6", minHeight: "100vh", padding: "32px 8px" }}>
       <div style={{ maxWidth: 1100, margin: "0 auto" }}>
-        {/* Header */}
-        <motion.div
-          style={{ textAlign: "center", marginBottom: 48, padding: "0 8px" }}
-          initial={{ opacity: 0, y: -20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5 }}
-        >
-          <h1
-            style={{
-              fontSize: 32,
-              fontWeight: 700,
-              marginBottom: 12,
-              color: "#6366f1",
-            }}
-          >
+        {/* header */}
+        <motion.div style={{ textAlign: "center", marginBottom: 48, padding: "0 8px" }}
+          initial={{ opacity: 0, y: -20 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.5 }}>
+          <h1 style={{ fontSize: 32, fontWeight: 700, marginBottom: 12, color: "#6366f1" }}>
             GSSoC'25 Leaderboard
           </h1>
-          <p
-            style={{
-              fontSize: 17,
-              maxWidth: 600,
-              margin: "0 auto",
-              color: isDark ? "#b3b3b3" : "#555",
-              lineHeight: 1.6,
-            }}
-          >
-            Celebrating the amazing contributions from GSSoC'25 participants.
-            Join us in building something incredible together!
+          <p style={{ fontSize: 17, maxWidth: 600, margin: "0 auto", color: isDark ? "#b3b3b3" : "#555", lineHeight: 1.6 }}>
+            Merged PRs count for each contributor. Points are awarded only when PRs carry level labels.
           </p>
         </motion.div>
 
-        {/* Search Bar */}
-        <div
-          style={{
-            display: "flex",
-            justifyContent: "center",
-            marginBottom: 24,
-          }}
-        >
+        {/* search */}
+        <div style={{ display: "flex", justifyContent: "center", marginBottom: 24 }}>
           <div style={{ position: "relative", width: "100%", maxWidth: 320 }}>
             <input
               type="text"
               placeholder="Search contributor..."
               value={searchTerm}
-              onChange={(e) => {
-                setSearchTerm(e.target.value);
-                setCurrentPage(1);
-              }}
+              onChange={(e) => { setSearchTerm(e.target.value); setCurrentPage(1); }}
               style={{
-                width: "100%",
-                padding: "8px 16px 8px 36px",
-                borderRadius: 8,
+                width: "100%", padding: "8px 16px 8px 36px", borderRadius: 8,
                 border: `1px solid ${isDark ? "#444" : "#ddd"}`,
                 background: isDark ? "#23272f" : "#fff",
-                color: isDark ? "#fff" : "#222",
-                fontSize: 15,
-                outline: "none",
+                color: isDark ? "#fff" : "#222", fontSize: 15, outline: "none",
               }}
             />
-            <FaSearch
-              style={{
-                position: "absolute",
-                left: 12,
-                top: "50%",
-                transform: "translateY(-50%)",
-                color: isDark ? "#b3b3b3" : "#aaa",
-              }}
-            />
+            <FaSearch style={{ position: "absolute", left: 12, top: "50%", transform: "translateY(-50%)", color: isDark ? "#b3b3b3" : "#aaa" }} />
           </div>
         </div>
 
-        {/* Stats Cards */}
-        <div
-          style={{
-            display: "flex",
-            gap: 18,
-            marginBottom: 48,
-            flexWrap: "wrap",
-          }}
-        >
-          <div
-            style={{
-              flex: 1,
-              minWidth: 220,
-              padding: 24,
-              borderRadius: 16,
-              boxShadow: "0 2px 8px rgba(0,0,0,0.04)",
-              border: `1px solid ${isDark ? "#444" : "#eee"}`,
-              background: isDark
-                ? "linear-gradient(135deg,#23272f,#1a1d23)"
-                : "linear-gradient(135deg,#e0e7ff,#f3f4f6)",
-            }}
-          >
+        {/* stats */}
+        <div style={{ display: "flex", gap: 18, marginBottom: 16, flexWrap: "wrap" }}>
+          <div style={{ flex: 1, minWidth: 220, padding: 24, borderRadius: 16, boxShadow: "0 2px 8px rgba(0,0,0,0.04)", border: `1px solid ${isDark ? "#444" : "#eee"}`, background: isDark ? "linear-gradient(135deg,#23272f,#1a1d23)" : "linear-gradient(135deg,#e0e7ff,#f3f4f6)" }}>
             <div style={{ display: "flex", alignItems: "center" }}>
-              <div
-                style={{
-                  padding: 12,
-                  borderRadius: 12,
-                  background: isDark ? "rgba(59,130,246,0.2)" : "#dbeafe",
-                  color: isDark ? "#60a5fa" : "#2563eb",
-                  marginRight: 16,
-                }}
-              >
+              <div style={{ padding: 12, borderRadius: 12, background: isDark ? "rgba(59,130,246,0.2)" : "#dbeafe", color: isDark ? "#60a5fa" : "#2563eb", marginRight: 16 }}>
                 <FaUsers style={{ fontSize: 22 }} />
               </div>
               <div>
-                <p style={{ fontSize: 14, color: isDark ? "#b3b3b3" : "#555" }}>
-                  Contributors
-                </p>
-                <p
-                  style={{
-                    fontSize: 22,
-                    fontWeight: 700,
-                    color: isDark ? "#fff" : "#222",
-                  }}
-                >
+                <p style={{ fontSize: 14, color: isDark ? "#b3b3b3" : "#555" }}>Contributors</p>
+                <p style={{ fontSize: 22, fontWeight: 700, color: isDark ? "#fff" : "#222" }}>
                   {loading ? "..." : stats.totalContributors}+
                 </p>
               </div>
             </div>
           </div>
-          <div
-            style={{
-              flex: 1,
-              minWidth: 220,
-              padding: 24,
-              borderRadius: 16,
-              boxShadow: "0 2px 8px rgba(0,0,0,0.04)",
-              border: `1px solid ${isDark ? "#444" : "#eee"}`,
-              background: isDark
-                ? "linear-gradient(135deg,#23272f,#1a1d23)"
-                : "linear-gradient(135deg,#e0e7ff,#f3f4f6)",
-            }}
-          >
+          <div style={{ flex: 1, minWidth: 220, padding: 24, borderRadius: 16, boxShadow: "0 2px 8px rgba(0,0,0,0.04)", border: `1px solid ${isDark ? "#444" : "#eee"}`, background: isDark ? "linear-gradient(135deg,#23272f,#1a1d23)" : "linear-gradient(135deg,#e0e7ff,#f3f4f6)" }}>
             <div style={{ display: "flex", alignItems: "center" }}>
-              <div
-                style={{
-                  padding: 12,
-                  borderRadius: 12,
-                  background: isDark ? "rgba(16,185,129,0.2)" : "#bbf7d0",
-                  color: isDark ? "#34d399" : "#059669",
-                  marginRight: 16,
-                }}
-              >
+              <div style={{ padding: 12, borderRadius: 12, background: isDark ? "rgba(16,185,129,0.2)" : "#bbf7d0", color: isDark ? "#34d399" : "#059669", marginRight: 16 }}>
                 <FaCode style={{ fontSize: 22 }} />
               </div>
               <div>
-                <p style={{ fontSize: 14, color: isDark ? "#b3b3b3" : "#555" }}>
-                  Pull Requests
-                </p>
-                <p
-                  style={{
-                    fontSize: 22,
-                    fontWeight: 700,
-                    color: isDark ? "#fff" : "#222",
-                  }}
-                >
+                <p style={{ fontSize: 14, color: isDark ? "#b3b3b3" : "#555" }}>Pull Requests</p>
+                <p style={{ fontSize: 22, fontWeight: 700, color: isDark ? "#fff" : "#222" }}>
                   {loading ? "..." : stats.flooredTotalPRs}+
                 </p>
               </div>
             </div>
           </div>
-          <div
-            style={{
-              flex: 1,
-              minWidth: 220,
-              padding: 24,
-              borderRadius: 16,
-              boxShadow: "0 2px 8px rgba(0,0,0,0.04)",
-              border: `1px solid ${isDark ? "#444" : "#eee"}`,
-              background: isDark
-                ? "linear-gradient(135deg,#23272f,#1a1d23)"
-                : "linear-gradient(135deg,#e0e7ff,#f3f4f6)",
-            }}
-          >
+          <div style={{ flex: 1, minWidth: 220, padding: 24, borderRadius: 16, boxShadow: "0 2px 8px rgba(0,0,0,0.04)", border: `1px solid ${isDark ? "#444" : "#eee"}`, background: isDark ? "linear-gradient(135deg,#23272f,#1a1d23)" : "linear-gradient(135deg,#e0e7ff,#f3f4f6)" }}>
             <div style={{ display: "flex", alignItems: "center" }}>
-              <div
-                style={{
-                  padding: 12,
-                  borderRadius: 12,
-                  background: isDark ? "rgba(139,92,246,0.2)" : "#ede9fe",
-                  color: isDark ? "#a78bfa" : "#7c3aed",
-                  marginRight: 16,
-                }}
-              >
+              <div style={{ padding: 12, borderRadius: 12, background: isDark ? "rgba(139,92,246,0.2)" : "#ede9fe", color: isDark ? "#a78bfa" : "#7c3aed", marginRight: 16 }}>
                 <FaStar style={{ fontSize: 22 }} />
               </div>
               <div>
-                <p style={{ fontSize: 14, color: isDark ? "#b3b3b3" : "#555" }}>
-                  Total Points
-                </p>
-                <p
-                  style={{
-                    fontSize: 22,
-                    fontWeight: 700,
-                    color: isDark ? "#fff" : "#222",
-                  }}
-                >
+                <p style={{ fontSize: 14, color: isDark ? "#b3b3b3" : "#555" }}>Total Points</p>
+                <p style={{ fontSize: 22, fontWeight: 700, color: isDark ? "#fff" : "#222" }}>
                   {loading ? "..." : stats.flooredTotalPoints}+
                 </p>
               </div>
@@ -515,190 +268,92 @@ export default function LeaderBoard() {
           </div>
         </div>
 
+        {/* error */}
+        {!!errorMsg && (
+          <div style={{
+            marginBottom: 24, padding: "12px 16px",
+            borderRadius: 8, border: `1px solid ${isDark ? "#9f1239" : "#fecaca"}`,
+            background: isDark ? "#3f1d1d" : "#fee2e2", color: isDark ? "#fecaca" : "#7f1d1d",
+          }}>
+            {errorMsg}
+          </div>
+        )}
+
         {loading ? (
           <SkeletonLoader isDark={isDark} />
         ) : (
-          <div
-            style={{
-              borderRadius: 16,
-              boxShadow: "0 2px 8px rgba(0,0,0,0.04)",
-              border: `1px solid ${isDark ? "#444" : "#eee"}`,
-              overflow: "hidden",
-              margin: "0 8px",
-            }}
-          >
-            {/* Contributors List */}
+          <div style={{ borderRadius: 16, boxShadow: "0 2px 8px rgba(0,0,0,0.04)", border: `1px solid ${isDark ? "#444" : "#eee"}`, overflow: "hidden", margin: "0 8px" }}>
             <div className="head-titles">
-              <div>
-                <h3>Rank</h3>
-              </div>
-              <div>
-                <h3>Profile</h3>
-              </div>
-              <div className="head-state">
-                <h3>PR's</h3>
-                <h3>Points</h3>
-              </div>
+              <div><h3>Rank</h3></div>
+              <div><h3>Profile</h3></div>
+              <div className="head-state"><h3>PR's</h3><h3>Points</h3></div>
             </div>
+
             <div>
-              {currentContributors.length === 0 ? (
-                <div
-                  style={{
-                    textAlign: "center",
-                    color: isDark ? "#b3b3b3" : "#555",
-                  }}
-                >
+              {pageRows.length === 0 ? (
+                <div style={{ textAlign: "center", color: isDark ? "#b3b3b3" : "#555", padding: 16 }}>
                   No contributors found.
                 </div>
               ) : (
-                currentContributors.map((contributor, index) => (
+                pageRows.map((c, idx) => (
                   <motion.div
                     className="leaderboard"
-                    key={contributor.username}
+                    key={c.username}
                     initial={{ opacity: 0, y: 10 }}
                     animate={{ opacity: 1, y: 0 }}
-                    transition={{ duration: 0.3, delay: index * 0.03 }}
+                    transition={{ duration: 0.3, delay: idx * 0.03 }}
                     style={{
                       padding: "20px 24px",
                       borderBottom: `1px solid ${isDark ? "#444" : "#eee"}`,
-                      background:
-                        index % 2 === 0
-                          ? isDark
-                            ? "#23272f"
-                            : "#fff"
-                          : isDark
-                          ? "#1a1d23"
-                          : "#f6f6f6",
+                      background: idx % 2 === 0 ? (isDark ? "#23272f" : "#fff") : (isDark ? "#1a1d23" : "#f6f6f6"),
                     }}
                   >
-                    {/* Rank Badge */}
-                    <div
-                      style={{
-                        width: 32,
-                        height: 32,
-                        borderRadius: "50%",
-                        display: "flex",
-                        alignItems: "center",
-                        justifyContent: "center",
-                        fontSize: 14,
-                        fontWeight: 500,
-                        marginRight: 16,
-                        background:
-                          contributor.rank === 1
-                            ? isDark
-                              ? "rgba(253,224,71,0.2)"
-                              : "#fef9c3"
-                            : contributor.rank === 2
-                            ? isDark
-                              ? "rgba(156,163,175,0.2)"
-                              : "#f3f4f6"
-                            : contributor.rank === 3
-                            ? isDark
-                              ? "rgba(251,191,36,0.2)"
-                              : "#fef3c7"
-                            : isDark
-                            ? "#23272f"
-                            : "#e5e7eb",
-                        color:
-                          contributor.rank === 1
-                            ? isDark
-                              ? "#fde047"
-                              : "#ca8a04"
-                            : contributor.rank === 2
-                            ? isDark
-                              ? "#d1d5db"
-                              : "#6b7280"
-                            : contributor.rank === 3
-                            ? isDark
-                              ? "#fbbf24"
-                              : "#f59e42"
-                            : isDark
-                            ? "#b3b3b3"
-                            : "#555",
-                      }}
-                    >
-                      {indexOfFirst + contributor.rank}
+                    {/* rank */}
+                    <div style={{
+                      width: 32, height: 32, borderRadius: "50%",
+                      display: "flex", alignItems: "center", justifyContent: "center",
+                      fontSize: 14, fontWeight: 500, marginRight: 16,
+                      background:
+                        c.rank === 1 ? (isDark ? "rgba(253,224,71,0.2)" : "#fef9c3") :
+                        c.rank === 2 ? (isDark ? "rgba(156,163,175,0.2)" : "#f3f4f6") :
+                        c.rank === 3 ? (isDark ? "rgba(251,191,36,0.2)" : "#fef3c7") :
+                        (isDark ? "#23272f" : "#e5e7eb"),
+                      color:
+                        c.rank === 1 ? (isDark ? "#fde047" : "#ca8a04") :
+                        c.rank === 2 ? (isDark ? "#d1d5db" : "#6b7280") :
+                        c.rank === 3 ? (isDark ? "#fbbf24" : "#f59e42") :
+                        (isDark ? "#b3b3b3" : "#555"),
+                    }}>
+                      {c.rank}
                     </div>
-                    {/* Avatar */}
+
+                    {/* profile */}
                     <div className="profile">
-                      <img
-                        src={contributor.avatar}
-                        alt={contributor.username}
-                        style={{
-                          width: 40,
-                          height: 40,
-                          borderRadius: "50%",
-                          border: `2px solid ${isDark ? "#444" : "#fff"}`,
-                          boxShadow: "0 1px 4px rgba(0,0,0,0.04)",
-                          marginRight: 16,
-                        }}
-                      />
+                      <img src={c.avatar} alt={c.username}
+                        style={{ width: 40, height: 40, borderRadius: "50%", border: `2px solid ${isDark ? "#444" : "#fff"}`, boxShadow: "0 1px 4px rgba(0,0,0,0.04)", marginRight: 16 }} />
                       <div className="info">
-                        <a
-                          href={contributor.profile}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          style={{
-                            fontWeight: 500,
-                            color: isDark ? "#fff" : "#222",
-                            fontSize: 15,
-                            textDecoration: "none",
-                            marginBottom: 4,
-                            display: "block",
-                          }}
-                        >
-                          {contributor.username}
+                        <a href={c.profile} target="_blank" rel="noopener noreferrer"
+                           style={{ fontWeight: 500, color: isDark ? "#fff" : "#222", fontSize: 15, textDecoration: "none", marginBottom: 4, display: "block" }}>
+                          {c.username}
                         </a>
                         <a
-                          href={`https://github.com/${GITHUB_REPO}/pulls?q=is:pr+author:${contributor.username}+is:merged`}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          style={{
-                            fontSize: 13,
-                            color: isDark ? "#b3b3b3" : "#555",
-                            textDecoration: "none",
-                            marginBottom: 4,
-                            display: "block",
-                            whiteSpace: "nowrap",
-                          }}
+                          href={`https://github.com/${GITHUB_REPO}/pulls?q=is:pr+author:${c.username}+is:merged`}
+                          target="_blank" rel="noopener noreferrer"
+                          style={{ fontSize: 13, color: isDark ? "#b3b3b3" : "#555", textDecoration: "none", marginBottom: 4, display: "block", whiteSpace: "nowrap" }}
                           className="view-contributors"
                         >
                           View Contributions →
                         </a>
                       </div>
                     </div>
-                    {/* User states */}
+
+                    {/* stats */}
                     <div className="states">
-                      <div
-                        className="state-content"
-                        style={{
-                          display: "flex",
-                          gap: "1.4rem",
-                          justifyContent: "center",
-                          alignItems: "center",
-                          whiteSpace: "nowrap",
-                        }}
-                      >
-                        <Badge
-                          count={contributor.prs}
-                          label={`PR${contributor.prs !== 1 ? "s" : ""}`}
-                          color={{
-                            background: isDark
-                              ? "rgba(59,130,246,0.2)"
-                              : "#dbeafe",
-                            color: isDark ? "#60a5fa" : "#2563eb",
-                          }}
-                        />
-                        <Badge
-                          count={contributor.points}
-                          label="Points"
-                          color={{
-                            background: isDark
-                              ? "rgba(139,92,246,0.2)"
-                              : "#ede9fe",
-                            color: isDark ? "#a78bfa" : "#7c3aed",
-                          }}
-                        />
+                      <div className="state-content" style={{ display: "flex", gap: "1.4rem", justifyContent: "center", alignItems: "center", whiteSpace: "nowrap" }}>
+                        <Badge count={c.prs} label={`PR${c.prs !== 1 ? "s" : ""}`}
+                               color={{ background: isDark ? "rgba(59,130,246,0.2)" : "#dbeafe", color: isDark ? "#60a5fa" : "#2563eb" }} />
+                        <Badge count={c.points} label="Points"
+                               color={{ background: isDark ? "rgba(139,92,246,0.2)" : "#ede9fe", color: isDark ? "#a78bfa" : "#7c3aed" }} />
                       </div>
                     </div>
                   </motion.div>
@@ -706,88 +361,30 @@ export default function LeaderBoard() {
               )}
             </div>
 
-            {/* Pagination Controls */}
-            <div
-              style={{
-                display: "flex",
-                justifyContent: "center",
-                alignItems: "center",
-                gap: 8,
-                padding: "16px 0",
-                borderTop: `1px solid ${isDark ? "#444" : "#eee"}`,
-              }}
-            >
-              <button
-                disabled={currentPage === 1}
-                onClick={() => setCurrentPage((p) => p - 1)}
-                style={currentPage === 1 ? buttonDisabledStyle : buttonStyle}
-              >
+            {/* pagination */}
+            <div style={{ display: "flex", justifyContent: "center", alignItems: "center", gap: 8, padding: "16px 0", borderTop: `1px solid ${isDark ? "#444" : "#eee"}` }}>
+              <button disabled={currentPage === 1} onClick={() => setCurrentPage((p) => p - 1)} style={currentPage === 1 ? buttonDisabledStyle : buttonStyle}>
                 <ChevronLeft size={16} />
               </button>
               <div style={{ display: "flex", gap: 8 }}>
-                {Array.from(
-                  {
-                    length: Math.ceil(filteredContributors.length / PAGE_SIZE),
-                  },
-                  (_, i) => (
-                    <button
-                      key={i + 1}
-                      onClick={() => setCurrentPage(i + 1)}
-                      style={
-                        currentPage === i + 1 ? buttonActiveStyle : buttonStyle
-                      }
-                    >
-                      {i + 1}
-                    </button>
-                  )
-                )}
+                {Array.from({ length: Math.ceil(filtered.length / PAGE_SIZE) }, (_, i) => (
+                  <button key={i + 1} onClick={() => setCurrentPage(i + 1)} style={currentPage === i + 1 ? buttonActiveStyle : buttonStyle}>
+                    {i + 1}
+                  </button>
+                ))}
               </div>
-              <button
-                disabled={currentPage === totalPages}
-                onClick={() => setCurrentPage((p) => p + 1)}
-                style={
-                  currentPage === totalPages ? buttonDisabledStyle : buttonStyle
-                }
-              >
+              <button disabled={currentPage === totalPages || totalPages === 0} onClick={() => setCurrentPage((p) => p + 1)} style={currentPage === totalPages || totalPages === 0 ? buttonDisabledStyle : buttonStyle}>
                 <ChevronRight size={16} />
               </button>
             </div>
 
-            {/* CTA Footer */}
-            <div
-              style={{
-                padding: "16px 24px",
-                textAlign: "center",
-                borderTop: `1px solid ${isDark ? "#444" : "#eee"}`,
-                background: isDark ? "#23272f" : "#f6f6f6",
-              }}
-            >
-              <p
-                style={{
-                  fontSize: 14,
-                  color: isDark ? "#b3b3b3" : "#555",
-                  marginBottom: 12,
-                }}
-              >
-                Want to see your name here? Join GSSoC'25 and start
-                contributing!
+            {/* CTA */}
+            <div style={{ padding: "16px 24px", textAlign: "center", borderTop: `1px solid ${isDark ? "#444" : "#eee"}`, background: isDark ? "#23272f" : "#f6f6f6" }}>
+              <p style={{ fontSize: 14, color: isDark ? "#b3b3b3" : "#555", marginBottom: 12 }}>
+                Want to see your name here? Add level labels to your PRs for points!
               </p>
-              <a
-                href="https://gssoc.girlscript.tech/"
-                target="_blank"
-                rel="noopener noreferrer"
-                style={{
-                  display: "inline-flex",
-                  alignItems: "center",
-                  padding: "8px 16px",
-                  background: isDark ? "#3b82f6" : "#6366f1",
-                  color: "#fff",
-                  fontSize: 15,
-                  fontWeight: 500,
-                  borderRadius: 8,
-                  textDecoration: "none",
-                }}
-              >
+              <a href="https://gssoc.girlscript.tech/" target="_blank" rel="noopener noreferrer"
+                 style={{ display: "inline-flex", alignItems: "center", padding: "8px 16px", background: isDark ? "#3b82f6" : "#6366f1", color: "#fff", fontSize: 15, fontWeight: 500, borderRadius: 8, textDecoration: "none" }}>
                 <FaGithub style={{ marginRight: 8 }} /> Join GSSoC'25
               </a>
             </div>


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #553

## Rationale for this change

The GSSoC’25 Leaderboard page was always showing “No contributors found.”  
This happened because the code used the `/pulls` API, which doesn’t return `merged_at` for list queries, so all PRs were filtered out.


## What changes are included in this PR?

- Switched to the GitHub Search API (`is:pr is:merged`) to reliably fetch merged PRs.  
- Normalized label strings (handles curly vs straight quotes in `GSSoC’25`).  
- Calculated points from `level-1/2/3` labels.  
- Displayed contributors and PR counts even if no level labels exist (points = 0).  
- Added error handling and better fallback messages.

## Are these changes tested?

- Yes, tested locally with and without a GitHub token (`VITE_GITHUB_TOKEN`).  
- Verified that contributors now appear with their PR counts.  
- Verified points calculation when level labels are applied.  
- Tested rate-limit fallback (works without a token but limited to 60 requests/hour).

## Are there any user-facing changes?

- **Yes**: The leaderboard now correctly shows contributors, PR counts, and points.  
- If a contributor has merged PRs but no level labels, they still appear with 0 points.  
- This fixes the empty leaderboard issue for GSSoC’25.


### before : 
<img width="1918" height="938" alt="image" src="https://github.com/user-attachments/assets/d9a4757d-c8fd-4625-872d-7fd9668c8eb5" />

### after : 
<img width="1917" height="966" alt="image" src="https://github.com/user-attachments/assets/c97ab1bc-da59-4681-9369-d6574050270b" />

