### PR TITLE
fix the community - overview page

### DIFF
--- a/src/pages/CommunityLanding.jsx
+++ b/src/pages/CommunityLanding.jsx
@@ -77,27 +77,35 @@ const CommunityLanding = () => {
 
         {/* Community Stats */}
         <motion.div 
-          variants={itemVariants}
-          className="stats-grid mb-12"
+            variants={itemVariants}
+            className="stats-grid mb-12"
+            style={{
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+                gap: '2rem', // space between boxes
+                width: '100%',
+                }}
         >
-          <div className="stat-card" style={{ background: 'linear-gradient(135deg, #4f46e5 10%, #7c3aed 100%)', color: 'white' }}>
+          <div className="stat-card" style={{ background: 'linear-gradient(135deg, #4f46e5 10%, #7c3aed 100%)', color: 'white', display: 'flex', flexDirection: 'column', alignItems: 'center', padding: '2rem 1.5rem', borderRadius: '1rem', minWidth: '200px', boxShadow: '0 4px 16px rgba(0,0,0,0.09)' }}>
             <Users size={32} style={{ marginBottom: '1rem', opacity: 0.9 }} />
             <div className="stat-value">100+</div>
             <div className="stat-label" style={{ color: 'rgba(255,255,255,0.9)' }}>Contributors</div>
           </div>
-          
-          <div className="stat-card" style={{ background: 'linear-gradient(135deg, #16a34a 10%, #22c55e 100%)', color: 'white' }}>
+
+          <div className="stat-card" style={{ background: 'linear-gradient(135deg, #16a34a 10%, #22c55e 100%)', color: 'white', display: 'flex', flexDirection: 'column', alignItems: 'center', padding: '2rem 1.5rem', borderRadius: '1rem', minWidth: '200px', boxShadow: '0 4px 16px rgba(0,0,0,0.09)' }}>
             <Github size={32} style={{ marginBottom: '1rem', opacity: 0.9 }} />
             <div className="stat-value">500+</div>
             <div className="stat-label" style={{ color: 'rgba(255,255,255,0.9)' }}>Commits</div>
           </div>
-          
-          <div className="stat-card" style={{ background: 'linear-gradient(135deg, #dc2626 10%, #f59e0b 100%)', color: 'white' }}>
+
+          <div className="stat-card" style={{ background: 'linear-gradient(135deg, #dc2626 10%, #f59e0b 100%)', color: 'white', display: 'flex', flexDirection: 'column', alignItems: 'center', padding: '2rem 1.5rem', borderRadius: '1rem', minWidth: '200px', boxShadow: '0 4px 16px rgba(0,0,0,0.09)' }}>
             <Star size={32} style={{ marginBottom: '1rem', opacity: 0.9 }} />
             <div className="stat-value">50+</div>
             <div className="stat-label" style={{ color: 'rgba(255,255,255,0.9)' }}>Projects</div>
           </div>
         </motion.div>
+
 
         {/* Community Sections */}
         <motion.div
@@ -106,7 +114,7 @@ const CommunityLanding = () => {
             display: 'grid',
             gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))',
             gap: '2rem',
-            marginBottom: '3rem'
+            marginBottom: '3rem',
           }}
         >
           {/* Overview Card */}

--- a/src/styles/global-theme.css
+++ b/src/styles/global-theme.css
@@ -70,6 +70,24 @@
   --code-text: #f8f8f2;
 }
 
+/* Add this to your CSS module or stylesheet */
+.stats-grid {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 2rem; /* space between boxes */
+}
+.stat-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 2rem 1.5rem;
+  border-radius: 1rem;
+  min-width: 200px;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.09);
+}
+
+
 /* -----------------
    2. Base & Layout
 ----------------- */


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #562 

## Rationale for this change

The stat cards on the Community page were not centered, resulting in a misaligned layout. Centering these boxes improves visual consistency and user experience by making the statistics section look professional and polished.

## What changes are included in this PR?
- Updated the inline styling of the parent motion.div to use Flexbox for centering :
      - Applied display: flex, justify-content: center, and alignItems: center to the container.
      - Added spacing (gap: 2rem) for even distribution.
- Standardized card appearance using flexDirection: column and alignItems: center in each stat card to ensure vertical alignment of content.

## Are these changes tested?
Yes, the changes were manually verified by observing the centered alignment of the stat boxes in the browser. The layout is consistent across desktop screen sizes.

## Are there any user-facing changes?

Yes. The stat cards (Contributors, Commits, Projects) now appear neatly centered in the Community Stats section, improving the site's visual layout.

Before : 
<img width="1919" height="856" alt="492041305-fac8a744-aed1-443e-872b-cdc22e463adf" src="https://github.com/user-attachments/assets/f9fa7e2f-7281-4dc4-bd03-132f6cf8a662" />

After : 
<img width="1830" height="866" alt="Screenshot 2025-09-24 204017" src="https://github.com/user-attachments/assets/d7e3c193-1b05-4eec-9f74-27d4c46aa7b6" />


