### PR TITLE
feat(dp): highlight DP code block + minimal copy icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "gif.js": "^0.2.0",
         "html2canvas": "^1.4.1",
         "lucide-react": "^0.473.0",
+        "prismjs": "^1.30.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-icons": "^5.5.0",
@@ -4645,6 +4646,15 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/prop-types": {
       "version": "15.8.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "gif.js": "^0.2.0",
     "html2canvas": "^1.4.1",
     "lucide-react": "^0.473.0",
+    "prismjs": "^1.30.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-icons": "^5.5.0",

--- a/src/pages/DPPage.jsx
+++ b/src/pages/DPPage.jsx
@@ -5,8 +5,44 @@ import { dpAlgorithms } from "../data/allCodes"; // make sure dpAlgorithms exist
 import "../styles/global-theme.css";
 import AOS from 'aos';
 import 'aos/dist/aos.css';
+import { useEffect, useRef, useMemo } from "react";                
+
+// ✅ Core
+import Prism from "prismjs";
+import "prismjs/themes/prism-tomorrow.css";
+
+// ✅ Language dependencies FIRST
+import "prismjs/components/prism-clike.min.js";
+import "prismjs/components/prism-c.min.js";
+
+// ✅ Then the languages you use
+import "prismjs/components/prism-javascript.min.js";
+import "prismjs/components/prism-java.min.js";
+import "prismjs/components/prism-cpp.min.js";
+import "prismjs/components/prism-python.min.js";
+
+// ✅ Plugins LAST
+import "prismjs/plugins/line-numbers/prism-line-numbers.css";
+import "prismjs/plugins/line-numbers/prism-line-numbers.js";
+
+import { FiCopy, FiCheck } from "react-icons/fi";
 
 const DPPage = () => {
+
+const [copied, setCopied] = useState(false);
+
+const handleCopy = async () => {
+  const code = algorithmData[selectedLanguage] || "";
+  try {
+    await navigator.clipboard.writeText(code);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1200); // reset after 1.2s
+  } catch (err) {
+    console.error("Failed to copy", err);
+  }
+};
+
+
   const [selectedLanguage, setSelectedLanguage] = useState("java");
   const [selectedAlgorithm, setSelectedAlgorithm] = useState("fibonacci"); // default algorithm
 
@@ -34,6 +70,17 @@ const DPPage = () => {
     subsetSum: "Subset Sum"
   };
 
+    const codeRef = useRef(null);
+    const prismLang = useMemo(() => {
+      const map = { javascript: "javascript", java: "java", cpp: "cpp", python: "python" };
+      return map[selectedLanguage] || "javascript";
+    }, [selectedLanguage]);
+
+    useEffect(() => {
+      if (codeRef.current) Prism.highlightElement(codeRef.current);
+    }, [algorithmData, selectedLanguage, selectedAlgorithm]);
+
+  
   return (
     <div className="theme-container" data-aos="fade-up" data-aos-duration="1000">
       <h1 className="theme-title">Dynamic Programming Visualizer</h1>
@@ -86,24 +133,46 @@ const DPPage = () => {
           </div>
         </div>
 
-        <div style={{
-          background: 'var(--surface-bg)',
-          borderRadius: '8px',
-          padding: '1.5rem',
-          overflow: 'auto',
-          maxHeight: '500px'
-        }}>
-          <pre style={{
-            margin: 0,
-            fontFamily: 'Consolas, Monaco, "Courier New", monospace',
-            fontSize: '0.9rem',
-            lineHeight: '1.5',
-            color: 'var(--text-primary)',
-            whiteSpace: 'pre-wrap',
-            wordBreak: 'break-word'
-          }}>
-            <code>
-              {algorithmData[selectedLanguage]}
+        <div
+          style={{
+            background: 'var(--surface-bg)',
+            borderRadius: '8px',
+            padding: '1rem 1.25rem',
+            overflow: 'auto',
+            maxHeight: '500px',
+            position: 'relative'
+          }}
+        >
+          <button
+            onClick={handleCopy}
+            title="Copy code"
+            style={{
+              position: "absolute",
+              top: "8px",
+              right: "12px",
+              background: "transparent",
+              border: "none",
+              color: "#ccc",
+              fontSize: "1.2rem",
+              cursor: "pointer",
+              zIndex: 10
+            }}
+          >
+            {copied ? <FiCheck /> : <FiCopy />}
+          </button>
+
+          <pre className="line-numbers" style={{ margin: 0 }}>
+            <code
+              ref={codeRef}
+              className={`language-${prismLang}`}
+              style={{
+                fontFamily: 'Consolas, Monaco, "Courier New", monospace',
+                fontSize: '0.9rem',
+                lineHeight: 1.5,
+                whiteSpace: 'pre'
+              }}
+            >
+              {algorithmData[selectedLanguage] || ""}
             </code>
           </pre>
         </div>


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #651

## Rationale for this change

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/ce99a8e7-10d6-4573-b9d0-3fdaa7d45590" />

The DP code block currently renders as plain text with no syntax highlighting or copy support. This makes it harder for users to read and reuse examples. This PR fixes that.

## What changes are included in this PR?

- Added Prism.js with required language dependencies (Java, Python, C++, JavaScript)
- Enabled syntax highlighting + line numbers in `DPPage.jsx`
- Prevented code wrapping (horizontal scroll instead)
- Added a minimal floating copy button with icon that shows a checkmark after copy

## Are these changes tested?

- Verified locally that each supported language highlights correctly
- Confirmed copy button copies the correct code and shows ✔️ feedback

## Are there any user-facing changes?

Yes. The “Code Implementation” section now shows:
- Proper syntax highlighting with line numbers
- A floating copy button to quickly copy code
