### PR TITLE
fix): remove duplicate Cycle Sort entry

### DIFF
--- a/src/pages/DataStructures.jsx
+++ b/src/pages/DataStructures.jsx
@@ -214,21 +214,6 @@ const algorithmDatabase = {
       },
 
       {
-        name: "Cycle Sort",
-        id: "cycleSort",
-         description:
-          "In-place algorithm that minimizes writes by rotating elements directly to their correct positions. It’s efficient when write operations (e.g., on EEPROM/flash memory) are costly.",
-        timeComplexity: {
-          best: "O(n²)", average: "O(n²)", worst: "O(n²)"
-        },
-        spaceComplexity: "O(1) (only a few variables)",
-          stability: "Unstable",
-        inPlace: true,
-        adaptivity: "Not Adaptive",
-        implemented: true,
-
-      },
-      {
         name: "Ternary Search",
         id: "ternarySearch",
         description:
@@ -351,14 +336,6 @@ function AlgorithmCard({ algorithm }) {
         if (algorithm.id === "exponentialSearch") {
         navigate("/searching/exponentialSearch");
         }
-        
-
-        if (algorithm.id === "cycleSort") {
-        navigate("/searching/cycleSort");
-        }
-
-        
-
       } else if (algorithm.category === "dataStructures") {
         navigate(`/data-structures/${algorithm.id}`);
       }


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #570

## Rationale for this change


<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/7234f2ee-d7a5-44ac-a2b1-b1ed44f70095" />

The "Cycle Sort" algorithm was incorrectly appearing multiple times when users toggled sorting/searching filters.  
This happened because Cycle Sort was mistakenly registered under both the **sorting** and **searching** categories in the algorithm database.  
As a result, the UI duplicated entries whenever filters were refreshed.  

Fixing this improves consistency, avoids confusion, and ensures algorithms are categorized correctly.

## What changes are included in this PR?

- Removed the duplicate `Cycle Sort` entry from the `searching` category in `DataStructures.jsx`.  
- Cleaned up navigation mapping logic so Cycle Sort is routed only through `/sorting/cycleSort`.  
- Verified that filters now render Cycle Sort exactly once, regardless of user interaction.

## Are these changes tested?

Yes:  
- Manually tested by toggling sorting/searching filters multiple times.  
- Confirmed that Cycle Sort no longer duplicates.  
- Checked navigation routes to ensure Cycle Sort opens correctly under the sorting category.

## Are there any user-facing changes?

Yes:  
- Users will now see **only one Cycle Sort** entry in the filter list.  
- Fix eliminates duplicate entries and provides a more polished and reliable UI experience.
