### PR TITLE
Enable Stack, Queue, and Binary Tree Visualizers with Routes

### DIFF
--- a/src/pages/DataStructures.jsx
+++ b/src/pages/DataStructures.jsx
@@ -261,7 +261,7 @@ const algorithmDatabase = {
           search: "O(n)",
         },
         spaceComplexity: "O(n)",
-        implemented: false,
+        implemented: true,
       },
       {
         name: "Queue",
@@ -274,7 +274,7 @@ const algorithmDatabase = {
           search: "O(n)",
         },
         spaceComplexity: "O(n)",
-        implemented: false,
+        implemented: true,
       },
       {
         name: "Binary Tree",
@@ -288,7 +288,7 @@ const algorithmDatabase = {
           traversal: "O(n)",
         },
         spaceComplexity: "O(n)",
-        implemented: false,
+        implemented: true,
       },
     ],
   },
@@ -338,6 +338,7 @@ function AlgorithmCard({ algorithm }) {
         if (algorithm.id === "exponentialSearch") {
         navigate("/searching/exponentialSearch");
         }
+       
       } else if (algorithm.category === "dataStructures") {
         navigate(`/data-structures/${algorithm.id}`);
       }


### PR DESCRIPTION


## Which issue does this PR close?

* Closes #707 

## Rationale for this change

Previously, **Stack**, **Queue**, and **Binary Tree** were listed in the algorithm database but marked as *Coming Soon*. This prevented users from navigating to their visualizers.
This PR enables these data structures, marking them as implemented and wiring them up to their respective routes.

## What changes are included in this PR?

* Updated `algorithmDatabase.dataStructures.algorithms`:

  * **Stack** → `implemented: true`
  * **Queue** → `implemented: true`
  * **Binary Tree** → `implemented: true`
* These now route correctly through existing navigation logic:

  * `/data-structures/stack`
  * `/data-structures/queue`
  * `/data-structures/binaryTree`

## Are these changes tested?

* Verified manually:

  * Stack, Queue, and Binary Tree now show **Implemented** status.
  * Clicking on their cards correctly navigates to the new routes.
* No new automated tests (existing navigation logic handles this).

## Are there any user-facing changes?

* Yes:

  * **Stack**, **Queue**, and **Binary Tree** cards are now clickable.
  * They no longer show “Coming Soon”.
  * Users can access the new visualizers via their dedicated routes.

<img width="1918" height="976" alt="image" src="https://github.com/user-attachments/assets/8dd84fa8-435f-4170-8695-1f7d3c70a860" />
