### PR TITLE
Fix: Fix Linked List Visualization Responsiveness on Mobile(in data structures->linked list page)

### DIFF
--- a/src/components/LinkedList/LinkedListVisualizer.jsx
+++ b/src/components/LinkedList/LinkedListVisualizer.jsx
@@ -646,8 +646,8 @@ const LinkedListVisualizer = () => {
       <div className="theme-card" style={{ marginTop: '2rem' }}>
         <div className="theme-card-header">
           <h3>Linked List Operations - Code Implementation</h3>
-          <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap', alignItems: 'center' }}>
-            <div style={{ display: 'flex', gap: '0.5rem' }}>
+          <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap', alignItems: 'center', justifyContent: 'center' }}>
+            <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
               <button
                 className={`btn ${selectedLanguage === 'java' ? 'btn-primary' : 'btn-secondary'}`}
                 onClick={() => setSelectedLanguage('java')}
@@ -699,8 +699,6 @@ const LinkedListVisualizer = () => {
           background: 'var(--surface-bg)',
           borderRadius: '8px',
           padding: '1.5rem',
-          overflow: 'auto',
-          maxHeight: '500px'
         }}>
           <pre style={{
             margin: 0,

--- a/src/styles/LinkedList.css
+++ b/src/styles/LinkedList.css
@@ -271,10 +271,16 @@
   padding: 2rem;
   border-bottom: 1px solid var(--border-color);
   display: flex;
+  flex-direction: column;
   justify-content: space-between;
   align-items: center;
   flex-wrap: wrap;
   gap: 1.5rem;
+}
+
+.header-content {
+  flex-direction: column;
+  text-align: center;
 }
 
 .header-content h1 {
@@ -296,6 +302,7 @@
 
 .header-stats {
   display: flex;
+  flex-wrap: wrap;
   gap: 1rem;
 }
 
@@ -499,12 +506,16 @@
   margin: 0;
   padding: 2rem;
   min-height: 500px;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
 }
 
 .visualization-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  text-align: center;
   margin-bottom: 2rem;
   padding-bottom: 1rem;
   border-bottom: 1px solid var(--border-color);
@@ -565,7 +576,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  overflow-x: auto;
+  max-width: 100%;
 }
 
 .nodes-container {
@@ -573,7 +584,7 @@
   align-items: center;
   gap: 1.5rem;
   padding: 1rem;
-  min-width: min-content;
+  overflow-x: auto;
 }
 
 /* Empty State */
@@ -758,7 +769,6 @@
   }
   
   .nodes-container {
-    flex-direction: column;
     align-items: center;
   }
   

--- a/src/styles/Sorting.css
+++ b/src/styles/Sorting.css
@@ -445,6 +445,7 @@ body {
 
 .theme-card-header {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
   padding-bottom: 8px;


### PR DESCRIPTION
Closes #544.

## Changes included in this PR

For smaller screen widths, contents of algorithm header and theme card in the linked list page are no longer overflowing.
Also fixed the linked list visualisation container and implemented the horizontal scrolling functionality for the nodes as needed in the issue. 
Made the code in the theme card to take full height so that the vertical scroll bar is no longer needed for small screens.
Other minor UI changes to make the page more visually appealing and responsive.