### PR TITLE
add Stack visualization with operations and info panel

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -53,6 +53,9 @@ import TreePage from "./pages/TreePage";
 // Divide & Conquer
 import DCOverview from "./pages/DCOverview";
 import DCPage from "./pages/DCPage";
+import Stack from "./components/Stack/Stack";
+
+
 
 
 
@@ -67,6 +70,7 @@ const App = () => {
     "/graph/bfs",
     "/graph/dfs",
     "/graph/dijkstra",
+    "/data-structures/stack",
   ];
 
   return (
@@ -103,6 +107,7 @@ const App = () => {
               path="/data-structures/linked-list"
               element={<LinkedListPage />}
             />
+            <Route path="/data-structures/stack" element={<Stack />} />
 
             <Route path="/sorting/:algoId/docs" element={<SortingDoc />} />
 
@@ -123,6 +128,7 @@ const App = () => {
             {/* Dynamic Programming */}
 <Route path="/dp-overview" element={<DPOverview />} />
 <Route path="/dp" element={<DPPage />} />
+
 
 
               {/* Hashing */}

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -78,6 +78,7 @@ const Navbar = () => {
       dropdown: [
         { path: "/data-structures", label: "Overview" },
         { path: "/data-structures/linked-list", label: "Linked List" },
+        { path: "/data-structures/stack", label: "Stack visualization" },
       ],
     },
     {

--- a/src/components/Stack/Stack.css
+++ b/src/components/Stack/Stack.css
@@ -1,0 +1,140 @@
+.stack-page {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 1.25rem;
+}
+
+.controls {
+  display: flex;
+  gap: .5rem;
+  flex-wrap: wrap;
+  margin: 1rem 0 1.5rem;
+}
+
+.controls input {
+  padding: .5rem .75rem;
+  border: 1px solid #444;
+  border-radius: 6px;
+  min-width: 220px;
+  background: transparent;
+  color: inherit;
+}
+
+.controls button {
+  padding: .5rem .9rem;
+  border: 1px solid #555;
+  background: #111;
+  color: #eee;
+  border-radius: 6px;
+  cursor: pointer;
+}
+.controls button:disabled {
+  opacity: .5;
+  cursor: not-allowed;
+}
+
+.stack-visual {
+  display: grid;
+  gap: 1rem;
+}
+
+.stack-container {
+  min-height: 300px;
+  border: 2px dashed #444;
+  border-radius: 8px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column-reverse;
+  align-items: stretch;
+  justify-content: flex-start;
+  background: rgba(255,255,255,0.02);
+}
+
+.stack-item {
+  padding: .6rem .8rem;
+  border: 1px solid #666;
+  border-radius: 6px;
+  margin: .35rem 0;
+  text-align: center;
+  transition: transform .2s ease, background .2s ease, box-shadow .2s ease;
+  background: #1f1f1f;
+}
+.stack-item.top {
+  outline: 2px solid #7c3aed;
+  box-shadow: 0 0 12px rgba(124,58,237,.4);
+}
+.stack-item.peek {
+  transform: translateY(-4px);
+}
+
+.stack-empty {
+  opacity: .7;
+  text-align: center;
+  margin-top: .5rem;
+}
+
+.legend { display: flex; align-items: center; gap: 1rem; opacity: .8; }
+.legend-box { width: 14px; height: 14px; border-radius: 3px; display: inline-block; border: 1px solid #666; }
+.legend-box.top { outline: 2px solid #7c3aed; box-shadow: 0 0 8px rgba(124,58,237,.35); }
+.legend-box.normal { background: #1f1f1f; }
+
+/* ---- Info Panel ---- */
+.ds-info {
+  margin-top: 2rem;
+  padding: 1.25rem;
+  border: 1px solid #333;
+  border-radius: 10px;
+  background: rgba(255,255,255,0.02);
+}
+
+.ds-info h2 { margin: 0 0 .5rem; }
+.ds-info h3 { margin: 1rem 0 .5rem; }
+.ds-info h4 { margin: .75rem 0 .25rem; }
+
+.ds-grid {
+  display: grid;
+  gap: 1rem;
+}
+@media (min-width: 900px) {
+  .ds-grid {
+    grid-template-columns: 1.2fr .8fr;
+    align-items: start;
+  }
+}
+
+.ds-table {
+  width: 100%;
+  border-collapse: collapse;
+  overflow: hidden;
+  border-radius: 8px;
+  border: 1px solid #333;
+}
+.ds-table th, .ds-table td {
+  padding: .65rem .75rem;
+  border-bottom: 1px solid #2a2a2a;
+  text-align: left;
+}
+.ds-table thead th {
+  background: rgba(124,58,237,.12);
+  font-weight: 600;
+}
+.ds-table tbody tr:last-child td { border-bottom: none; }
+
+.ds-note {
+  border: 1px dashed #3a3a3a;
+  border-radius: 8px;
+  padding: .75rem .9rem;
+  background: rgba(255,255,255,0.02);
+}
+.ds-note ul { margin: .4rem 0 .6rem 1.1rem; }
+.ds-note li { margin: .25rem 0; }
+
+/* Highlighted when Peek is clicked */
+.stack-item.peek {
+  background: linear-gradient(135deg, #4f46e5, #9333ea); /* nice purple/indigo gradient */
+  color: #fff;
+  font-weight: 600;
+  box-shadow: 0 0 14px rgba(147, 51, 234, 0.6);
+  transform: scale(1.05);
+  transition: all 0.3s ease;
+}

--- a/src/components/Stack/Stack.jsx
+++ b/src/components/Stack/Stack.jsx
@@ -1,0 +1,182 @@
+import { useState, useEffect } from "react";
+import "./Stack.css";
+
+export default function Stack() {
+  const [items, setItems] = useState([]);
+  const [input, setInput] = useState("");
+  const [peekTick, setPeekTick] = useState(0); // used to trigger a brief highlight on peek
+  const topIndex = items.length - 1;
+
+  // brief animation toggle for Peek
+  useEffect(() => {
+    if (!peekTick) return;
+    const t = setTimeout(() => setPeekTick(0), 500);
+    return () => clearTimeout(t);
+  }, [peekTick]);
+
+  const push = () => {
+    const val = input.trim();
+    if (!val) return;
+    setItems(prev => [...prev, val]);
+    setInput("");
+  };
+
+  const pop = () => {
+    if (!items.length) return;
+    setItems(prev => prev.slice(0, -1));
+  };
+
+  const peek = () => {
+    if (!items.length) return;
+    setPeekTick(peekTick + 1);
+  };
+
+  const reset = () => setItems([]);
+
+  // convenience actions
+  const pushSample = () => {
+    const sample = ["A", "B", "C", "D"];
+    setItems(sample);
+  };
+
+  return (
+    <div className="stack-page">
+      <h1>Stack (LIFO)</h1>
+
+      {/* Controls */}
+      <div className="controls">
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Value to push"
+          onKeyDown={(e) => e.key === "Enter" && push()}
+        />
+        <button onClick={push}>Push</button>
+        <button onClick={pop} disabled={!items.length}>Pop</button>
+        <button onClick={peek} disabled={!items.length}>Peek</button>
+        <button onClick={reset} disabled={!items.length}>Reset</button>
+        <button onClick={pushSample}>Fill sample</button>
+      </div>
+
+      {/* Visualization */}
+      <div className="stack-visual">
+        <div className="stack-container" aria-label="Stack container">
+          {items.map((val, i) => {
+            const isTop = i === topIndex;
+            const classes = [
+              "stack-item",
+              isTop ? "top" : "",
+              isTop && peekTick ? "peek" : "",
+            ]
+              .filter(Boolean)
+              .join(" ");
+
+            return (
+              <div
+                key={i}
+                className={classes}
+                aria-label={isTop ? "Top element" : "Stack element"}
+                title={isTop ? "Top" : ""}
+                role="listitem"
+              >
+                {val}
+              </div>
+            );
+          })}
+          {!items.length && (
+            <div className="stack-empty" role="status">
+              Stack is empty
+            </div>
+          )}
+        </div>
+
+        <div className="legend">
+          <span className="legend-box top" /> Top
+          <span className="legend-box normal" /> Element
+        </div>
+      </div>
+
+      {/* ---- Info Panel ---- */}
+      <section className="ds-info">
+        <h2>About Stack</h2>
+        <p>
+          A <strong>Stack</strong> is a linear data structure that follows{" "}
+          <em>Last In, First Out (LIFO)</em>. Elements are added and removed only from
+          the top.
+        </p>
+
+        <h3>Operations &amp; Complexity</h3>
+        <div className="ds-grid">
+          <table className="ds-table">
+            <thead>
+              <tr>
+                <th>Operation</th>
+                <th>What it does</th>
+                <th>Time</th>
+                <th>Space</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><code>push(x)</code></td>
+                <td>Add <code>x</code> to the top</td>
+                <td>O(1)</td>
+                <td>O(1)</td>
+              </tr>
+              <tr>
+                <td><code>pop()</code></td>
+                <td>Remove &amp; return top</td>
+                <td>O(1)</td>
+                <td>O(1)</td>
+              </tr>
+              <tr>
+                <td><code>peek()</code></td>
+                <td>Read top without removing</td>
+                <td>O(1)</td>
+                <td>O(1)</td>
+              </tr>
+              <tr>
+                <td><code>size()</code> / <code>isEmpty()</code></td>
+                <td>Get count / check empty</td>
+                <td>O(1)</td>
+                <td>O(1)</td>
+              </tr>
+              <tr>
+                <td><code>search(x)</code></td>
+                <td>Find element by value</td>
+                <td>O(n)</td>
+                <td>O(1)</td>
+              </tr>
+            </tbody>
+          </table>
+
+          <div className="ds-note">
+            <h4>Implementation Notes</h4>
+            <ul>
+              <li><strong>Array-based</strong> stack: simple &amp; cache-friendly; pushes/pops at the end are O(1).</li>
+              <li><strong>Linked-list</strong> stack: no resize cost; each node has pointer overhead.</li>
+              <li><strong>Space complexity:</strong> O(n) to store n items.</li>
+            </ul>
+
+            <h4>Common Uses</h4>
+            <ul>
+              <li>Function call stack / recursion</li>
+              <li>Undo / Redo</li>
+              <li>Balanced parentheses, expression evaluation</li>
+              <li>Depth-First Search (DFS)</li>
+            </ul>
+          </div>
+        </div>
+
+        <h3 style={{ marginTop: "1rem" }}>Pseudo-code</h3>
+        <pre className="ds-code" aria-label="Stack pseudo-code">
+{`init stack S = []
+push(x): append x to S
+pop(): if S not empty -> remove and return last element
+peek(): if S not empty -> return last element
+isEmpty(): return length(S) == 0`}
+        </pre>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #596 

## Rationale for this change

Currently, AlgoVisualizer does not provide a visualization for **Stack**.  
Adding this feature improves the learning experience by allowing users to interactively understand **LIFO (Last In, First Out)** operations such as push, pop, and peek.  

This aligns with the goal of making Data Structures more accessible and visually engaging for learners.

## What changes are included in this PR?

- Added a new `Stack` component under `src/components/Stack/`
  - Interactive controls for **Push**, **Pop**, **Peek**, **Reset**
  - Visual highlight for the **top element**
  - Smooth peek animation with glow effect
- Added a **Stack info panel**:
  - Short description of Stack
  - Big-O complexities table for all key operations
  - Implementation notes (array vs. linked list)
  - Common real-world use cases
  - Simple pseudo-code block
- Registered a new route: `/data-structures/stack`
- Updated **Navbar** dropdown under Data Structures to include **Stack**

## Are these changes tested?

- Tested locally by running the app (`npm run dev`)
- Verified:
  - All buttons (Push, Pop, Peek, Reset) behave as expected
  - Top element highlight on Peek is animated
  - Page renders correctly on both desktop and mobile views
  - Navbar link to **Data Structures → Stack** works

## Are there any user-facing changes?

Yes ✅  
- New **Stack Visualizer page** is now available under *Data Structures → Stack*.  
- Users can interactively perform operations on a stack and see corresponding changes in real time.  
- Added an info panel to help users understand the theory and complexities.  

No breaking API changes.  

### video : 

https://github.com/user-attachments/assets/7c764404-5d11-4a27-bf9b-b231c75c4bbd

