### PR TITLE
feature - interactive BST Visualizer: Instant Inserts, Batch Input, and Arrow-Order Traversals (Mobile-First UI)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -62,6 +62,7 @@ import Stack from "./components/Stack/Stack";
 
 import AOS from 'aos';
 import 'aos/dist/aos.css';
+import BinaryTreeVisualizer from "./components/BinaryTree/BinaryTreeVisualizer";
  
 
 
@@ -162,6 +163,8 @@ const App = () => {
   {/* Divide & Conquer */}
   <Route path="/dc-overview" element={<DCOverview />} />
   <Route path="/dc" element={<DCPage />} />
+
+  <Route path="/binary-tree" element={<BinaryTreeVisualizer />} />
 
 
 

--- a/src/components/BinaryTree/BinaryTreeVisualizer.css
+++ b/src/components/BinaryTree/BinaryTreeVisualizer.css
@@ -1,0 +1,192 @@
+/* src/components/BinaryTree/BinaryTreeVisualizer.css */
+
+:root{
+  --bg:#0b0f1a;
+  --surface:#0f1626;
+  --surface-2:#111b2d;
+  --border:#1d2b49;
+  --muted:#98a2b3;
+  --text:#eef2f8;
+  --primary:#5aa1ff;
+  --accent:#b485ff;
+  --edge:#334569;
+  --path:#ff6b6b;
+  --visited:#ffd166;
+}
+
+.btv-wrap{
+  width:100%;
+  margin:0 auto;
+  font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Helvetica Neue, Arial;
+  color:var(--text);
+}
+
+.btv-toolbar{
+  padding:12px;
+  margin:12px;
+  border-radius:16px;
+  background:linear-gradient(180deg, rgba(255,255,255,0.02), transparent), var(--surface);
+  box-shadow: 0 10px 30px rgba(0,0,0,.35), inset 0 1px 0 rgba(255,255,255,.06);
+  border:1px solid var(--border);
+}
+
+.btv-controls .btv-row{
+  display:grid;
+  grid-template-columns:1fr;
+  gap:12px;
+}
+@media (min-width:880px){
+  .btv-controls .btv-row{
+    grid-template-columns: 1fr 1fr 1fr;
+  }
+}
+
+.btv-card{
+  background:var(--surface-2);
+  border:1px solid var(--border);
+  border-radius:14px;
+  padding:12px;
+}
+.btv-card-title{
+  font-size:13px;
+  color:var(--muted);
+  margin-bottom:8px;
+  letter-spacing:.2px;
+}
+
+.btv-input-row{
+  display:flex;
+  gap:8px;
+  align-items:center;
+  flex-wrap:wrap;
+  margin-bottom:8px;
+}
+.btv-input{
+  flex:1 1 140px;
+  padding:12px 12px;
+  background:#0b1426;
+  border:1px solid var(--border);
+  border-radius:12px;
+  color:var(--text);
+  font-size:14px;
+}
+.btv-textarea{ min-height:64px; resize:vertical; }
+
+.btv-btn{
+  padding:11px 14px;
+  background:#0b1426;
+  color:var(--text);
+  border:1px solid var(--border);
+  border-radius:12px;
+  cursor:pointer;
+  transition:transform .05s ease, background .15s ease, border-color .15s ease;
+}
+.btv-btn:active{ transform:translateY(1px); }
+.btv-btn[disabled]{ opacity:.6; cursor:not-allowed; }
+.btv-primary{ border-color:var(--primary); background:rgba(90,161,255,.15); }
+.btv-accent{  border-color:var(--accent);  background:rgba(180,133,255,.16); }
+
+.btv-seg{ display:flex; flex-wrap:wrap; gap:8px; }
+.btv-seg-btn{
+  padding:10px 12px;
+  border-radius:12px;
+  border:1px solid var(--border);
+  background:#0b1426;
+  color:var(--text);
+  cursor:pointer;
+}
+.btv-seg-btn.is-active{ background:rgba(90,161,255,.16); border-color:var(--primary); }
+
+.btv-subtle{ color:var(--muted); font-size:12px; margin:4px 0 6px; }
+
+.btv-toggle-row{ display:flex; gap:10px; align-items:center; flex-wrap:wrap; margin-top:6px; }
+
+.btv-checkbox{ display:inline-flex; gap:8px; align-items:center; color:var(--muted); user-select:none; }
+
+.btv-speed{ display:flex; align-items:center; gap:10px; }
+.btv-speed-label{ color:var(--muted); font-size:12px; }
+
+.btv-hint{ margin-top:8px; color:var(--muted); font-size:12px; }
+
+/* Canvas */
+.btv-canvas{
+  margin:12px;
+  background:var(--bg);
+  border:1px solid var(--border);
+  border-radius:16px;
+  overflow:hidden;
+  position:relative;
+}
+.btv-canvas.btv-shake{ animation:btv-shake .42s cubic-bezier(.36,.07,.19,.97) both; }
+@keyframes btv-shake{
+  10%,90%{ transform:translateX(-1px); }
+  20%,80%{ transform:translateX(2px); }
+  30%,50%,70%{ transform:translateX(-4px); }
+  40%,60%{ transform:translateX(4px); }
+}
+
+.btv-svg{ width:100%; height:clamp(320px, 56vh, 620px); display:block; }
+.btv-edge{ stroke:var(--edge); stroke-width:2; }
+
+.btv-node circle{
+  fill:#0f1933;
+  stroke:#2b3b61;
+  stroke-width:2;
+  filter: drop-shadow(0 8px 18px rgba(0,0,0,.35));
+  transition: transform .18s ease, fill .18s ease, stroke .18s ease;
+}
+.btv-node text{
+  fill:#eef2f8; font-weight:700; font-size:13px; text-anchor:middle;
+}
+.btv-node.is-active circle{ fill:rgba(90,161,255,.22); stroke:var(--primary); transform:scale(1.08); }
+.btv-node.in-path circle{ stroke:var(--path); }
+.btv-node.is-visited circle{ stroke:var(--visited); }
+
+/* Legend */
+.btv-legend{
+  display:flex; gap:14px; align-items:center;
+  padding:12px 16px 18px;
+  color:var(--muted); font-size:13px;
+}
+.chip{ width:16px; height:8px; border-radius:999px; display:inline-block; margin-right:6px; background:var(--edge); }
+.chip-active{ background:var(--primary); }
+.chip-path{ background:var(--path); }
+.chip-visited{ background:var(--visited); }
+
+/* Traversal order strip */
+.btv-order{
+  margin: 4px 12px 18px;
+  padding: 12px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+}
+.btv-order-head{
+  display:flex; align-items:center; justify-content:space-between; gap:12px;
+  margin-bottom:10px;
+}
+.btv-order-title{ font-size:13px; color:var(--muted); letter-spacing:.2px; }
+
+.btv-order-copy{
+  padding:8px 10px;
+  background:#0b1426;
+  color:var(--text);
+  border:1px solid var(--border);
+  border-radius:10px;
+  cursor:pointer;
+}
+.btv-order-line{
+  display:flex; flex-wrap:wrap; gap:8px; align-items:center;
+}
+.btv-pill{
+  padding:6px 10px;
+  background:#0b1426;
+  border:1px solid var(--border);
+  border-radius:999px;
+  font-weight:700; font-size:12px;
+}
+.btv-arrow{
+  opacity:.9;
+  font-weight:700;
+  user-select:none;
+}

--- a/src/components/BinaryTree/BinaryTreeVisualizer.jsx
+++ b/src/components/BinaryTree/BinaryTreeVisualizer.jsx
@@ -1,0 +1,461 @@
+// src/components/BinaryTree/BinaryTreeVisualizer.jsx
+import React, { useMemo, useRef, useState, useEffect } from "react";
+import "./BinaryTreeVisualizer.css";
+import { insertBST, deleteBST, findBST, cloneTree } from "./utils/bst";
+import { layoutTree } from "./utils/layout";
+
+export default function BinaryTreeVisualizer() {
+  // core tree
+  const [root, setRoot] = useState(null);
+
+  // UI state
+  const [value, setValue] = useState("");      // single ops
+  const [bulk, setBulk] = useState("");        // batch insert
+  const [animateInserts, setAnimateInserts] = useState(false); // instant by default
+  const [stepMode, setStepMode] = useState(false);             // off by default
+  const [speed, setSpeed] = useState(450);
+  const [traversal, setTraversal] = useState("inorder");
+  const [isBusy, setIsBusy] = useState(false);
+
+  // animation state
+  const [activePath, setActivePath] = useState([]);
+  const [activeNodeId, setActiveNodeId] = useState(null);
+  const [visited, setVisited] = useState([]);
+
+  // textual traversal order
+  const [order, setOrder] = useState([]);
+
+  // id generator
+  const idCounter = useRef(1);
+  function makeNode(val) {
+    return { id: idCounter.current++, val, left: null, right: null };
+  }
+
+  const laidOut = useMemo(() => layoutTree(root), [root, activeNodeId]);
+
+  function resetHighlights() {
+    setActivePath([]);
+    setActiveNodeId(null);
+    setVisited([]);
+    setOrder([]);
+  }
+
+  // ---- step runner ----
+  const nextResolver = useRef(null);
+  function waitForNextClick() {
+    return new Promise((resolve) => { nextResolver.current = resolve; });
+  }
+  function handleNext() {
+    if (nextResolver.current) {
+      nextResolver.current();
+      nextResolver.current = null;
+    }
+  }
+
+  async function runWithSteps(steps, postApply) {
+    setIsBusy(true);
+    for (let i = 0; i < steps.length; i++) {
+      const s = steps[i];
+      if (s.type === "focus") {
+        setActiveNodeId(s.nodeId);
+        setActivePath((p) => (p[p.length - 1] === s.nodeId ? p : [...p, s.nodeId]));
+      } else if (s.type === "visit") {
+        setVisited((v) => (v[v.length - 1] === s.nodeId ? v : [...v, s.nodeId]));
+      } else if (s.type === "apply" && s.snapshot) {
+        setRoot(cloneTree(s.snapshot));
+      }
+
+      if (stepMode) {
+        // eslint-disable-next-line no-await-in-loop
+        await waitForNextClick();
+      } else {
+        // eslint-disable-next-line no-await-in-loop
+        await new Promise((r) => setTimeout(r, speed));
+      }
+    }
+    if (typeof postApply === "function") postApply();
+    setIsBusy(false);
+  }
+
+  // ---- helpers ----
+  function parseNums(str) {
+    return str
+      .split(/[\s,]+/)
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .map(Number)
+      .filter((n) => Number.isFinite(n));
+  }
+
+  // ---- ops ----
+  async function onInsertOne(e) {
+    e?.preventDefault?.();
+    if (value === "") return;
+    const num = Number(value);
+    if (!Number.isFinite(num)) return;
+
+    resetHighlights();
+    const { rootAfter, steps } = insertBST(root, makeNode, num);
+    if (animateInserts) {
+      await runWithSteps(steps, () => setRoot(rootAfter));
+    } else {
+      setRoot(rootAfter); // instant
+    }
+    setValue("");
+  }
+
+  async function onSearch(e) {
+    e?.preventDefault?.();
+    if (value === "") return;
+    const num = Number(value);
+    if (!Number.isFinite(num)) return;
+
+    resetHighlights();
+    const { found, steps } = findBST(root, num);
+    await runWithSteps(steps, () => {
+      if (!found) {
+        const wrap = document.querySelector(".btv-canvas");
+        wrap?.classList.add("btv-shake");
+        setTimeout(() => wrap?.classList.remove("btv-shake"), 420);
+      }
+    });
+  }
+
+  async function onDelete(e) {
+    e?.preventDefault?.();
+    if (value === "") return;
+    const num = Number(value);
+    if (!Number.isFinite(num)) return;
+
+    resetHighlights();
+    const { rootAfter, steps } = deleteBST(root, num);
+    await runWithSteps(steps, () => setRoot(rootAfter));
+    setValue("");
+  }
+
+  async function onInsertMany() {
+    const nums = parseNums(bulk);
+    if (!nums.length) return;
+    resetHighlights();
+    let cur = root;
+    for (const n of nums) {
+      const { rootAfter } = insertBST(cur, makeNode, n);
+      cur = rootAfter;
+    }
+    setRoot(cur);     // instant batch
+    setBulk("");
+  }
+
+  async function onInsertManyAnimated() {
+    const nums = parseNums(bulk);
+    if (!nums.length) return;
+    resetHighlights();
+    let cur = root;
+    setIsBusy(true);
+    for (const n of nums) {
+      const { rootAfter, steps } = insertBST(cur, makeNode, n);
+      await runWithSteps(steps);
+      cur = rootAfter;
+    }
+    setRoot(cur);
+    setBulk("");
+    setIsBusy(false);
+  }
+
+  // Traversals with textual order
+  async function onTraverse(kind) {
+    resetHighlights();
+    setTraversal(kind);
+
+    const seq = [];
+    const orderVals = [];
+    const pushVisit = (node) => {
+      if (!node) return;
+      seq.push({ type: "visit", nodeId: node.id });
+      orderVals.push(node.val);
+    };
+
+    function inorder(n) {
+      if (!n) return;
+      seq.push({ type: "focus", nodeId: n.id });
+      inorder(n.left);
+      pushVisit(n);
+      inorder(n.right);
+    }
+    function preorder(n) {
+      if (!n) return;
+      seq.push({ type: "focus", nodeId: n.id });
+      pushVisit(n);
+      preorder(n.left);
+      preorder(n.right);
+    }
+    function postorder(n) {
+      if (!n) return;
+      seq.push({ type: "focus", nodeId: n.id });
+      postorder(n.left);
+      postorder(n.right);
+      pushVisit(n);
+    }
+    function level(n) {
+      const q = [];
+      if (n) q.push(n);
+      while (q.length) {
+        const cur = q.shift();
+        seq.push({ type: "focus", nodeId: cur.id });
+        pushVisit(cur);
+        if (cur.left) q.push(cur.left);
+        if (cur.right) q.push(cur.right);
+      }
+    }
+
+    if (kind === "inorder") inorder(root);
+    if (kind === "preorder") preorder(root);
+    if (kind === "postorder") postorder(root);
+    if (kind === "level") level(root);
+
+    setOrder(orderVals); // show the order immediately
+    await runWithSteps(seq);
+  }
+
+  function onClear() {
+    resetHighlights();
+    setRoot(null);
+    setOrder([]);
+  }
+
+  // keyboard: Enter inserts; shift+Enter deletes; N advances in step mode
+  useEffect(() => {
+    function onKey(e) {
+      if (e.key === "Enter" && !e.shiftKey) onInsertOne(e);
+      if (e.key === "Enter" && e.shiftKey) onDelete(e);
+      if ((e.key === "n" || e.key === "N") && stepMode) handleNext();
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [stepMode, value, root]);
+
+  return (
+    <div className="btv-wrap">
+      {/* TOP BAR */}
+      <header className="btv-toolbar">
+        <div className="btv-controls">
+          <div className="btv-row">
+            {/* Insert */}
+            <div className="btv-card">
+              <div className="btv-card-title">Insert (fast)</div>
+              <div className="btv-input-row">
+                <input
+                  className="btv-input"
+                  type="number"
+                  placeholder="e.g. 50"
+                  value={value}
+                  onChange={(e) => setValue(e.target.value)}
+                  disabled={isBusy && stepMode}
+                />
+                <button
+                  className="btv-btn btv-primary"
+                  onClick={onInsertOne}
+                  disabled={isBusy && stepMode}
+                  title="Insert instantly"
+                >
+                  Insert
+                </button>
+              </div>
+
+              <div className="btv-subtle">Paste many: spaces / commas / newlines</div>
+              <div className="btv-input-row">
+                <textarea
+                  className="btv-input btv-textarea"
+                  placeholder="50 30,70 20,40 60 80"
+                  value={bulk}
+                  onChange={(e) => setBulk(e.target.value)}
+                  rows={2}
+                />
+              </div>
+              <div className="btv-input-row">
+                <button className="btv-btn" onClick={onInsertMany} disabled={isBusy}>
+                  Insert all (instant)
+                </button>
+                <button
+                  className="btv-btn"
+                  onClick={onInsertManyAnimated}
+                  disabled={isBusy}
+                  title="Show each path"
+                >
+                  Insert all (animated)
+                </button>
+              </div>
+
+              <label className="btv-checkbox">
+                <input
+                  type="checkbox"
+                  checked={animateInserts}
+                  onChange={(e) => setAnimateInserts(e.target.checked)}
+                />
+                Animate single inserts
+              </label>
+            </div>
+
+            {/* Search / Delete */}
+            <div className="btv-card">
+              <div className="btv-card-title">Search / Delete</div>
+              <div className="btv-input-row">
+                <input
+                  className="btv-input"
+                  type="number"
+                  placeholder="value"
+                  value={value}
+                  onChange={(e) => setValue(e.target.value)}
+                />
+                <button className="btv-btn" onClick={onSearch} disabled={isBusy && stepMode}>
+                  Search
+                </button>
+                <button className="btv-btn" onClick={onDelete} disabled={isBusy && stepMode}>
+                  Delete
+                </button>
+              </div>
+
+              <div className="btv-toggle-row">
+                <label className="btv-checkbox">
+                  <input
+                    type="checkbox"
+                    checked={stepMode}
+                    onChange={(e) => setStepMode(e.target.checked)}
+                  />
+                  Step-by-step
+                </label>
+                <div className="btv-speed">
+                  <label className="btv-speed-label">Speed</label>
+                  <input
+                    type="range"
+                    min="200"
+                    max="1200"
+                    step="50"
+                    value={speed}
+                    onChange={(e) => setSpeed(Number(e.target.value))}
+                    disabled={stepMode}
+                    aria-label="Animation speed"
+                  />
+                </div>
+                {stepMode && (
+                  <button
+                    className="btv-btn btv-accent"
+                    type="button"
+                    onClick={handleNext}
+                    disabled={!isBusy}
+                    title="Next step (N)"
+                  >
+                    Next
+                  </button>
+                )}
+              </div>
+            </div>
+
+            {/* Traversals */}
+            <div className="btv-card">
+              <div className="btv-card-title">Traversals</div>
+              <div className="btv-seg" role="group" aria-label="Traversal">
+                {[
+                  ["inorder", "Inorder"],
+                  ["preorder", "Preorder"],
+                  ["postorder", "Postorder"],
+                  ["level", "Level"],
+                ].map(([k, label]) => (
+                  <button
+                    key={k}
+                    type="button"
+                    className={`btv-seg-btn ${traversal === k ? "is-active" : ""}`}
+                    onClick={() => onTraverse(k)}
+                    disabled={!root || (isBusy && stepMode)}
+                    aria-pressed={traversal === k}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+
+              <div className="btv-actions">
+                <button className="btv-btn" onClick={onClear}>Clear</button>
+              </div>
+            </div>
+          </div>
+
+          <p className="btv-hint">
+            Insert many instantly, then pick a traversal to see the path and the exact visiting order.
+            Press <kbd>N</kbd> to advance when Step-by-step is on. Shift+Enter deletes the current value.
+          </p>
+        </div>
+      </header>
+
+      {/* CANVAS */}
+      <section className="btv-canvas" role="region" aria-label="Binary tree canvas">
+        <svg className="btv-svg" viewBox={laidOut.viewBox.join(" ")} preserveAspectRatio="xMidYMid meet">
+          {/* edges */}
+          {laidOut.links.map((l) => (
+            <line
+              key={`${l.source.id}-${l.target.id}`}
+              x1={l.source.x}
+              y1={l.source.y}
+              x2={l.target.x}
+              y2={l.target.y}
+              className="btv-edge"
+            />
+          ))}
+          {/* nodes */}
+          {laidOut.nodes.map((n) => {
+            const isActive = n.id === activeNodeId;
+            const inPath = activePath.includes(n.id);
+            const isVisited = visited.includes(n.id);
+            const classes = ["btv-node", isActive && "is-active", inPath && "in-path", isVisited && "is-visited"]
+              .filter(Boolean)
+              .join(" ");
+            return (
+              <g key={n.id} transform={`translate(${n.x},${n.y})`} className={classes}>
+                <circle r="20" />
+                <text dy="6">{n.val}</text>
+              </g>
+            );
+          })}
+        </svg>
+      </section>
+
+      {/* LEGEND */}
+      <footer className="btv-legend" aria-label="Legend">
+        <span className="chip chip-active" /> Current
+        <span className="chip chip-path" /> Path
+        <span className="chip chip-visited" /> Visited
+      </footer>
+
+      {/* TRAVERSAL ORDER */}
+      {order.length > 0 && (
+        <section className="btv-order" aria-label="Traversal order">
+          <div className="btv-order-head">
+            <span className="btv-order-title">
+              {traversal === "inorder" && "Inorder"}
+              {traversal === "preorder" && "Preorder"}
+              {traversal === "postorder" && "Postorder"}
+              {traversal === "level" && "Level-order"} order
+            </span>
+            <button
+              className="btv-btn btv-order-copy"
+              type="button"
+              onClick={() => navigator.clipboard?.writeText(order.join(" "))}
+              title="Copy order"
+            >
+              Copy
+            </button>
+          </div>
+
+          <div className="btv-order-line" role="list">
+            {order.map((v, i) => (
+              <React.Fragment key={`${v}-${i}`}>
+                <span role="listitem" className="btv-pill">{v}</span>
+                {i < order.length - 1 && <span className="btv-arrow">→</span>}
+              </React.Fragment>
+            ))}
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/src/components/BinaryTree/utils/bst.js
+++ b/src/components/BinaryTree/utils/bst.js
@@ -1,0 +1,102 @@
+// src/components/BinaryTree/utils/bst.js
+
+/**
+ * Steps consumed by the visualizer:
+ * { type: "focus", nodeId }
+ * { type: "visit", nodeId }
+ * { type: "apply", snapshot: root }
+ */
+
+export function cloneTree(node) {
+  if (!node) return null;
+  const n = { id: node.id, val: node.val, left: null, right: null };
+  n.left = cloneTree(node.left);
+  n.right = cloneTree(node.right);
+  return n;
+}
+
+export function findBST(root, value) {
+  const steps = [];
+  let cur = root;
+  while (cur) {
+    steps.push({ type: "focus", nodeId: cur.id });
+    if (value === cur.val) return { found: true, steps };
+    cur = value < cur.val ? cur.left : cur.right;
+  }
+  return { found: false, steps };
+}
+
+export function insertBST(root, makeNode, value) {
+  const steps = [];
+  if (!root) {
+    const newRoot = makeNode(value);
+    steps.push({ type: "apply", snapshot: cloneTree(newRoot) });
+    return { rootAfter: newRoot, steps };
+  }
+
+  const newRoot = cloneTree(root);
+  let cur = newRoot;
+
+  while (true) {
+    steps.push({ type: "focus", nodeId: cur.id });
+    if (value === cur.val) {
+      // no duplicates; still apply to “flash”
+      steps.push({ type: "apply", snapshot: cloneTree(newRoot) });
+      return { rootAfter: newRoot, steps };
+    }
+    if (value < cur.val) {
+      if (cur.left) {
+        cur = cur.left;
+      } else {
+        cur.left = makeNode(value);
+        steps.push({ type: "apply", snapshot: cloneTree(newRoot) });
+        return { rootAfter: newRoot, steps };
+      }
+    } else {
+      if (cur.right) {
+        cur = cur.right;
+      } else {
+        cur.right = makeNode(value);
+        steps.push({ type: "apply", snapshot: cloneTree(newRoot) });
+        return { rootAfter: newRoot, steps };
+      }
+    }
+  }
+}
+
+export function deleteBST(root, value) {
+  const steps = [];
+  const newRoot = cloneTree(root);
+
+  function minNode(n) {
+    while (n.left) n = n.left;
+    return n;
+  }
+
+  function _del(n) {
+    if (!n) return null;
+    steps.push({ type: "focus", nodeId: n.id });
+    if (value < n.val) {
+      n.left = _del(n.left);
+      return n;
+    }
+    if (value > n.val) {
+      n.right = _del(n.right);
+      return n;
+    }
+    // found node
+    if (!n.left && !n.right) return null;
+    if (!n.left) return n.right;
+    if (!n.right) return n.left;
+
+    // two children: replace with inorder successor
+    const succ = minNode(n.right);
+    n.val = succ.val;
+    n.right = _del(n.right, succ.val);
+    return n;
+  }
+
+  const result = _del(newRoot);
+  steps.push({ type: "apply", snapshot: cloneTree(result) });
+  return { rootAfter: result, steps };
+}

--- a/src/components/BinaryTree/utils/layout.js
+++ b/src/components/BinaryTree/utils/layout.js
@@ -1,0 +1,65 @@
+// src/components/BinaryTree/utils/layout.js
+
+/**
+ * Simple tidy layout:
+ * - x via inorder index
+ * - y via depth
+ * Returns { nodes, links, viewBox }
+ */
+export function layoutTree(root) {
+  if (!root) {
+    return { nodes: [], links: [], viewBox: [-50, -50, 100, 100] };
+  }
+
+  const nodes = [];
+  const rawLinks = [];
+  let idx = 0;
+  const xGap = 48;
+  const yGap = 70;
+  let minX = Infinity;
+  let maxX = -Infinity;
+
+  function markDepth(n, d = 0) {
+    if (!n) return;
+    markDepth(n.left, d + 1);
+    n._depth = d;
+    markDepth(n.right, d + 1);
+  }
+  markDepth(root, 0);
+
+  function inorder(n) {
+    if (!n) return;
+    inorder(n.left);
+
+    const x = idx * xGap;
+    const y = n._depth * yGap;
+    idx += 1;
+    nodes.push({ id: n.id, val: n.val, x, y, _ref: n });
+    if (n.left) rawLinks.push({ source: n, target: n.left });
+    if (n.right) rawLinks.push({ source: n, target: n.right });
+
+    if (x < minX) minX = x;
+    if (x > maxX) maxX = x;
+
+    inorder(n.right);
+  }
+  inorder(root);
+
+  const byId = new Map(nodes.map((n) => [n.id, n]));
+  const links = rawLinks.map((l) => ({
+    source: byId.get(l.source.id),
+    target: byId.get(l.target.id),
+  }));
+
+  const pad = 60;
+  const minY = 0;
+  const maxY = Math.max(...nodes.map((n) => n.y), 0);
+  const width = (maxX - minX) + pad * 2 + 1;
+  const height = (maxY - minY) + pad * 2 + 1;
+  const shiftX = pad - minX;
+  const shiftY = pad - minY;
+
+  nodes.forEach((n) => { n.x += shiftX; n.y += shiftY; });
+
+  return { nodes, links, viewBox: [0, 0, width, height] };
+}

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -70,6 +70,8 @@ const Navbar = () => {
 
         { path: "/data-structures/queue", label: "Queue visualization" },
         { path: "/data-structures/stack", label: "Stack visualization" },
+        { path: "/binary-tree", label: "Binary Tree visualization" },
+
 
       ],
     },


### PR DESCRIPTION

## Which issue does this PR close?

* Closes #653

## Rationale for this change

Adds an interactive Binary Tree/BST visualizer to improve learning. Users can quickly build trees, run operations step-by-step, and view traversal order clearly — much better than static diagrams.

## What changes are included in this PR?

* **Core ops:** Insert (instant or animated), Delete (all cases), Search (with path + miss feedback).
* **Batch insert:** Paste comma/space-separated numbers.
* **Traversals:** Inorder, Preorder, Postorder, Level-order. Shows **arrow-separated order strip** with copy button.
* **UI/UX:** Modern mobile-first design, step-by-step mode with Next/auto-play, speed slider, keyboard shortcuts (**Enter**, **Shift+Enter**, **N**).
* **Visuals:** Highlights for current, path, visited. Tidy layout via inorder indexing.

## Are these changes tested?

* ✅ Manual testing on desktop & mobile for all operations and traversals.
* ❌ No automated tests yet; core BST/layout functions are good candidates for unit tests in a follow-up.

## Are there any user-facing changes?

* Yes — entirely new Binary Tree visualization feature.
* Docs: should add usage examples (batch input, shortcuts).


video : 

https://github.com/user-attachments/assets/b87606d8-4db8-4867-8463-e16886b71dec

