### PR TITLE
Added separate custom graph inputs for graph comparison

### DIFF
--- a/src/components/GraphComparison.jsx
+++ b/src/components/GraphComparison.jsx
@@ -1,4 +1,3 @@
-// src/pages/GraphComparison.jsx
 import React, { useState } from "react";
 import algorithmsData from "../algorithms/algorithms.json";
 import GraphVisualizer from "../components/GraphVisualizer";
@@ -16,6 +15,38 @@ export default function GraphComparison() {
   const [algo1, setAlgo1] = useState(options[0].name);
   const [algo2, setAlgo2] = useState(options[1].name);
 
+  // ✅ Separate custom graphs for each visualizer
+  const [customGraph1, setCustomGraph1] = useState(null);
+  const [customGraph2, setCustomGraph2] = useState(null);
+  const [inputText1, setInputText1] = useState("");
+  const [inputText2, setInputText2] = useState("");
+
+  const handleLoadCustomGraph1 = () => {
+    try {
+      const parsed = JSON.parse(inputText1);
+      if (!parsed.nodes || !parsed.edges) {
+        alert("Invalid graph format for Graph 1. Must contain 'nodes' and 'edges'.");
+        return;
+      }
+      setCustomGraph1(parsed);
+    } catch (err) {
+      alert("Invalid JSON format for Graph 1.");
+    }
+  };
+
+  const handleLoadCustomGraph2 = () => {
+    try {
+      const parsed = JSON.parse(inputText2);
+      if (!parsed.nodes || !parsed.edges) {
+        alert("Invalid graph format for Graph 2. Must contain 'nodes' and 'edges'.");
+        return;
+      }
+      setCustomGraph2(parsed);
+    } catch (err) {
+      alert("Invalid JSON format for Graph 2.");
+    }
+  };
+
   return (
     <div className="theme-container">
       <h1 className="theme-title">Graph Algorithms Comparison</h1>
@@ -27,9 +58,86 @@ export default function GraphComparison() {
           color: "var(--theme-text-secondary)",
         }}
       >
-        Compare two graph algorithms side by side. You can load the default graph
-        or create your own to see how the algorithms behave differently.
+        Compare two graph algorithms side by side. Load default graphs or create your own for each visualizer.
       </p>
+
+      {/* Custom Input Section for Graph 1 */}
+      <div style={{
+        background: 'var(--surface-bg)',
+        padding: '1rem',
+        borderRadius: '8px',
+        marginBottom: '1.5rem'
+      }}>
+        <label style={{ fontWeight: 500 }}>Custom Graph 1:</label>
+        <textarea
+          value={inputText1}
+          onChange={(e) => setInputText1(e.target.value)}
+          placeholder='Enter graph JSON: {"nodes":[...], "edges":[...]}'
+          style={{
+            width: '100%',
+            minHeight: '100px',
+            fontFamily: 'Consolas, Monaco, "Courier New", monospace',
+            fontSize: '0.9rem',
+            padding: '0.5rem',
+            borderRadius: '6px',
+            border: '1px solid var(--border-primary)',
+            marginBottom: '0.5rem',
+            resize: 'vertical'
+          }}
+        />
+        <button
+          onClick={handleLoadCustomGraph1}
+          style={{
+            padding: '0.5rem 1rem',
+            background: 'var(--accent-primary-bg)',
+            color: 'var(--text-on-accent)',
+            border: 'none',
+            borderRadius: '6px',
+            cursor: 'pointer'
+          }}
+        >
+          Load Graph 1
+        </button>
+      </div>
+
+      {/* Custom Input Section for Graph 2 */}
+      <div style={{
+        background: 'var(--surface-bg)',
+        padding: '1rem',
+        borderRadius: '8px',
+        marginBottom: '1.5rem'
+      }}>
+        <label style={{ fontWeight: 500 }}>Custom Graph 2:</label>
+        <textarea
+          value={inputText2}
+          onChange={(e) => setInputText2(e.target.value)}
+          placeholder='Enter graph JSON: {"nodes":[...], "edges":[...]}'
+          style={{
+            width: '100%',
+            minHeight: '100px',
+            fontFamily: 'Consolas, Monaco, "Courier New", monospace',
+            fontSize: '0.9rem',
+            padding: '0.5rem',
+            borderRadius: '6px',
+            border: '1px solid var(--border-primary)',
+            marginBottom: '0.5rem',
+            resize: 'vertical'
+          }}
+        />
+        <button
+          onClick={handleLoadCustomGraph2}
+          style={{
+            padding: '0.5rem 1rem',
+            background: 'var(--accent-primary-bg)',
+            color: 'var(--text-on-accent)',
+            border: 'none',
+            borderRadius: '6px',
+            cursor: 'pointer'
+          }}
+        >
+          Load Graph 2
+        </button>
+      </div>
 
       {/* Controls */}
       <div
@@ -42,9 +150,7 @@ export default function GraphComparison() {
         }}
       >
         <div className="flex flex-col w-64">
-          <label className="mb-2 font-medium text-gray-700">
-            Algorithm 1:
-          </label>
+          <label className="mb-2 font-medium text-gray-700">Algorithm 1:</label>
           <select
             value={algo1}
             onChange={(e) => setAlgo1(e.target.value)}
@@ -59,9 +165,7 @@ export default function GraphComparison() {
         </div>
 
         <div className="flex flex-col w-64">
-          <label className="mb-2 font-medium text-gray-700">
-            Algorithm 2:
-          </label>
+          <label className="mb-2 font-medium text-gray-700">Algorithm 2:</label>
           <select
             value={algo2}
             onChange={(e) => setAlgo2(e.target.value)}
@@ -88,11 +192,23 @@ export default function GraphComparison() {
       >
         <div className="p-4 rounded-2xl shadow-lg" style={{ overflow: "auto" }}>
           <h2 className="text-xl font-semibold mb-4 text-center">{algo1}</h2>
-          <GraphVisualizer defaultAlgorithm={algo1} autoLoadExample={true} canvasWidth={640} canvasHeight={420} />
+          <GraphVisualizer
+            defaultAlgorithm={algo1}
+            autoLoadExample={!customGraph1}
+            customGraph={customGraph1}
+            canvasWidth={640}
+            canvasHeight={420}
+          />
         </div>
         <div className="p-4 rounded-2xl shadow-lg" style={{ overflow: "auto" }}>
           <h2 className="text-xl font-semibold mb-4 text-center">{algo2}</h2>
-          <GraphVisualizer defaultAlgorithm={algo2} autoLoadExample={true} canvasWidth={640} canvasHeight={420} />
+          <GraphVisualizer
+            defaultAlgorithm={algo2}
+            autoLoadExample={!customGraph2}
+            customGraph={customGraph2}
+            canvasWidth={640}
+            canvasHeight={420}
+          />
         </div>
       </div>
     </div>

--- a/src/pages/GraphBFS.jsx
+++ b/src/pages/GraphBFS.jsx
@@ -5,48 +5,95 @@ import "../styles/global-theme.css";
 
 const GraphBFS = () => {
   const [selectedLanguage, setSelectedLanguage] = useState("java");
+  const [customGraph, setCustomGraph] = useState(null);
+  const [inputText, setInputText] = useState("");
+
+  // Handler to parse input
+  const handleInputChange = (e) => {
+    setInputText(e.target.value);
+  };
+
+  const handleLoadCustomGraph = () => {
+    try {
+      const parsed = JSON.parse(inputText);
+      // Simple validation: must have nodes and edges
+      if (!parsed.nodes || !parsed.edges) {
+        alert("Invalid graph format. Must contain 'nodes' and 'edges'.");
+        return;
+      }
+      setCustomGraph(parsed);
+    } catch (err) {
+      alert("Invalid JSON format.");
+    }
+  };
 
   return (
     <div className="theme-container">
       <h1 className="theme-title">Breadth-First Search (BFS)</h1>
       <p style={{ textAlign: 'center', maxWidth: '700px', margin: '-2rem auto 2rem auto', color: 'var(--theme-text-secondary)' }}>
-        Visualize BFS traversal on a graph. Load the default example or create your own graph.
+        Visualize BFS traversal on a graph. You can edit the graph JSON below and click "Load Graph".
       </p>
-      <GraphVisualizer defaultAlgorithm="BFS" autoLoadExample={true} />
 
-      {/* Code Implementation Section */}
+      {/* ✅ Custom Input Section */}
+      <div style={{
+        background: 'var(--surface-bg)',
+        padding: '1rem',
+        borderRadius: '8px',
+        marginBottom: '1.5rem'
+      }}>
+        <textarea
+          value={inputText}
+          onChange={handleInputChange}
+          placeholder='Enter graph JSON: {"nodes":[...], "edges":[...]}'
+          style={{
+            width: '100%',
+            minHeight: '120px',
+            fontFamily: 'Consolas, Monaco, "Courier New", monospace',
+            fontSize: '0.9rem',
+            padding: '0.5rem',
+            borderRadius: '6px',
+            border: '1px solid var(--border-primary)',
+            marginBottom: '0.5rem',
+            resize: 'vertical'
+          }}
+        />
+        <button
+          onClick={handleLoadCustomGraph}
+          style={{
+            padding: '0.5rem 1rem',
+            background: 'var(--accent-primary-bg)',
+            color: 'var(--text-on-accent)',
+            border: 'none',
+            borderRadius: '6px',
+            cursor: 'pointer'
+          }}
+        >
+          Load Graph
+        </button>
+      </div>
+
+      {/* Graph Visualizer */}
+      <GraphVisualizer 
+        defaultAlgorithm="BFS" 
+        autoLoadExample={!customGraph} 
+        customGraph={customGraph} 
+      />
+
+      {/* Code Section */}
       <div className="theme-card" style={{ marginTop: '2rem' }}>
         <div className="theme-card-header">
           <h3>BFS - Code Implementation</h3>
           <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
-            <button
-              className={`btn ${selectedLanguage === 'java' ? 'btn-primary' : 'btn-secondary'}`}
-              onClick={() => setSelectedLanguage('java')}
-              style={{ fontSize: '0.9rem', padding: '0.5rem 1rem' }}
-            >
-              Java
-            </button>
-            <button
-              className={`btn ${selectedLanguage === 'python' ? 'btn-primary' : 'btn-secondary'}`}
-              onClick={() => setSelectedLanguage('python')}
-              style={{ fontSize: '0.9rem', padding: '0.5rem 1rem' }}
-            >
-              Python
-            </button>
-            <button
-              className={`btn ${selectedLanguage === 'cpp' ? 'btn-primary' : 'btn-secondary'}`}
-              onClick={() => setSelectedLanguage('cpp')}
-              style={{ fontSize: '0.9rem', padding: '0.5rem 1rem' }}
-            >
-              C++
-            </button>
-             <button
-              className={`btn ${selectedLanguage === 'javascript' ? 'btn-primary' : 'btn-secondary'}`}
-              onClick={() => setSelectedLanguage('javascript')}
-              style={{ fontSize: '0.9rem', padding: '0.5rem 1rem' }}
-            >
-            Javascript
-            </button>
+            {["java", "python", "cpp", "javascript"].map(lang => (
+              <button
+                key={lang}
+                className={`btn ${selectedLanguage === lang ? 'btn-primary' : 'btn-secondary'}`}
+                onClick={() => setSelectedLanguage(lang)}
+                style={{ fontSize: '0.9rem', padding: '0.5rem 1rem' }}
+              >
+                {lang.charAt(0).toUpperCase() + lang.slice(1)}
+              </button>
+            ))}
           </div>
         </div>
         <div style={{
@@ -90,5 +137,3 @@ const GraphBFS = () => {
 };
 
 export default GraphBFS;
-
-

--- a/src/pages/GraphDFS.jsx
+++ b/src/pages/GraphDFS.jsx
@@ -5,41 +5,94 @@ import "../styles/global-theme.css";
 
 const GraphDFS = () => {
   const [selectedLanguage, setSelectedLanguage] = useState("java");
+  const [customGraph, setCustomGraph] = useState(null);
+  const [inputText, setInputText] = useState("");
+
+  // Handler to parse input
+  const handleInputChange = (e) => {
+    setInputText(e.target.value);
+  };
+
+  const handleLoadCustomGraph = () => {
+    try {
+      const parsed = JSON.parse(inputText);
+      if (!parsed.nodes || !parsed.edges) {
+        alert("Invalid graph format. Must contain 'nodes' and 'edges'.");
+        return;
+      }
+      setCustomGraph(parsed);
+    } catch (err) {
+      alert("Invalid JSON format.");
+    }
+  };
 
   return (
     <div className="theme-container">
       <h1 className="theme-title">Depth-First Search (DFS)</h1>
       <p style={{ textAlign: 'center', maxWidth: '700px', margin: '-2rem auto 2rem auto', color: 'var(--theme-text-secondary)' }}>
-        Visualize DFS traversal on a graph. Load the default example or create your own graph.
+        Visualize DFS traversal on a graph. You can edit the graph JSON below and click "Load Graph".
       </p>
-      <GraphVisualizer defaultAlgorithm="DFS" autoLoadExample={true} />
+
+      {/* Custom Input Section */}
+      <div style={{
+        background: 'var(--surface-bg)',
+        padding: '1rem',
+        borderRadius: '8px',
+        marginBottom: '1.5rem'
+      }}>
+        <textarea
+          value={inputText}
+          onChange={handleInputChange}
+          placeholder='Enter graph JSON: {"nodes":[...], "edges":[...]}'
+          style={{
+            width: '100%',
+            minHeight: '120px',
+            fontFamily: 'Consolas, Monaco, "Courier New", monospace',
+            fontSize: '0.9rem',
+            padding: '0.5rem',
+            borderRadius: '6px',
+            border: '1px solid var(--border-primary)',
+            marginBottom: '0.5rem',
+            resize: 'vertical'
+          }}
+        />
+        <button
+          onClick={handleLoadCustomGraph}
+          style={{
+            padding: '0.5rem 1rem',
+            background: 'var(--accent-primary-bg)',
+            color: 'var(--text-on-accent)',
+            border: 'none',
+            borderRadius: '6px',
+            cursor: 'pointer'
+          }}
+        >
+          Load Graph
+        </button>
+      </div>
+
+      {/* Graph Visualizer */}
+      <GraphVisualizer 
+        defaultAlgorithm="DFS" 
+        autoLoadExample={!customGraph} 
+        customGraph={customGraph} 
+      />
 
       {/* Code Implementation Section */}
       <div className="theme-card" style={{ marginTop: '2rem' }}>
         <div className="theme-card-header">
           <h3>DFS - Code Implementation</h3>
           <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
-            <button
-              className={`btn ${selectedLanguage === 'java' ? 'btn-primary' : 'btn-secondary'}`}
-              onClick={() => setSelectedLanguage('java')}
-              style={{ fontSize: '0.9rem', padding: '0.5rem 1rem' }}
-            >
-              Java
-            </button>
-            <button
-              className={`btn ${selectedLanguage === 'python' ? 'btn-primary' : 'btn-secondary'}`}
-              onClick={() => setSelectedLanguage('python')}
-              style={{ fontSize: '0.9rem', padding: '0.5rem 1rem' }}
-            >
-              Python
-            </button>
-            <button
-              className={`btn ${selectedLanguage === 'cpp' ? 'btn-primary' : 'btn-secondary'}`}
-              onClick={() => setSelectedLanguage('cpp')}
-              style={{ fontSize: '0.9rem', padding: '0.5rem 1rem' }}
-            >
-              C++
-            </button>
+            {["java", "python", "cpp", "javascript"].map(lang => (
+              <button
+                key={lang}
+                className={`btn ${selectedLanguage === lang ? 'btn-primary' : 'btn-secondary'}`}
+                onClick={() => setSelectedLanguage(lang)}
+                style={{ fontSize: '0.9rem', padding: '0.5rem 1rem' }}
+              >
+                {lang.charAt(0).toUpperCase() + lang.slice(1)}
+              </button>
+            ))}
           </div>
         </div>
         <div style={{
@@ -83,5 +136,3 @@ const GraphDFS = () => {
 };
 
 export default GraphDFS;
-
-

--- a/src/pages/GraphDijkstra.jsx
+++ b/src/pages/GraphDijkstra.jsx
@@ -5,41 +5,95 @@ import "../styles/global-theme.css";
 
 const GraphDijkstra = () => {
   const [selectedLanguage, setSelectedLanguage] = useState("java");
+  const [customGraph, setCustomGraph] = useState(null);
+  const [inputText, setInputText] = useState("");
+
+  // Handle textarea change
+  const handleInputChange = (e) => {
+    setInputText(e.target.value);
+  };
+
+  // Load custom graph from JSON input
+  const handleLoadCustomGraph = () => {
+    try {
+      const parsed = JSON.parse(inputText);
+      if (!parsed.nodes || !parsed.edges) {
+        alert("Invalid graph format. Must contain 'nodes' and 'edges'.");
+        return;
+      }
+      setCustomGraph(parsed);
+    } catch (err) {
+      alert("Invalid JSON format.");
+    }
+  };
 
   return (
     <div className="theme-container">
       <h1 className="theme-title">Dijkstra's Algorithm</h1>
       <p style={{ textAlign: 'center', maxWidth: '700px', margin: '-2rem auto 2rem auto', color: 'var(--theme-text-secondary)' }}>
-        Visualize shortest paths using Dijkstra's algorithm. Load the default example or create your own graph.
+        Visualize shortest paths using Dijkstra's algorithm. You can edit the graph JSON below and click "Load Graph".
       </p>
-      <GraphVisualizer defaultAlgorithm="Dijkstra" autoLoadExample={true} />
+
+      {/* Custom Input Section */}
+      <div style={{
+        background: 'var(--surface-bg)',
+        padding: '1rem',
+        borderRadius: '8px',
+        marginBottom: '1.5rem'
+      }}>
+        <textarea
+          value={inputText}
+          onChange={handleInputChange}
+          placeholder='Enter graph JSON: {"nodes":[...], "edges":[...]}'
+          style={{
+            width: '100%',
+            minHeight: '120px',
+            fontFamily: 'Consolas, Monaco, "Courier New", monospace',
+            fontSize: '0.9rem',
+            padding: '0.5rem',
+            borderRadius: '6px',
+            border: '1px solid var(--border-primary)',
+            marginBottom: '0.5rem',
+            resize: 'vertical'
+          }}
+        />
+        <button
+          onClick={handleLoadCustomGraph}
+          style={{
+            padding: '0.5rem 1rem',
+            background: 'var(--accent-primary-bg)',
+            color: 'var(--text-on-accent)',
+            border: 'none',
+            borderRadius: '6px',
+            cursor: 'pointer'
+          }}
+        >
+          Load Graph
+        </button>
+      </div>
+
+      {/* Graph Visualizer */}
+      <GraphVisualizer 
+        defaultAlgorithm="Dijkstra" 
+        autoLoadExample={!customGraph} 
+        customGraph={customGraph} 
+      />
 
       {/* Code Implementation Section */}
       <div className="theme-card" style={{ marginTop: '2rem' }}>
         <div className="theme-card-header">
           <h3>Dijkstra's Algorithm - Code Implementation</h3>
           <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
-            <button
-              className={`btn ${selectedLanguage === 'java' ? 'btn-primary' : 'btn-secondary'}`}
-              onClick={() => setSelectedLanguage('java')}
-              style={{ fontSize: '0.9rem', padding: '0.5rem 1rem' }}
-            >
-              Java
-            </button>
-            <button
-              className={`btn ${selectedLanguage === 'python' ? 'btn-primary' : 'btn-secondary'}`}
-              onClick={() => setSelectedLanguage('python')}
-              style={{ fontSize: '0.9rem', padding: '0.5rem 1rem' }}
-            >
-              Python
-            </button>
-            <button
-              className={`btn ${selectedLanguage === 'cpp' ? 'btn-primary' : 'btn-secondary'}`}
-              onClick={() => setSelectedLanguage('cpp')}
-              style={{ fontSize: '0.9rem', padding: '0.5rem 1rem' }}
-            >
-              C++
-            </button>
+            {["java", "python", "cpp", "javascript"].map(lang => (
+              <button
+                key={lang}
+                className={`btn ${selectedLanguage === lang ? 'btn-primary' : 'btn-secondary'}`}
+                onClick={() => setSelectedLanguage(lang)}
+                style={{ fontSize: '0.9rem', padding: '0.5rem 1rem' }}
+              >
+                {lang.charAt(0).toUpperCase() + lang.slice(1)}
+              </button>
+            ))}
           </div>
         </div>
         <div style={{
@@ -84,5 +138,3 @@ const GraphDijkstra = () => {
 };
 
 export default GraphDijkstra;
-
-


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #595.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->This change is proposed to enhance the functionality and usability of the graph visualization feature. By allowing users to input custom graphs for each visualizer individually, the platform now supports more flexible testing and learning scenarios. This improvement directly addresses user feedback requesting the ability to compare different custom graphs across algorithms.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->Added the ability to input custom graphs separately for each graph visualizer in the Graph Comparison page.

Updated state management to maintain individual custom graph data for both algorithms.

Improved UI for custom graph input with validation and JSON parsing.

Ensured that default example graphs are still loaded when no custom input is provided.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->Yes, the changes have been manually tested:

Users can input valid JSON for both visualizers independently.

Alerts are shown for invalid JSON or missing required fields (nodes and edges).

Visualizations update correctly when custom graphs are loaded.

Default examples load when no custom graph is provided.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->Yes, users can now:

Enter custom graph data for each visualizer separately.

Compare two different custom graphs side by side for graph algorithms like BFS, DFS, and Dijkstra.

Receive validation feedback for incorrect input formats.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->