### PR TITLE
Fix: Footer "Contribute" link now redirects to GitHub contribute page

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -183,11 +183,16 @@ const Footer = () => {
                 </Link>
               </li>
               <li>
-                <Link to="/contribute">
-                  <FaArrowRight className="link-icon" />
-                  Contribute
-                </Link>
-              </li>
+  <a 
+    href="https://github.com/RhythmPahwa14/AlgoVisualizer" 
+    target="_blank" 
+    rel="noopener noreferrer"
+  >
+    <FaArrowRight className="link-icon" />
+    Contribute
+  </a>
+</li>
+
             </ul>
           </div>
 


### PR DESCRIPTION


### PR Description

## Which issue does this PR close?

* Closes #593 

## Rationale for this change

The "Contribute" link in the footer was incorrectly redirecting users to the "Doubts" section instead of the intended Contribute page.
Fixing this ensures users can easily find contribution guidelines and participate in the project.

## What changes are included in this PR?

* Updated the footer `Contribute` link to correctly redirect to the GitHub repository’s Contribute page (`https://github.com/RhythmPahwa14/AlgoVisualizer`).
* Replaced the incorrect `<Link>` with an `<a>` tag to properly handle external navigation.

## Are these changes tested?

* Verified manually by clicking the footer link.
* Confirmed it now opens the GitHub Contribute page in a new tab.

## Are there any user-facing changes?

* Yes. Users clicking the footer "Contribute" link will now be taken to the GitHub Contribute page instead of the "Doubts" section.


