### PR TITLE
Added a warning and improved visibility of Start Quiz button

### DIFF
--- a/src/components/QuizStart.jsx
+++ b/src/components/QuizStart.jsx
@@ -118,8 +118,24 @@ const QuizStart = ({
         >
           <FaPlay /> Start Quiz
         </button>
+        {/* Warning */}
+  {!selectedTopic || !selectedDifficulty ? (
+    <p className="warning-msg">Please select a topic, difficulty and mode.</p>
+  ) : null}
 
-        {error && <p className="error-msg">{error}</p>}
+  {selectedTopic && selectedDifficulty && (
+    <p className="quiz-info">
+      Get ready for{" "}
+      <strong>
+        {selectedTopic === "all"
+          ? "All Topics"
+          : topics.find((t) => t.id === selectedTopic)?.name}
+      </strong>{" "}
+      at <strong>{selectedDifficulty}</strong> difficulty{" "}
+      {timedMode ? "(Timed)" : "(Practice)"}.
+    </p>
+  )}
+        {/*{error && <p className="error-msg">{error}</p>}
 
         {selectedTopic && selectedDifficulty && (
           <p className="quiz-info">
@@ -132,7 +148,7 @@ const QuizStart = ({
             at <strong>{selectedDifficulty}</strong> difficulty{" "}
             {timedMode ? "(Timed)" : "(Practice)"}.
           </p>
-        )}
+        )}*/}
       </div>
     </div>
   );

--- a/src/styles/Quiz.css
+++ b/src/styles/Quiz.css
@@ -468,7 +468,7 @@
     }
 }
 
-.quiz-btn:disabled {
+{/*}.quiz-btn:disabled {
     background: var(--disabled-bg);
     cursor: not-allowed;
     transform: none;
@@ -479,7 +479,16 @@
 
 [data-theme="light"] .quiz-btn:disabled {
     color: #656d76;
+}*/}
+.quiz-btn:disabled {
+    background: #83a6da;
+    border: 1px solid #30363d;
 }
+[data-theme="light"] .quiz-btn:disabled {
+    background: #83a6da;
+    border: 1px solid #d1d9e0;
+}
+
 
 .quiz-btn.secondary {
     background: #21262d;


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #519 

## What changes are included in this PR?

Added a warning below the Start Quiz button to help users understand that they must be selecting all options before opting to start a quiz. Also made the font color of Start Quiz visible while still maintaining the restricted hover mode.

## Are these changes tested?

Changes are tested locally.

## Image for reference
<img width="1366" height="768" alt="Screenshot (464)" src="https://github.com/user-attachments/assets/dcf6dd30-1869-4aec-b995-f5a54f4bbbdf" />
