### PR TITLE
fix(dp): correct Fibonacci bases and add step highlight; init AOS once (fixes #650)

### DIFF
--- a/src/components/DPVisualizer.jsx
+++ b/src/components/DPVisualizer.jsx
@@ -21,15 +21,22 @@ const DPVisualizer = ({
   const fibonacci = (n) => {
     const stepsArr = [];
     const memo = Array(n + 1).fill(-1);
+    // Correct bases so UI never shows -1 leading entries
+    if (n >= 0) memo[0] = 0;
+    if (n >= 1) memo[1] = 1; // switch to 1 if you want the 1,1,2,3… variant
 
-    const fib = (k) => {
-      if (k <= 1) return k;
-      if (memo[k] !== -1) return memo[k];
-      stepsArr.push({ board: copySteps(memo), message: `Computing fib(${k})` });
-      memo[k] = fib(k - 1) + fib(k - 2);
-      stepsArr.push({ board: copySteps(memo), message: `fib(${k}) = ${memo[k]}` });
-      return memo[k];
-    };
+     const fib = (k) => {
+      if (k <= 1) {
+        // show base usage
+        stepsArr.push({ board: copySteps(memo), message: `Base: fib(${k}) = ${memo[k]}`, focusIndex: k });
+        return memo[k];
+      }
+       if (memo[k] !== -1) return memo[k];
+      stepsArr.push({ board: copySteps(memo), message: `Computing fib(${k})`, focusIndex: k });
+       memo[k] = fib(k - 1) + fib(k - 2);
+      stepsArr.push({ board: copySteps(memo), message: `fib(${k}) = ${memo[k]}`, focusIndex: k });
+       return memo[k];
+     };
 
     fib(n);
     return stepsArr;
@@ -165,21 +172,30 @@ const DPVisualizer = ({
     setMessage("Select an algorithm and run.");
   };
 
-  // ================= Render =================
-  const renderBoard = () => {
-    if (!steps[currentStep]) return null;
+   // ================= Render =================
+   const renderBoard = () => {
+     if (!steps[currentStep]) return null;
     const stepBoard = steps[currentStep].board;
+    const focusIndex = steps[currentStep].focusIndex;
 
-    // Array of numbers
-    if (Array.isArray(stepBoard) && !Array.isArray(stepBoard[0])) {
-      return (
-        <div className="list-visualizer">
-          {stepBoard.map((num, i) => (
-            <span key={i} className="list-item">{num === Infinity ? "∞" : num}</span>
-          ))}
-        </div>
-      );
-    }
+     // Array of numbers
+     if (Array.isArray(stepBoard) && !Array.isArray(stepBoard[0])) {
+       return (
+        <div className="list-visualizer dp-seq">
+           {stepBoard.map((num, i) => (
+            <span
+              key={i}
+              className={`list-item dp-cell ${i === focusIndex ? "is-active" : ""}`}
+              title={i === focusIndex ? "Current step" : undefined}
+            >
+              <span className="dp-cell-index">{i}</span>
+              <span className="dp-cell-value">{num === Infinity ? "∞" : num}</span>
+            </span>
+           ))}
+         </div>
+       );
+     }
+
 
     return (
       <div className="board">

--- a/src/pages/DPPage.jsx
+++ b/src/pages/DPPage.jsx
@@ -1,5 +1,5 @@
 // src/pages/DPPage.jsx
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import DPVisualizer from "../components/DPVisualizer";
 import { dpAlgorithms } from "../data/allCodes"; // make sure dpAlgorithms exists in allCodes.js
 import "../styles/global-theme.css";
@@ -10,7 +10,11 @@ const DPPage = () => {
   const [selectedLanguage, setSelectedLanguage] = useState("java");
   const [selectedAlgorithm, setSelectedAlgorithm] = useState("fibonacci"); // default algorithm
 
-  const algorithmData = dpAlgorithms[selectedAlgorithm] || {};
+  const algorithmData = (dpAlgorithms && dpAlgorithms[selectedAlgorithm]) || {};
+
+  useEffect(() => {
+    AOS.init({ duration: 600, once: true });
+  }, []);
 
   // Default problem sizes for visualizer
   const defaultSizes = {

--- a/src/styles/global-theme.css
+++ b/src/styles/global-theme.css
@@ -1324,3 +1324,37 @@ body {
   line-height: 1.6;
   padding: 0; 
 }
+/* Boxed sequence grid with step highlight */
+.dp-seq {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(70px, 1fr));
+  gap: .5rem;
+  margin: 1rem 0;
+}
+
+.dp-cell {
+  border: 1px solid var(--border, rgba(255,255,255,.12));
+  border-radius: 10px;
+  padding: .5rem .25rem;
+  background: var(--surface-bg, rgba(255,255,255,.03));
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: .25rem;
+}
+
+.dp-cell-index {
+  font-size: .7rem;
+  opacity: .65;
+}
+
+.dp-cell-value {
+  font-weight: 600;
+}
+
+.dp-cell.is-active {
+  outline: 2px solid var(--accent-primary, #7aa2f7);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent-primary, #7aa2f7) 25%, transparent);
+}
+


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #650

## Rationale for this change


https://github.com/user-attachments/assets/c2f64d3c-8cd8-46dc-831d-9648c7cdb954

Fibonacci visualizer was showing `-1` as the first value and acked a clear step highlight. This PR fixes the base cases and adds a moving highlight so users can see the current step while stepping or autoplaying.

## What changes are included in this PR?

- Fix Fibonacci DP base cases (`memo[0] = 0`, `memo[1] = 1`)  
- Add `focusIndex` to steps and highlight the current cell in the UI  
- Render Fibonacci as a clean grid of boxed cells  
- Initialize AOS properly so animations actually work  
- Update styles in `global-theme.css` for `.dp-cell` and `.is-active`

## Are these changes tested?

Manually tested:
- Fibonacci sequence starts with `0, 1, 1, 2, …` (no `-1`)  
- Highlight moves correctly with **Run**, **Prev**, and **Next**  
- Other algorithms (Coin Change, LCS, Knapsack, Matrix Chain) still render and step without errors  
- AOS animations are working after initialization  

## Are there any user-facing changes?

Yes:
- Fibonacci visualizer now displays in a readable boxed grid with a highlighted current step  
- Users see correct base values instead of `-1`  
- Animations run smoothly across DP pages
