### PR TITLE
feat: improve Matrix Chain visualization with focus highlight and persistent result box

### DIFF
--- a/src/styles/global-theme.css
+++ b/src/styles/global-theme.css
@@ -1380,5 +1380,22 @@ body {
   white-space: nowrap;
   color: var(--header-text-color);
 }
+.cell.is-focus {
+  outline: 2px solid #f59e0b;  /* amber for splits */
+  outline-offset: -2px;
+  background-color: #fbbf24 !important;
+  color: #111;
+  font-weight: bold;
+}
+.result-box {
+  margin-top: 12px;
+  padding: 8px 12px;
+  background: rgba(16, 185, 129, 0.1); /* teal tint */
+  border: 1px solid rgba(16, 185, 129, 0.3);
+  border-radius: 6px;
+  font-size: 0.95rem;
+  color: #d1fae5;
+}
+
 
 /*  */


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #719

## Rationale for this change

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/2508bc51-7a65-401e-a532-8a0a84fa1aef" />

The Matrix Chain Multiplication visualization was previously incomplete:
- Users could see the DP cost table filling, but there was no clear indication of which cell was being updated.
- The optimal parenthesization (actual order of multiplications) was not shown, so the result was less instructive.
- The result disappeared after the animation completed, making it harder to reference the final answer.

These changes make the visualization clearer, more interactive, and user-friendly.

## What changes are included in this PR?

- Added focus highlighting to show the exact DP cell being updated during each step.
- Extended `matrixChain` to track split points (`k`) and reconstruct the optimal parenthesization.
- Displayed both the **minimum cost** and the **optimal multiplication order** in a persistent result box that remains visible after the animation completes.
- Updated styles to support `.is-focus` highlighting and a result box with consistent theme colors.

## Are these changes tested?

- Verified locally by running the Matrix Chain visualization:
  - Each DP update highlights the correct cell.
  - Messages show the chosen split `k` during computation.
  - After completion, the persistent result box displays the final cost and parenthesization correctly.
- Other algorithms (Fibonacci, Coin Change, LCS, Knapsack) remain unaffected.

## Are there any user-facing changes?

- Yes.  
  - Users now see a highlighted focus cell as the DP table fills.  
  - At the end of the visualization, a result box remains on screen showing both the minimum cost and the optimal parenthesization (e.g. `((A1 x A2) x A3)`).  
  - Improves clarity and educational value of the Matrix Chain visualization.
