### PR TITLE
fixed navbar #703

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -77,7 +77,7 @@ import CodeEditor from "./pages/CodeEditor";
 import AOS from "aos";
 import "aos/dist/aos.css";
 import "./styles/components.css";
-
+import LearnLanding from "./pages/LearnLanding";
 const App = () => {
   const location = useLocation();
   const selectedAlgorithm = "bubbleSort";
@@ -153,6 +153,7 @@ const App = () => {
               <Route path="/branchbound" element={<BranchBoundPage />} />
               <Route path="/string-overview" element={<StringOverview />} />
               <Route path="/string" element={<StringPage />} />
+              
 
               {/* Other Pages */}
               <Route path="/quiz" element={<Quiz />} />
@@ -174,6 +175,8 @@ const App = () => {
               <Route path="/notes/java" element={<Navigate to="/notes/java/fundamentals" replace />} />
               <Route path="/notes/java/fundamentals" element={<Fundamentals />} />
               <Route path="/notes/java/variables-and-data-types" element={<VariablesAndDataTypes />} />
+              <Route path="/learn" element={<LearnLanding />} />
+              <Route path="/settings" element={<Settings />} />
             </Routes>
 
             {/* Show ComplexityBox only on selected pages */}

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -10,14 +10,19 @@ import {
   Trophy,
   Settings,
   X,
+  Type,
   ChevronDown,
   BookOpen,
+  Cpu,
   Code,
+  Hash,
+  Zap,
+  Gamepad,
+  TreeDeciduous,
   Menu,
 } from "lucide-react";
 import { useTheme } from "../ThemeContext";
-import AOS from "aos";
-import "aos/dist/aos.css";
+import { navbarNavigationItems } from "../utils/navigation";
 
 const Navbar = () => {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
@@ -32,20 +37,76 @@ const Navbar = () => {
   const navbarRef = useRef(null);
   const searchRef = useRef(null);
 
+  // Map string icon names to actual icon components
+  const getIconComponent = (iconName) => {
+    const iconMap = {
+      Home,
+      BarChart3,
+      Search,
+      Database,
+      GitBranch,
+      Users,
+      Trophy,
+      Settings,
+      Type,
+      BookOpen,
+      Cpu,
+      Code,
+      Hash,
+      Zap,
+      Gamepad,
+      TreeDeciduous,
+      Menu,
+    };
+    return iconMap[iconName] || null;
+  };
+
+  // Detect mobile screen
   useEffect(() => {
     const handleResize = () => {
-      setIsMobile(window.innerWidth <= 768);
-      if (window.innerWidth > 768) setIsMobileMenuOpen(false);
+      const mobile = window.innerWidth <= 768;
+      setIsMobile(mobile);
+      if (!mobile) setIsMobileMenuOpen(false);
     };
     handleResize();
     window.addEventListener("resize", handleResize);
     return () => window.removeEventListener("resize", handleResize);
   }, []);
 
-  useEffect(() => {
-    AOS.init({ duration: 1000, once: true });
-  }, []);
+  const isActive = (path) => location.pathname === path;
 
+  const handleDropdownToggle = (index) => {
+    setIsDropdownOpen(isDropdownOpen === index ? null : index);
+  };
+
+  // Handle live search
+  const handleSearch = (query) => {
+    setSearchQuery(query);
+    if (!query.trim()) {
+      setSearchResults([]);
+      setIsSearchOpen(false);
+      return;
+    }
+
+    const results = [];
+    navbarNavigationItems.forEach((item) => {
+      if (item.label.toLowerCase().includes(query.toLowerCase()) && item.path) {
+        results.push({ path: item.path, label: item.label });
+      }
+      if (item.dropdown) {
+        item.dropdown.forEach((subItem) => {
+          if (subItem.label.toLowerCase().includes(query.toLowerCase())) {
+            results.push({ path: subItem.path, label: subItem.label });
+          }
+        });
+      }
+    });
+
+    setSearchResults(results);
+    setIsSearchOpen(results.length > 0);
+  };
+
+  // Close dropdowns & search on click outside
   useEffect(() => {
     const handleClickOutside = (event) => {
       if (navbarRef.current && !navbarRef.current.contains(event.target)) {
@@ -59,106 +120,18 @@ const Navbar = () => {
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
 
-  const navigationItems = [
-    { path: "/", icon: Home, label: "Home" },
-    {
-      label: "Sorting",
-      icon: BarChart3,
-      dropdown: [
-        { path: "/sorting", label: "Overview" },
-        { path: "/sorting/comparison", label: "Algorithm Comparison" },
-      ],
-    },
-    {
-      label: "Searching",
-      icon: Search,
-      dropdown: [
-        { path: "/searchingOverview", label: "Overview" },
-        { path: "/searching", label: "Searching Algorithm" },
-        { path: "/searching/comparison", label: "Algorithm Comparison" },
-      ],
-    },
-    {
-      label: "Data Structures",
-      icon: Database,
-      dropdown: [
-        { path: "/data-structures", label: "Overview" },
-        { path: "/data-structures/linked-list", label: "Linked List" },
-        { path: "/data-structures/queue", label: "Queue" },
-        { path: "/data-structures/stack", label: "Stack" },
-        { path: "/binary-tree", label: "Binary Tree" },
-      ],
-    },
-    {
-      label: "Graph",
-      icon: GitBranch,
-      dropdown: [
-        { path: "/graph", label: "Overview" },
-        { path: "/graph/bfs", label: "BFS" },
-        { path: "/graph/dfs", label: "DFS" },
-        { path: "/graph/dijkstra", label: "Dijkstra" },
-        { path: "/graph/comparison", label: "Graph Comparison" },
-      ],
-    },
-    {
-      label: "Java Notes",
-      icon: BookOpen,
-      dropdown: [
-        { path: "/notes/java/fundamentals", label: "Fundamentals" },
-        { path: "/notes/java/variables-and-data-types", label: "Variables & Data Types" },
-      ],
-    },
-    { path: "/editor", icon: Code, label: "Code Editor" },
-    { path: "/quiz", icon: Trophy, label: "Quiz" },
-    {
-      label: "Community",
-      icon: Users,
-      dropdown: [
-        { path: "/community", label: "Overview" },
-        { path: "/contributors", label: "Contributors" },
-        { path: "/contributor-leaderboard", label: "Leaderboard" },
-      ],
-    },
-    { path: "/settings", icon: Settings, label: "Settings" },
-  ];
-
-  const isActive = (path) => location.pathname === path;
-  const handleDropdownToggle = (index) =>
-    setIsDropdownOpen(isDropdownOpen === index ? null : index);
-
-  const handleSearch = (query) => {
-    setSearchQuery(query);
-    if (!query.trim()) {
-      setSearchResults([]);
-      setIsSearchOpen(false);
-      return;
-    }
-    const results = [];
-    navigationItems.forEach((item) => {
-      if (item.label.toLowerCase().includes(query.toLowerCase()) && item.path) {
-        results.push({ path: item.path, label: item.label });
-      }
-      if (item.dropdown) {
-        item.dropdown.forEach((subItem) => {
-          if (subItem.label.toLowerCase().includes(query.toLowerCase())) {
-            results.push({ path: subItem.path, label: subItem.label });
-          }
-        });
-      }
-    });
-    setSearchResults(results);
-    setIsSearchOpen(results.length > 0);
-  };
-
   return (
-    <nav className={`navbar ${theme}`} ref={navbarRef} data-aos="fade-down">
+    <nav className={`navbar ${theme}`} ref={navbarRef}>
       <div className="navbar-container">
+        {/* Logo */}
         <Link to="/" className="navbar-logo">
           <img src="/logo.jpg" alt="AlgoVisualizer Logo" className="logo-img" />
-          <span className="logo-text">Algo<span>Visualizer</span></span>
+          <span className="logo-text">
+            Algo<span>Visualizer</span>
+          </span>
         </Link>
 
-        {/* Search */}
+        {/* Search Bar */}
         <div className="navbar-search" ref={searchRef}>
           <input
             type="text"
@@ -179,126 +152,85 @@ const Navbar = () => {
               <X size={16} />
             </button>
           )}
+          <Search size={18} className="search-icon" />
           {isSearchOpen && (
             <div className="search-results">
-              {searchResults.length > 0 ? (
-                searchResults.map((item, index) => (
-                  <Link
-                    key={index}
-                    to={item.path}
-                    className="search-result-item"
-                    onClick={() => setIsSearchOpen(false)}
-                  >
-                    {item.label}
-                  </Link>
-                ))
-              ) : (
+              {searchResults.map((item, index) => (
+                <Link
+                  key={index}
+                  to={item.path}
+                  className="search-result-item"
+                  onClick={() => setIsSearchOpen(false)}
+                >
+                  {item.label}
+                </Link>
+              ))}
+              {searchResults.length === 0 && (
                 <div className="search-no-results">No results found</div>
               )}
             </div>
           )}
         </div>
 
-        {/* Mobile Button */}
-        {isMobile && (
-          <button
-            className="mobile-menu-button"
-            onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
-            aria-label={isMobileMenuOpen ? "Close menu" : "Open menu"}
-          >
-            {isMobileMenuOpen ? <X size={24} /> : <Menu size={24} />}
-          </button>
-        )}
-
-        {/* Desktop Menu */}
-        {!isMobile && (
-          <div className="navbar-menu">
-            {navigationItems.map((item, index) =>
-              item.dropdown ? (
-                <div key={index} className="navbar-item dropdown">
-                  <button
-                    className={`dropdown-toggle ${isDropdownOpen === index ? "active" : ""}`}
-                    onClick={() => handleDropdownToggle(index)}
-                  >
-                    <item.icon size={18} className="drop-icon" />
-                    <span>{item.label}</span>
-                    <ChevronDown size={16} className={`dropdown-arrow ${isDropdownOpen === index ? "rotated" : ""}`} />
-                  </button>
-                  {isDropdownOpen === index && (
-                    <div className="dropdown-menu">
-                      {item.dropdown.map((subItem, subIndex) => (
-                        <Link
-                          key={subIndex}
-                          to={subItem.path}
-                          className={`dropdown-item ${isActive(subItem.path) ? "active" : ""}`}
-                          onClick={() => setIsDropdownOpen(null)}
-                        >
-                          {subItem.label}
-                        </Link>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              ) : (
-                <Link
-                  key={index}
-                  to={item.path}
-                  className={`navbar-link ${isActive(item.path) ? "active" : ""}`}
+        {/* Desktop Navigation */}
+        <div className="navbar-menu">
+          {navbarNavigationItems.map((item, index) =>
+            item.dropdown ? (
+              <div key={index} className="navbar-item dropdown">
+                <button
+                  className={`dropdown-toggle ${
+                    isDropdownOpen === index ? "active" : ""
+                  }`}
+                  onClick={() => handleDropdownToggle(index)}
                 >
-                  <item.icon size={18} className="icon" />
+                  {item.icon &&
+                    React.createElement(getIconComponent(item.icon), {
+                      size: 18,
+                      className: "drop-icon",
+                    })}
                   <span>{item.label}</span>
-                </Link>
-              )
-            )}
-          </div>
-        )}
-
-        {/* Mobile Menu */}
-        {isMobile && isMobileMenuOpen && (
-          <div className="mobile-menu">
-            {navigationItems.map((item, index) =>
-              item.dropdown ? (
-                <div key={index} className="mobile-dropdown">
-                  <button
-                    className={`mobile-dropdown-toggle ${isDropdownOpen === index ? "active" : ""}`}
-                    onClick={() => handleDropdownToggle(index)}
-                  >
-                    <item.icon size={18} className="icon" />
-                    <span>{item.label}</span>
-                    <ChevronDown size={16} className={`dropdown-arrow ${isDropdownOpen === index ? "rotated" : ""}`} />
-                  </button>
-                  {isDropdownOpen === index && (
-                    <div className="mobile-dropdown-menu">
-                      {item.dropdown.map((subItem, subIndex) => (
-                        <Link
-                          key={subIndex}
-                          to={subItem.path}
-                          className={`mobile-dropdown-item ${isActive(subItem.path) ? "active" : ""}`}
-                          onClick={() => {
-                            setIsDropdownOpen(null);
-                            setIsMobileMenuOpen(false);
-                          }}
-                        >
-                          {subItem.label}
-                        </Link>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              ) : (
-                <Link
-                  key={index}
-                  to={item.path}
-                  className={`mobile-menu-link ${isActive(item.path) ? "active" : ""}`}
-                  onClick={() => setIsMobileMenuOpen(false)}
-                >
-                  <item.icon size={18} className="icon" />
-                  <span>{item.label}</span>
-                </Link>
-              )
-            )}
-          </div>
-        )}
+                  <ChevronDown
+                    size={16}
+                    className={`dropdown-arrow ${
+                      isDropdownOpen === index ? "rotated" : ""
+                    }`}
+                  />
+                </button>
+                {isDropdownOpen === index && (
+                  <div className="dropdown-menu">
+                    {item.dropdown.map((subItem, subIndex) => (
+                      <Link
+                        key={subIndex}
+                        to={subItem.path}
+                        className={`dropdown-item ${
+                          isActive(subItem.path) ? "active" : ""
+                        }`}
+                        onClick={() => setIsDropdownOpen(null)}
+                      >
+                        {subItem.label}
+                      </Link>
+                    ))}
+                  </div>
+                )}
+              </div>
+            ) : (
+              <Link
+                key={index}
+                to={item.path}
+                className={`navbar-link ${
+                  isActive(item.path) ? "active" : ""
+                }`}
+              >
+                {item.icon &&
+                  React.createElement(getIconComponent(item.icon), {
+                    size: 18,
+                    className: "icon",
+                  })}
+                <span>{item.label}</span>
+              </Link>
+            )
+          )}
+        </div>
       </div>
     </nav>
   );

--- a/src/styles/navbar.css
+++ b/src/styles/navbar.css
@@ -387,3 +387,27 @@
   border-color: rgba(15,23,42,.08);
 }
 .navbar.light .feature-desc { color: #3a4253; }
+/* Make navbar always visible at the top */
+.navbar {
+  position: sticky;  /* or fixed */
+  top: 0;
+  z-index: 1200;     /* higher than mega-menu & search results */
+}
+/* === NAVBAR FIX === */
+.navbar {
+  position: fixed;     /* lock it to the viewport */
+  top: 0;              /* stick to the top */
+  left: 0;
+  right: 0;
+  width: 100%;
+  z-index: 2000;       /* above everything (mega-menu, search, etc.) */
+  background: var(--navbar-bg, rgba(17,18,22,0.92)); /* dark bg fallback */
+  backdrop-filter: blur(8px); /* keep your nice glass effect */
+  -webkit-backdrop-filter: blur(8px);
+}
+
+/* push page content down so navbar doesn’t overlap */
+body {
+  margin: 0;
+  padding-top: 72px; /* adjust to your navbar’s actual height */
+}

--- a/src/utils/navigation.js
+++ b/src/utils/navigation.js
@@ -11,7 +11,7 @@ export const navbarNavigationItems = [
   { path: "/", label: "Home", icon: "Home" },
   { path: "/learn", label: "Learn", icon: "BookOpen" }, // ← simple link now
   { path: "/quiz", label: "Quiz", icon: "Trophy" },
-  { path: "/ContributorLeaderboard", label: "Contributors", icon: "Users" },
+  { path: "/contributor-leaderboard", label: "Contributors", icon: "Users" },
   { path: "/data-structures", label: "Documentation", icon: "BookOpen" },
   { path: "/settings", label: "Settings", icon: "Settings" },
 ];


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #703  

## Rationale for this change

The navbar was previously overloaded and buggy:
- None of the top-nav items (Home, Sorting, Searching, Data Structures, Graph, etc.) navigated correctly.
- The active tab highlight updated, but routes did not change.
- Dropdowns were large, cluttered, and unintuitive, making the navbar "traffic-heavy".

This PR resolves the navigation bug and **introduces a dedicated `/learn` landing page**.  
By moving all educational/visualization links into this page, the navbar becomes clean and lightweight while still giving users full access to all learning materials.

## What changes are included in this PR?

- ✅ Fixed broken `Navbar` links so that navigation now updates the URL and renders the correct page.  
- ✅ Simplified navbar structure: replaced dropdown-heavy design with a single **"Learn"** link.  
- ✅ Created new **`LearnLanding` page**:
  - Organized content into cards (Data Structures, Sorting, Searching, Graphs, Paradigms, Other Topics).
  - Added search bar to quickly filter topics.
  - Added featured callout (e.g., Binary Tree Visualizer).
  - Full dark/light theme support for readability.
  - Staggered animations and hover effects for creative, stepwise exploration.

## Are these changes tested?

- Manually tested navigation for all top-level and section links.
- Verified `/learn` page renders all sections and search works correctly.
- Checked both dark and light themes for readability.
- Tested responsiveness (desktop, tablet, mobile widths).

## Are there any user-facing changes?

- Yes:
  - Navbar is now lighter: only high-level entries (Home, Learn, Quiz, Contributors, Documentation, Settings).
  - New `/learn` page centralizes all learning material in an organized, visually engaging layout.
  - Users can now navigate correctly to Sorting, Searching, Data Structures, Graphs, etc.
  - Improved dark theme readability (true-black background, high-contrast text).

These are **non-breaking UX improvements** and make navigation intuitive.

## before : 
<img width="1918" height="933" alt="image" src="https://github.com/user-attachments/assets/651ac9c8-8033-423a-bae9-67c7302b8ac9" />

## after : 
<img width="1917" height="972" alt="image" src="https://github.com/user-attachments/assets/a5088449-5c6b-4cdd-8bf5-4b30db2fc179" />
### learn page :
<img width="1918" height="953" alt="image" src="https://github.com/user-attachments/assets/bd19fe23-8fdf-4d0f-9859-11edd44f776e" />

