### PR TITLE
fix: improve ComplexityBox dark mode, unify chart styles, and disable Recharts hover cursor (closes #722 & #717)

### DIFF
--- a/src/components/ComplexityBox.jsx
+++ b/src/components/ComplexityBox.jsx
@@ -222,6 +222,16 @@ const ComplexityBox = ({ algorithm }) => {
     document.documentElement.getAttribute("data-theme") === "dark"
   );
 
+  // react to theme changes after mount
+  useEffect(() => {
+    const el = document.documentElement;
+    const update = () => setIsDarkMode(el.getAttribute("data-theme") === "dark");
+    const observer = new MutationObserver(update);
+    observer.observe(el, { attributes: true, attributeFilter: ["data-theme"] });
+    update();
+    return () => observer.disconnect();
+  }, []);
+
   // keep dropdown in sync when parent prop changes
   useEffect(() => {
     if (algorithm && KEY_MAP[algorithm]) setAlgo(KEY_MAP[algorithm]);
@@ -252,11 +262,18 @@ const ComplexityBox = ({ algorithm }) => {
         </select>
       </div>
       <div className="chart-wrapper">
-        <ResponsiveContainer width="100%" height={300}>
+          <ResponsiveContainer width="100%" height={300}>
           <BarChart data={chartData} barSize={60}>
-            <XAxis dataKey="name" stroke={isDarkMode ? "#9ca3af" : "#6b7280"} />
-            <YAxis stroke={isDarkMode ? "#9ca3af" : "#6b7280"} />
-            <Tooltip content={<CustomTooltip />} />
+            <XAxis
+              dataKey="name"
+              stroke={isDarkMode ? "#94a3b8" : "#6b7280"}
+              tick={{ fill: isDarkMode ? "#cbd5e1" : "#6b7280" }}
+            />
+            <YAxis
+              stroke={isDarkMode ? "#94a3b8" : "#6b7280"}
+              tick={{ fill: isDarkMode ? "#cbd5e1" : "#6b7280" }}
+            />
+            <Tooltip content={<CustomTooltip />} cursor={false} />
             <Bar dataKey="value" radius={[10, 10, 0, 0]}>
               {chartData.map((entry, index) => (
                 <Cell

--- a/src/components/complexityBox.css
+++ b/src/components/complexityBox.css
@@ -152,3 +152,34 @@
 .complexity-container.force-dark .recharts-bar-rectangle path:hover {
   filter: drop-shadow(0px 0px 10px rgba(255, 255, 255, 0.4));
 }
+/* default (light theme) */
+.complexity-container {
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 16px;
+  color: #111827;
+}
+
+/* force dark mode */
+.complexity-container.force-dark {
+  background: #111827;     /* dark background */
+  border-color: #374151;   /* subtle dark border */
+  color: #e5e7eb;          /* readable text */
+}
+
+.complexity-container.force-dark .complexity-title,
+.complexity-container.force-dark .complexity-subtitle {
+  color: #e5e7eb;
+}
+
+.complexity-container.force-dark select {
+  background: #1f2937;
+  color: #f9fafb;
+  border: 1px solid #374151;
+}
+:root[data-theme="dark"] .complexity-container {
+  background: #111827;
+  border-color: #374151;
+  color: #e5e7eb;
+}

--- a/src/styles/UnifiedVisualizer.css
+++ b/src/styles/UnifiedVisualizer.css
@@ -70,6 +70,9 @@
   font-size: 10px;
   font-weight: bold;
 }
+.array-bar {
+  background-color: initial !important; /* lets their own color rules win */
+}
 
 .bar-default {
   background-color: #007bff;

--- a/src/styles/global-dark-theme.css
+++ b/src/styles/global-dark-theme.css
@@ -20,13 +20,7 @@ body,
     transition: background 0.25s ease, color 0.25s ease;
 }
 
-/* Force all container backgrounds to be transparent */
-div,
-section,
-main,
-article {
-    background-color: transparent !important;
-}
+
 
 /* Global text styling */
 p, h1, h2, h3, h4, h5, h6, span, a {


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #722 
- Closes #717 
## Rationale for this change

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/75c14b84-3063-4abb-a373-6b90708b8f2f" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/c470a118-302b-47cd-a94a-524ab631bed2" />

The ComplexityBox component did not fully support dark mode and showed an unwanted grey hover background on bars. This reduced readability and made the component visually inconsistent compared to the rest of the app.  

## What changes are included in this PR?

- Disabled Recharts’ default hover cursor highlight on bars (`cursor={false}`)
- Added dark mode styles for the ComplexityBox container, dropdowns, and chart wrapper
- Themed axis labels, ticks, and borders for dark mode readability
- Synced `isDarkMode` state with `data-theme` using a `MutationObserver`
- Updated `UnifiedVisualizer.css` and `global-dark-theme.css` for consistent backgrounds and text

## Are these changes tested?

- Verified locally in both light and dark themes
- Confirmed that switching themes updates the ComplexityBox live
- Tested hover and click interactions to ensure no background overlay remains

## Are there any user-facing changes?

- Bars no longer show a grey hover background
- ComplexityBox now correctly adapts to dark mode (background, text, chart, dropdowns)
