### PR TITLE
Fix: Ensure quiz screen scrolls to top on start

### DIFF
--- a/src/components/QuizManager.jsx
+++ b/src/components/QuizManager.jsx
@@ -180,6 +180,13 @@ const QuizManager = () => {
     return () => clearTimeout(timer);
   }, [timeRemaining, timedMode, currentStep, isPaused]);
 
+  // 🔹 Scroll fix
+useEffect(() => {
+  if (currentStep === QUIZ_STEPS.QUIZ) {
+    window.scrollTo(0, 0);
+  }
+}, [currentStep]);
+
   const startQuiz = (topic, difficulty, timed = false) => {
     // Filter and shuffle questions
     let filteredQuestions = QuizHelpers.filterAndShuffleQuestions(quizQuestions, topic, difficulty);


### PR DESCRIPTION
*Related Issue*:
Closes #911 

**Bug**:
When a user selected a topic and clicked Start Quiz, the new quiz screen sometimes opened at a random/middle position instead of at the top. This created a confusing user experience.

**Fix Implemented**:
Added a useEffect in QuizManager.jsx that triggers window.scrollTo(0,0) when the quiz step changes to QUIZ.
This ensures the quiz screen always loads from the top.

https://github.com/user-attachments/assets/290161d1-abe0-47b2-84bc-24bd9237abea





****Result****:
Now the quiz screen consistently starts at the top, improving navigation and overall UX.