### PR TITLE
Add documentation for 9 sorting algorithms to improve learning experience

### DIFF
--- a/src/pages/SortingDoc.jsx
+++ b/src/pages/SortingDoc.jsx
@@ -1,3 +1,4 @@
+// src/pages/SortingDoc.jsx
 import React, { useMemo } from "react";
 import { useParams, Link } from "react-router-dom";
 import { ALGORITHM_INFO } from "../data/algorithmInfo";
@@ -5,25 +6,56 @@ import { ALGORITHM_PSEUDOCODE as PSEUDO } from "../data/pseudocode";
 import { sortingAlgorithms as CODE } from "../data/allCodes";
 import "../styles/SortingDoc.css";
 
+/* helpers */
 function normalizeStable(v) {
   if (typeof v === "boolean") return v ? "Yes" : "No";
   if (typeof v === "string") return v;
   return String(v ?? "Unknown");
 }
 
+const toCamel = (s = "") =>
+  s
+    .trim()
+    .replace(/[_\s]+/g, "-")
+    .toLowerCase()
+    .replace(/-([a-z0-9])/g, (_, c) => c.toUpperCase());
+
+const toSlug = (s = "") =>
+  s
+    .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+    .replace(/[_\s]+/g, "-")
+    .toLowerCase();
+
+const toTitle = (k = "") =>
+  k.replace(/([A-Z])/g, " $1").replace(/^./, (s) => s.toUpperCase());
+
 export default function SortingDoc() {
   const { algoId = "" } = useParams();
 
-  const info = ALGORITHM_INFO?.[algoId];
-  const pseudo = PSEUDO?.[algoId]; // your pseudocode keys are camelCase (e.g., bubbleSort)
-  const code = CODE?.[algoId];
+  // nested structure under .sorting
+  const INFO_ROOT = ALGORITHM_INFO?.sorting ?? {};
+  const PSEUDO_ROOT = PSEUDO?.sorting ?? PSEUDO ?? {};
+  const CODE_ROOT = CODE?.sorting ?? CODE ?? {};
 
-  const title = useMemo(() => {
-    // turn "bubbleSort" -> "Bubble Sort"
-    return algoId
-      .replace(/([A-Z])/g, " $1")
-      .replace(/^./, (s) => s.toUpperCase());
-  }, [algoId]);
+  const resolvedKey = useMemo(() => {
+    const incoming = algoId.trim();
+
+    if (INFO_ROOT[incoming]) return incoming;
+    const camel = toCamel(incoming);
+    if (INFO_ROOT[camel]) return camel;
+
+    const keys = Object.keys(INFO_ROOT);
+    return keys.find((k) => toSlug(k) === incoming.toLowerCase()) || null;
+  }, [algoId, INFO_ROOT]);
+
+  const info = resolvedKey ? INFO_ROOT[resolvedKey] : null;
+  const pseudo = resolvedKey ? PSEUDO_ROOT?.[resolvedKey] : null;
+  const code = resolvedKey ? CODE_ROOT?.[resolvedKey] : null;
+
+  const title = useMemo(() => toTitle(resolvedKey || algoId || ""), [
+    resolvedKey,
+    algoId,
+  ]);
 
   if (!info) {
     return (
@@ -32,8 +64,12 @@ export default function SortingDoc() {
           <h1 className="doc-title">Documentation not available</h1>
           <p className="muted">No docs found for “{algoId}”.</p>
           <div className="cta-row">
-            <Link className="btn" to="/data-structures">Back to Overview</Link>
-            <Link className="btn primary" to="/sorting">Open Visualizer</Link>
+            <Link className="btn" to="/data-structures">
+              Back to Overview
+            </Link>
+            <Link className="btn primary" to="/sorting">
+              Open Visualizer
+            </Link>
           </div>
         </header>
       </div>
@@ -42,82 +78,129 @@ export default function SortingDoc() {
 
   return (
     <div className="doc-page">
+      {/* HERO */}
       <header className="doc-hero">
         <div className="hero-text">
           <h1 className="doc-title">
             {title} <span className="tag">docs</span>
           </h1>
-          <p className="muted">{info.description ?? "No description available."}</p>
+          <p className="muted">
+            {info.description ?? "No description available."}
+          </p>
 
-          <nav className="cta-row" aria-label="Quick links">
-            <Link to="/sorting" className="btn primary">Open Visualizer</Link>
-            {pseudo?.length ? <a className="btn" href="#pseudocode">Pseudocode</a> : null}
-            {code ? <a className="btn" href="#reference">Reference</a> : null}
-          </nav>
+          <div className="cta-row" aria-label="Quick links">
+            <Link to="/sorting" className="btn primary">
+              Open Visualizer
+            </Link>
+            {Array.isArray(pseudo) && pseudo.length > 0 && (
+              <a className="btn" href="#pseudocode">
+                Pseudocode
+              </a>
+            )}
+            {code && (
+              <a className="btn" href="#reference">
+                Reference
+              </a>
+            )}
+          </div>
         </div>
       </header>
 
-      <section className="stats-grid" aria-label="Key properties">
-        <article className="stat-card">
-          <h3>Time Complexity</h3>
-          <p><strong>Avg/Worst:</strong> {info.timeComplexity}</p>
-          <p><strong>Best:</strong> {info.bestCase}</p>
-        </article>
+      {/* KEY PROPERTIES */}
+      <section className="doc-section" aria-label="Key properties">
+        <h2>Key Properties</h2>
+        <div className="stats-grid">
+          <article className="stat-card">
+            <h3>⚡ Time Complexity</h3>
+            <p>
+              <strong>Avg/Worst:</strong> {info.timeComplexity}
+            </p>
+            <p>
+              <strong>Best:</strong> {info.bestCase}
+            </p>
+          </article>
 
-        <article className="stat-card">
-          <h3>Space</h3>
-          <p><strong>{info.spaceComplexity}</strong></p>
-        </article>
+          <article className="stat-card">
+            <h3>💾 Space</h3>
+            <p>
+              <strong>{info.spaceComplexity}</strong>
+            </p>
+          </article>
 
-        <article className="stat-card">
-          <h3>Stable</h3>
-          <p><strong>{normalizeStable(info.stable)}</strong></p>
-        </article>
+          <article className="stat-card">
+            <h3>🔄 Stable</h3>
+            <p>
+              <strong>{normalizeStable(info.stable)}</strong>
+            </p>
+          </article>
+
+          <article className="stat-card callout success">
+            <strong>Tip:</strong> Try the same input in the visualizer and see
+            how {title} behaves on nearly-sorted vs. reversed arrays.
+          </article>
+        </div>
       </section>
 
-      {pseudo?.length ? (
+      {/* PSEUDOCODE */}
+      {Array.isArray(pseudo) && pseudo.length > 0 && (
         <section id="pseudocode" className="doc-section">
           <h2>Pseudocode</h2>
-          <div className="pseudo-steps">
+          <div className="steps">
             {pseudo.map((step, i) => (
-              <div className="pseudo-step" key={i}>
-                <pre><code>{step.code}</code></pre>
-                {step.explain ? <p className="muted">{step.explain}</p> : null}
+              <div className="step" key={i}>
+                <div className="step-no">{i + 1}</div>
+                <div className="step-body">
+                  <pre>
+                    <code>{step.code}</code>
+                  </pre>
+                  {step.explain && <p className="muted">{step.explain}</p>}
+                </div>
               </div>
             ))}
           </div>
         </section>
-      ) : null}
+      )}
 
-      {code ? (
+      {/* REFERENCE */}
+      {code && (
         <section id="reference" className="doc-section">
-          <h2>Reference implementation</h2>
-
+          <h2>Reference Implementation</h2>
           {code.java && (
             <>
               <h3>Java</h3>
-              <pre><code>{code.java}</code></pre>
+              <pre>
+                <code>{code.java}</code>
+              </pre>
             </>
           )}
-
           {code.python && (
             <>
               <h3>Python</h3>
-              <pre><code>{code.python}</code></pre>
+              <pre>
+                <code>{code.python}</code>
+              </pre>
             </>
           )}
-
           {code.cpp && (
             <>
               <h3>C++</h3>
-              <pre><code>{code.cpp}</code></pre>
+              <pre>
+                <code>{code.cpp}</code>
+              </pre>
             </>
           )}
         </section>
-      ) : null}
+      )}
 
+      {/* CTA */}
       <section className="doc-section center">
-        <Link to="/sorting" className="btn primary lg">Try in Visualizer</Link>
+        <div className="callout success">
+          Ready to experiment? Try small arrays (n ≤ 10) first, then scale up
+          and compare {title} with other algorithms.
+        </div>
+        <Link to="/sorting" className="btn primary lg">
+          Try in Visualizer
+        </Link>
       </section>
     </div>
   );

--- a/src/styles/SortingDoc.css
+++ b/src/styles/SortingDoc.css
@@ -296,3 +296,37 @@ summary:focus {
   outline-offset: 2px;
   border-radius: 10px;
 }
+
+/* SortingDoc light tweaks (only when app is light) */
+html[data-theme="light"] .doc-page {
+  --bg: #ffffff;
+  --surface: #f8fafc;
+  --surface-2: #eef2f7;
+  --text: #0f172a;
+  --text-muted: #475569;
+  --primary: #2563eb;
+  --primary-contrast: #ffffff;
+  --border: #e2e8f0;
+  --success-bg: #e7f7ef;
+  --success-text: #176c3a;
+  --code-bg: #f1f5f9;
+  --code-text: #1e293b;
+  --shadow: 0 8px 22px rgba(2, 6, 23, 0.08);
+}
+
+/* SortingDoc dark tweaks (only when app is dark) */
+html[data-theme="dark"] .doc-page {
+  --bg: #0b1220;
+  --surface: #0f172a;
+  --surface-2: #131c2f;
+  --text: #e5e7eb;
+  --text-muted: #94a3b8;
+  --primary: #8ab4ff;
+  --primary-contrast: #0b1220;
+  --border: #243049;
+  --success-bg: #0d2a1a;
+  --success-text: #77d39a;
+  --code-bg: #0b1020;
+  --code-text: #e5e7eb;
+  --shadow: 0 8px 22px rgba(0, 0, 0, 0.4);
+}


### PR DESCRIPTION
## Which issue does this PR close?

Closes #701 

## Rationale for this change

The sorting visualizer already had implementations, but learners could not access algorithm explanations, pseudocode, or reference code directly from the UI.  
This PR introduces proper documentation pages for all sorting algorithms, improving the overall learning experience.

## What changes are included in this PR?

- Added documentation support for **9 sorting algorithms**:
  - Bubble Sort
  - Selection Sort
  - Insertion Sort
  - Merge Sort
  - Quick Sort
  - Tim Sort
  - Intro Sort
  - Shell Sort
  - Cycle Sort
- Connected algorithm cards → docs page using `SortingDoc.jsx`
- Styled docs page with **theme-aware UI** (light + dark mode supported)
- Added learner-friendly features:
  - Key properties grid (time, space, stable)
  - Step-by-step pseudocode
  - Reference implementations in Java, Python, and C++
  - Tips & callouts to guide learners

## Are these changes tested?

- Verified locally:
  - Each sorting card routes correctly to its documentation page
  - Docs render properly in both light and dark themes
  - Pseudocode and reference code blocks display without errors
- Manual testing across all 9 algorithms

## Are there any user-facing changes?

Yes:
- Users can now **click any sorting algorithm** card to view its documentation.
- Documentation includes description, pseudocode, complexity, and reference implementations.
- UI adapts to light/dark themes for accessibility.


https://github.com/user-attachments/assets/1a5c0fc7-b78a-4be3-9075-d97c19513e45

<img width="1918" height="972" alt="image" src="https://github.com/user-attachments/assets/eed43e9f-ef7e-4b93-a9d3-a70979bc0c53" />

<img width="1918" height="947" alt="image" src="https://github.com/user-attachments/assets/89921637-e429-4562-aa5f-7454bfaceb5d" />

<img width="1918" height="972" alt="image" src="https://github.com/user-attachments/assets/ad98f81f-922b-426d-8b4e-12075c0478b2" />

continues for 
   - Merge Sort
  - Quick Sort
  - Tim Sort
  - Intro Sort
  - Shell Sort
  - Cycle Sort

