### PR TITLE
fix(ui): remove white tooltip background in dark mode for complexity …

### DIFF
--- a/src/components/ComplexityBox.jsx
+++ b/src/components/ComplexityBox.jsx
@@ -160,22 +160,20 @@ const CustomTooltip = ({ active, payload }) => {
   if (active && payload && payload.length) {
     const { name, complexity } = payload[0].payload;
     // Use data-theme attribute for theme detection
-    const isDarkMode =
-      document.documentElement.getAttribute("data-theme") === "dark";
     return (
       <div
         style={{
-          backgroundColor: isDarkMode ? "#1f2937" : "#ffffff",
-          padding: "10px 14px",
-          borderRadius: "8px",
-          border: `1px solid ${isDarkMode ? "#374151" : "#e5e7eb"}`,
-          color: isDarkMode ? "#e4e6ef" : "#1f2937",
-          fontSize: "0.9rem",
-          fontWeight: "500",
-          boxShadow: "0 4px 6px rgba(0, 0, 0, 0.1)",
+       background: "var(--theme-card-bg)",
+       color: "var(--theme-text-primary)",
+       border: "1px solid var(--theme-border)",
+       boxShadow: "var(--theme-card-shadow)",
+       padding: "10px 14px",
+       borderRadius: "8px",
+       fontSize: "0.9rem",
+       fontWeight: "500",
         }}
       >
-        <p style={{ margin: 0, fontWeight: "600", color: "#38bdf8" }}>
+         <p style={{ margin: 0, fontWeight: 600, color: "var(--theme-accent)" }}>
           {name} Case
         </p>
         <p style={{ margin: 0 }}>
@@ -236,7 +234,19 @@ const ComplexityBox = () => {
           <BarChart data={chartData} barSize={60}>
             <XAxis dataKey="name" stroke={isDarkMode ? "#9ca3af" : "#6b7280"} />
             <YAxis stroke={isDarkMode ? "#9ca3af" : "#6b7280"} />
-            <Tooltip content={<CustomTooltip />} />
+             <Tooltip
+               content={<CustomTooltip />}
+              
+                  cursor={false}
+
+                wrapperStyle={{ background: 'transparent', border: 'none', boxShadow: 'none', padding: 0 }}
+                 contentStyle={{ background: 'transparent', border: 'none', boxShadow: 'none', padding: 0 }}
+                 labelStyle={{ color: 'var(--theme-text-primary)' }}
+                 itemStyle={{ color: 'var(--theme-text-primary)' }}
+                 trigger="hover"              // prevent click-to-toggle behavior
+                 allowEscapeViewBox={{ x: true, y: true }}
+             />
+
             <Bar dataKey="value" radius={[10, 10, 0, 0]}>
               {chartData.map((entry, index) => (
                 <Cell

--- a/src/components/complexityBox.css
+++ b/src/components/complexityBox.css
@@ -69,6 +69,19 @@
 .dropdown-container select option:hover {
   background-color: #f3f4f6;
 }
+/* Kill Recharts' default tooltip (the white box) if it mounts on click */
+.complexity-container .recharts-default-tooltip {
+  display: none !important;
+}
+
+/* Extra belt-and-suspenders: make wrapper transparent and unclickable */
+.complexity-container .recharts-tooltip-wrapper {
+  background: transparent !important;
+  border: none !important;
+  box-shadow: none !important;
+  padding: 0 !important;
+  pointer-events: none !important; /* so it never takes focus on click */
+}
 
 .chart-wrapper {
   margin-top: 10px;
@@ -76,6 +89,13 @@
   padding: 16px;
   background: #f9fafb;
   border: 1px solid #e5e7eb;
+}
+/* Kill default Recharts tooltip white box */
+.complexity-container .recharts-default-tooltip {
+  background: transparent !important;
+  border: none !important;
+  box-shadow: none !important;
+  padding: 0 !important;
 }
 
 /* Chart bar effects */


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #571 

## Rationale for this change

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/8a6ee4cb-1d9e-4df1-86c6-f370bf2eb092" />

In dark mode, the tooltip for the complexity chart was visually inconsistent — when clicking a bar, a default white tooltip container from Recharts would briefly appear, breaking immersion and clashing with the dark theme.  

This fix ensures the tooltip styling fully respects the current theme (light or dark), removing the distracting white background and making the visualization more seamless and professional.

## What changes are included in this PR?

- Disabled the default tooltip cursor background applied by Recharts when clicking bars.  
- Implemented theme-aware background, border, and text colors for the tooltip container.  
- Cleaned up tooltip rendering logic to ensure consistency between hover and click states.  
- Verified that both light and dark mode transitions render smoothly without style leaks.  

## Are these changes tested?

Yes:
- Manually tested in both light and dark modes.  
- Verified that tooltips on hover and click render correctly without white backgrounds.  
- Checked across multiple algorithms to confirm consistent behavior.

## Are there any user-facing changes?

Yes:
- Users will now see a fully theme-aware tooltip in the complexity chart (no more sudden white box in dark mode).  
- Improves overall polish and consistency of the dark theme experience.
