### PR TITLE
Using appropriate social icons for social links instead of same ones

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -210,21 +210,7 @@ const Footer = () => {
     { href: "https://nodejs.org/", label: "Node.js" },
   ];
 
-  // Icon mapping helper
-  const getIconComponent = (iconName) => {
-    const iconMap = {
-      "FaRocket": FaRocket,
-      "FaCode": FaCode,
-      "FaGraduationCap": FaGraduationCap,
-      "FaEnvelope": FaEnvelope,
-      "FaGithub": FaGithub,
-      "FaLinkedin": FaLinkedin,
-      "FaXTwitter": FaXTwitter,
-      "FaDiscord": FaDiscord,
-      "FaYoutube": FaYoutube,
-    };
-    return iconMap[iconName] || FaGraduationCap;
-  };
+  
 
   return (
     <>
@@ -294,14 +280,15 @@ const Footer = () => {
                 <FooterLink 
                   key={index} 
                   to={link.to} 
-                  icon={getIconComponent(link.icon)}
+                  icon={link.icon}
                 >
+              
                   {link.label}
                 </FooterLink>
               ))}
             </ul>
           </div>
-
+             
           {/* Resources */}
           <div
             className="footer-column resources-column"
@@ -315,7 +302,7 @@ const Footer = () => {
                 <FooterLink 
                   key={index} 
                   to={link.to} 
-                  icon={getIconComponent(link.icon)}
+                  icon={link.icon}
                 >
                   {link.label}
                 </FooterLink>
@@ -349,7 +336,7 @@ const Footer = () => {
                 <SocialLink
                   key={index}
                   href={link.href}
-                  icon={getIconComponent(link.icon)}
+                  icon={link.icon}
                   title={link.title}
                 />
               ))}


### PR DESCRIPTION

## Which issue does this PR close?

- Closes #930 .

## Rationale for this change

- Ensures proper use of distinct social icons for better UI clarity and user experience.

- Prevents confusion where different social media links had the same icon, making navigation harder.

- Simplifies the code by removing redundant getIconComponent logic.

## What changes are included in this PR?

- Removed getIconComponent helper function.

- Updated socialLinks, navigationLinks, and resourceLinks rendering to directly use icon components instead of passing them through a converter.

- Fixed footer UI to display the correct icons for each link.

## Are these changes tested?

✅ Yes, tested manually by running the application and verifying that each footer link displays the correct icon.
- No automated tests are included since this is a visual/UI fix.

## Are there any user-facing changes?

- Yes. Users will now see the correct icons (GitHub, LinkedIn, Twitter, Discord, YouTube, etc.) for each corresponding footer link.
- No breaking changes.

<img width="1857" height="562" alt="Screenshot 2025-10-02 164815" src="https://github.com/user-attachments/assets/7ac407f3-83e6-4a94-bf96-a08d97e96f52" />
