### PR TITLE
Fix: Navbar now visible on initial page load (Closes #710)

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -22,8 +22,6 @@ import {
   Menu,
 } from "lucide-react";
 import { useTheme } from "../ThemeContext";
-import AOS from "aos";
-import "aos/dist/aos.css";
 import { navbarNavigationItems } from "../utils/navigation";
 
 const Navbar = () => {
@@ -37,29 +35,28 @@ const Navbar = () => {
   const location = useLocation();
   const { theme } = useTheme();
   const navbarRef = useRef(null);
-
   const searchRef = useRef(null);
 
   // Map string icon names to actual icon components
   const getIconComponent = (iconName) => {
     const iconMap = {
-      "Home": Home,
-      "BarChart3": BarChart3,
-      "Search": Search,
-      "Database": Database,
-      "GitBranch": GitBranch,
-      "Users": Users,
-      "Trophy": Trophy,
-      "Settings": Settings,
-      "Type": Type,
-      "BookOpen": BookOpen,
-      "Cpu": Cpu,
-      "Code": Code,
-      "Hash": Hash,
-      "Zap": Zap,
-      "Gamepad": Gamepad,
-      "TreeDeciduous": TreeDeciduous,
-      "Menu": Menu
+      Home,
+      BarChart3,
+      Search,
+      Database,
+      GitBranch,
+      Users,
+      Trophy,
+      Settings,
+      Type,
+      BookOpen,
+      Cpu,
+      Code,
+      Hash,
+      Zap,
+      Gamepad,
+      TreeDeciduous,
+      Menu,
     };
     return iconMap[iconName] || null;
   };
@@ -124,17 +121,14 @@ const Navbar = () => {
   }, []);
 
   return (
-    <nav
-      className={`navbar ${theme}`}
-      ref={navbarRef}
-      data-aos="fade-down"
-      data-aos-duration="1000"
-    >
+    <nav className={`navbar ${theme}`} ref={navbarRef}>
       <div className="navbar-container">
         {/* Logo */}
         <Link to="/" className="navbar-logo">
           <img src="/logo.jpg" alt="AlgoVisualizer Logo" className="logo-img" />
-          <span className="logo-text">Algo<span>Visualizer</span></span>
+          <span className="logo-text">
+            Algo<span>Visualizer</span>
+          </span>
         </Link>
 
         {/* Search Bar */}
@@ -184,14 +178,22 @@ const Navbar = () => {
             item.dropdown ? (
               <div key={index} className="navbar-item dropdown">
                 <button
-                  className={`dropdown-toggle ${isDropdownOpen === index ? "active" : ""}`}
+                  className={`dropdown-toggle ${
+                    isDropdownOpen === index ? "active" : ""
+                  }`}
                   onClick={() => handleDropdownToggle(index)}
                 >
-                  {item.icon && React.createElement(getIconComponent(item.icon), { size: 18, className: "drop-icon" })}
+                  {item.icon &&
+                    React.createElement(getIconComponent(item.icon), {
+                      size: 18,
+                      className: "drop-icon",
+                    })}
                   <span>{item.label}</span>
                   <ChevronDown
                     size={16}
-                    className={`dropdown-arrow ${isDropdownOpen === index ? "rotated" : ""}`}
+                    className={`dropdown-arrow ${
+                      isDropdownOpen === index ? "rotated" : ""
+                    }`}
                   />
                 </button>
                 {isDropdownOpen === index && (
@@ -200,7 +202,9 @@ const Navbar = () => {
                       <Link
                         key={subIndex}
                         to={subItem.path}
-                        className={`dropdown-item ${isActive(subItem.path) ? "active" : ""}`}
+                        className={`dropdown-item ${
+                          isActive(subItem.path) ? "active" : ""
+                        }`}
                         onClick={() => setIsDropdownOpen(null)}
                       >
                         {subItem.label}
@@ -213,9 +217,15 @@ const Navbar = () => {
               <Link
                 key={index}
                 to={item.path}
-                className={`navbar-link ${isActive(item.path) ? "active" : ""}`}
+                className={`navbar-link ${
+                  isActive(item.path) ? "active" : ""
+                }`}
               >
-                {item.icon && React.createElement(getIconComponent(item.icon), { size: 18, className: "icon" })}
+                {item.icon &&
+                  React.createElement(getIconComponent(item.icon), {
+                    size: 18,
+                    className: "icon",
+                  })}
                 <span>{item.label}</span>
               </Link>
             )


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #710

## Rationale for this change

Previously, the navbar was hidden on first page load and only appeared after the user scrolled slightly.  
This was caused by `data-aos="fade-down"` (AOS animation) which sets `opacity: 0` until a scroll event.  
Users should always see navigation options immediately when landing on the site.

### Before

https://github.com/user-attachments/assets/cdefaa78-07f7-4f9a-838e-c9d771b4b510

### After
Navbar is visible right away on load, with consistent sticky/fixed behavior.

https://github.com/user-attachments/assets/36a94e41-525c-47fb-ade5-c9b888cae945


## What changes are included in this PR?

- Removed `data-aos="fade-down"` from the `<nav>` element in `Navbar.jsx` so it does not rely on scroll to render.
- Added a CSS safeguard in `Navbar.css`:
  ```css
  /* Ensure navbar never hidden by AOS */
  .navbar[data-aos] {
    opacity: 1 !important;
    transform: none !important;
  }
