### PR TITLE
Add Python Notes Feature

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,3 +1,4 @@
+// src/App.jsx
 import React, { useEffect } from "react";
 import { Route, Routes, useLocation, Navigate } from "react-router-dom";
 import { Analytics } from "@vercel/analytics/react";
@@ -32,6 +33,10 @@ import CommunityLanding from "./pages/CommunityLanding";
 // Java Notes
 import Fundamentals from "./pages/Notes/Java/Fundamentals";
 import VariablesAndDataTypes from "./pages/Notes/Java/VariablesAndDataTypes";
+
+// ✅ Python Notes
+import PythonFundamentals from "./pages/Notes/Python/Fundamentals";
+import PythonVariablesAndDataTypes from "./pages/Notes/Python/VariablesAndDataTypes";
 
 // Algorithm Pages
 import DPOverview from "./pages/DPOverview";
@@ -174,6 +179,11 @@ const App = () => {
               <Route path="/notes/java" element={<Navigate to="/notes/java/fundamentals" replace />} />
               <Route path="/notes/java/fundamentals" element={<Fundamentals />} />
               <Route path="/notes/java/variables-and-data-types" element={<VariablesAndDataTypes />} />
+
+              {/* ✅ Python Notes */}
+              <Route path="/notes/python" element={<Navigate to="/notes/python/fundamentals" replace />} />
+              <Route path="/notes/python/fundamentals" element={<PythonFundamentals />} />
+              <Route path="/notes/python/variables-and-data-types" element={<PythonVariablesAndDataTypes />} />
             </Routes>
 
             {/* Show ComplexityBox only on selected pages */}

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -108,6 +108,14 @@ const Navbar = () => {
         { path: "/notes/java/variables-and-data-types", label: "Variables & Data Types" },
       ],
     },
+    {
+  label: "Python Notes",
+  icon: BookOpen,
+  dropdown: [
+    { path: "/notes/python/variables-and-data-types", label: "Variables & Data Types" },
+    { path: "/notes/python/fundamentals", label: "Fundamentals" },
+  ],
+},
     { path: "/editor", icon: Code, label: "Code Editor" },
     { path: "/quiz", icon: Trophy, label: "Quiz" },
     {

--- a/src/pages/Notes/Python/Fundamentals.jsx
+++ b/src/pages/Notes/Python/Fundamentals.jsx
@@ -1,0 +1,57 @@
+import React from "react";
+
+const PythonFundamentals = () => {
+  return (
+    <div className="notes-page" style={{ padding: "2rem", maxWidth: "900px", margin: "0 auto" }}>
+      <h1 style={{ textAlign: "center", marginBottom: "1.5rem", color: "#4f46e5" }}>
+        Python Fundamentals
+      </h1>
+
+      <section style={{ marginBottom: "1.5rem" }}>
+        <h2 style={{ color: "#111827" }}>1. Introduction to Python</h2>
+        <ul>
+          <li>Python is a high-level, interpreted, general-purpose programming language.</li>
+          <li>Known for its simplicity and readability, widely used in web development, data science, AI, and automation.</li>
+          <li>Runs line by line using the Python interpreter (no compilation step).</li>
+        </ul>
+      </section>
+
+      <section style={{ marginBottom: "1.5rem" }}>
+        <h2 style={{ color: "#111827" }}>2. Key Features</h2>
+        <ul>
+          <li>Dynamic typing (no need to declare variable types explicitly).</li>
+          <li>Rich standard library with extensive modules and packages.</li>
+          <li>Supports multiple paradigms – object-oriented, functional, and procedural.</li>
+          <li>Cross-platform and open source.</li>
+        </ul>
+      </section>
+
+      <section style={{ marginBottom: "1.5rem" }}>
+        <h2 style={{ color: "#111827" }}>3. Basic Syntax</h2>
+        <ul>
+          <li>Indentation defines code blocks (not braces `{}` like Java/C++).</li>
+          <li>Case-sensitive language.</li>
+          <li>Comments use <code>#</code> for single-line, and triple quotes <code>"""..."""</code> for multi-line.</li>
+        </ul>
+      </section>
+
+      <section style={{ marginBottom: "1.5rem" }}>
+        <h2 style={{ color: "#111827" }}>4. Example Code</h2>
+        <pre
+          style={{
+            background: "#1f2937",
+            color: "#f9fafb",
+            padding: "1rem",
+            borderRadius: "6px",
+            overflowX: "auto"
+          }}
+        >
+{`# Hello World in Python
+print("Hello, Python!")`}
+        </pre>
+      </section>
+    </div>
+  );
+};
+
+export default PythonFundamentals;

--- a/src/pages/Notes/Python/VariablesAndDataTypes.jsx
+++ b/src/pages/Notes/Python/VariablesAndDataTypes.jsx
@@ -1,0 +1,70 @@
+import React from "react";
+
+const PythonVariablesAndDataTypes = () => {
+  return (
+    <div className="notes-page" style={{ padding: "2rem", maxWidth: "900px", margin: "0 auto" }}>
+      <h1 style={{ textAlign: "center", marginBottom: "1.5rem", color: "#4f46e5" }}>
+        Python Variables and Data Types
+      </h1>
+
+      <section style={{ marginBottom: "1.5rem" }}>
+        <h2 style={{ color: "#111827" }}>1. Variables</h2>
+        <ul>
+          <li>No need to declare type explicitly – Python infers it automatically.</li>
+          <li>Variable names must start with a letter or underscore, not numbers.</li>
+          <li>Variables are dynamically typed (can change type at runtime).</li>
+        </ul>
+        <pre
+          style={{
+            background: "#1f2937",
+            color: "#f9fafb",
+            padding: "1rem",
+            borderRadius: "6px",
+            overflowX: "auto"
+          }}
+        >
+{`x = 10       # Integer
+name = "Ada"  # String
+pi = 3.14     # Float
+is_valid = True  # Boolean`}
+        </pre>
+      </section>
+
+      <section style={{ marginBottom: "1.5rem" }}>
+        <h2 style={{ color: "#111827" }}>2. Data Types</h2>
+        <ul>
+          <li><b>Numeric:</b> int, float, complex</li>
+          <li><b>Sequence:</b> str, list, tuple, range</li>
+          <li><b>Mapping:</b> dict</li>
+          <li><b>Set Types:</b> set, frozenset</li>
+          <li><b>Boolean:</b> bool</li>
+          <li><b>Binary Types:</b> bytes, bytearray, memoryview</li>
+        </ul>
+      </section>
+
+      <section style={{ marginBottom: "1.5rem" }}>
+        <h2 style={{ color: "#111827" }}>3. Example Code</h2>
+        <pre
+          style={{
+            background: "#1f2937",
+            color: "#f9fafb",
+            padding: "1rem",
+            borderRadius: "6px",
+            overflowX: "auto"
+          }}
+        >
+{`# Different data types in Python
+a = 42            # int
+b = 3.14          # float
+c = "Python"      # string
+d = [1, 2, 3]     # list
+e = (4, 5, 6)     # tuple
+f = {"name": "Ada", "age": 25}  # dict
+g = {1, 2, 3}     # set`}
+        </pre>
+      </section>
+    </div>
+  );
+};
+
+export default PythonVariablesAndDataTypes;


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #734

## Rationale for this change

This PR introduces Python Fundamentals notes to align with the existing Java Fundamentals module.  
It helps learners who prefer Python to easily access structured learning materials like variables, data types, and control flow basics within the same platform.  

## What changes are included in this PR?

- Added a new `PythonFundamentals.jsx` file under `src/pages/Notes/Python/`.
- Added routing for Python Fundamentals in `App.jsx`.
- Updated the Navbar to include a Python Fundamentals link.
- Provided example content covering Python basics (variables, data types, etc.).

## Are these changes tested?

- Verified that the Python Fundamentals page renders correctly.  
- Checked navigation from the Navbar to the new page.  
- Manual testing confirmed links and content work as expected.  

## Are there any user-facing changes?

- Yes, users will now see a **Python Fundamentals** option in the Navbar.  
- Clicking the link opens a new page with Python basic notes.  

<img width="1920" height="949" alt="Screenshot (737)" src="https://github.com/user-attachments/assets/8af4ed1b-f9f7-4d73-97e1-cbb3ec0e9e5a" />


@RhythmPahwa14 Fixes Issue #734 number