### PR TITLE
fix: correct exponential search visualization

### DIFF
--- a/src/algorithms/exponentialSearch.js
+++ b/src/algorithms/exponentialSearch.js
@@ -1,27 +1,68 @@
-import { binarySearch } from './binarySearch';
+// exponentialSearch.js
+import { binarySearch } from "./binarySearch"; // (kept in case you still need it elsewhere)
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 export const exponentialSearch = async (array, target, setColorArray, delay) => {
-    if (array[0] === target) {
-        setColorArray([ 'green', ...Array(array.length - 1).fill('lightgrey') ]);
-        return 0;
-    }
+  const n = array.length;
+  if (n === 0) return -1;
 
-    let i = 1;
-    while (i < array.length && array[i] <= target) {
-        await new Promise(resolve => setTimeout(resolve, delay));
-        // eslint-disable-next-line no-loop-func
-        setColorArray(prevColors => {
-            const newColors = [...prevColors];
-            newColors[i] = 'yellow';
-            return newColors;
-        });
-        i *= 2;
-    }
+  // Quick check index 0
+  setColorArray(Array.from({ length: n }, (_, idx) => (idx === 0 ? "yellow" : "lightgrey")));
+  await sleep(delay);
+  if (array[0] === target) {
+    setColorArray(Array.from({ length: n }, (_, idx) => (idx === 0 ? "green" : "lightgrey")));
+    return 0;
+  }
 
-    return await binarySearch(
-        array.slice(i / 2, Math.min(i, array.length)),
-        target,
-        setColorArray,
-        delay
+  // Exponential probe: 1,2,4,8,...
+  let i = 1;
+  while (i < n && array[i] <= target) {
+    // highlight the probe index i
+    setColorArray(Array.from({ length: n }, (_, idx) => (idx === i ? "yellow" : "lightgrey")));
+    await sleep(delay);
+    i *= 2;
+  }
+
+  // Compute window [left, right] to binary-search
+  const left = Math.floor(i / 2);
+  const right = Math.min(i, n - 1);
+
+  // Shade the window
+  setColorArray(
+    Array.from({ length: n }, (_, idx) =>
+      idx >= left && idx <= right ? "#66ccff" : "#2b3a4b"
+    )
+  );
+  await sleep(delay);
+
+  // Binary search INSIDE [left, right] on the ORIGINAL array
+  let l = left,
+    r = right;
+  while (l <= r) {
+    const mid = l + Math.floor((r - l) / 2);
+
+    // highlight current mid inside the window
+    setColorArray(
+      Array.from({ length: n }, (_, idx) => {
+        if (idx < left || idx > right) return "#2b3a4b";
+        if (idx === mid) return "red";
+        return "#66ccff";
+      })
     );
+    await sleep(delay);
+
+    if (array[mid] === target) {
+      setColorArray(Array.from({ length: n }, (_, idx) => (idx === mid ? "green" : "lightgrey")));
+      await sleep(delay);
+      return mid; // ✅ return absolute index
+    }
+    if (array[mid] < target) l = mid + 1;
+    else r = mid - 1;
+  }
+
+  // Not found
+  setColorArray(Array.from({ length: n }, () => "lightgrey"));
+  await sleep(delay);
+  return -1;
 };


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #572 

## Rationale for this change

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/cc0853a7-4105-455e-a19b-16e470fba655" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/5b0dc271-8a40-4fdf-9455-bb214c94d350" />



Exponential Search visualization was highlighting the wrong bars and reporting incorrect indices because the implementation sliced the array before binary search. This caused indices to be relative to the slice instead of the original array. The fix ensures binary search runs on the original array with correct bounds, so both the returned index and visualization align properly.

## What changes are included in this PR?

- Rewrote `exponentialSearch.js` to:
  - Remove the `array.slice(...)` call.
  - Perform binary search on the original array within the `[left, right]` window.
  - Correctly highlight exponential probes, the search window, mid checks, and the final found index.
  - Ensure the returned index is absolute, not slice-relative.

## Are these changes tested?

- Verified manually with arrays of various sizes and targets:
  - Correct index is returned (matches native `indexOf`).
  - Visualization correctly highlights probes, window, mids, and found index.
- Edge cases (empty array, first element, last element, not found) are handled correctly.

## Are there any user-facing changes?

- Yes:
  - Users will now see the correct index in the result message.
  - Visualization highlights now match the expected exponential + binary search process.
