### PR TITLE
Fix: Footer "Algorithms" link redirects correctly to Data Structures page

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -122,7 +122,7 @@ const Footer = () => {
                 </Link>
               </li>
               <li>
-                <Link to="/algorithms">
+                <Link to="/data-structures">
                   <FaArrowRight className="link-icon" />
                   Algorithms
                 </Link>


### PR DESCRIPTION

### PR Description

## Which issue does this PR close?

* Closes #591 

## Rationale for this change

The "Algorithms" link in the footer was incorrectly redirecting users to the "Doubts" section.
Updating the path to the correct `data-structures` page ensures users can access algorithm-related content as intended.

## What changes are included in this PR?

* Updated the footer `Algorithms` link path from `doubts` to `data-structures`.
* Verified navigation now points to the correct section.

## Are these changes tested?

* Yes, tested manually by clicking the footer "Algorithms" link.
* Confirmed it now redirects to the Data Structures page as expected.

## Are there any user-facing changes?

* Yes. Users clicking the footer "Algorithms" link will now be taken to the Data Structures page instead of the Doubts section.
