### PR TITLE
Add Contribution LeaderBoard

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -81,6 +81,8 @@ import DSDocumentation from "./pages/DSDocumentation";
 // Dynamic Notes Page
 import NotesPage from "./pages/Notes/NotesPage";
 
+import ContributorBoard from "./pages/ContributorBoard";
+
 const App = () => {
   const location = useLocation();
   const selectedAlgorithm = "bubbleSort";
@@ -184,6 +186,8 @@ const App = () => {
                 path="/notes/:language"
                 element={<Navigate to="/notes/:language/fundamentals" replace />}
               />
+
+              <Route path="/contributor-board" element={<ContributorBoard />} />
 
               {/* Learning & Settings */}
               <Route path="/learn" element={<LearnLanding />} />

--- a/src/data/contributors.jsx
+++ b/src/data/contributors.jsx
@@ -1,0 +1,6 @@
+export const contributors = [
+  { id: 1, name: "Aryan ", commits: 50, content: 30, quizPoints: 80 },
+  { id: 2, name: "krish", commits: 60, content: 20, quizPoints: 70 },
+  { id: 3, name: "John Doe", commits: 40, content: 50, quizPoints: 90 },
+  { id: 4, name: "Jane Smith", commits: 70, content: 25, quizPoints: 60 },
+];

--- a/src/pages/ContributorBoard.jsx
+++ b/src/pages/ContributorBoard.jsx
@@ -1,0 +1,78 @@
+import React, { useState } from "react";
+import { contributors as initialContributors } from "../data/contributors";
+
+const ContributorBoard = () => {
+  const [sortBy, setSortBy] = useState("commits");
+  const [order, setOrder] = useState("desc");
+
+  // Sorting logic
+  const sortedContributors = [...initialContributors].sort((a, b) => {
+    if (order === "asc") return a[sortBy] - b[sortBy];
+    else return b[sortBy] - a[sortBy];
+  });
+
+  return (
+    <div className="p-4 max-w-4xl mx-auto">
+      <h2 className="text-2xl font-bold mb-4 text-center">🏆 Top Contributors</h2>
+
+      {/* Sort Controls */}
+      <div className="flex flex-wrap gap-4 justify-center mb-6">
+        <label className="flex items-center gap-2">
+          <span className="font-medium">Sort by:</span>
+          <select
+            value={sortBy}
+            onChange={(e) => setSortBy(e.target.value)}
+            className="border px-3 py-1 rounded-md shadow-sm"
+          >
+            <option value="commits">Commits</option>
+            <option value="content">Content</option>
+            <option value="quizPoints">Quiz Points</option>
+          </select>
+        </label>
+
+        <label className="flex items-center gap-2">
+          <span className="font-medium">Order:</span>
+          <select
+            value={order}
+            onChange={(e) => setOrder(e.target.value)}
+            className="border px-3 py-1 rounded-md shadow-sm"
+          >
+            <option value="desc">Descending</option>
+            <option value="asc">Ascending</option>
+          </select>
+        </label>
+      </div>
+
+      {/* Leaderboard Table */}
+      <div className="overflow-x-auto">
+        <table className="w-full border-collapse border border-gray-300 rounded-lg overflow-hidden shadow">
+          <thead>
+            <tr className="bg-gray-100 text-gray-700">
+              <th className="border px-4 py-2 text-left">Name</th>
+              <th className="border px-4 py-2 text-center">Commits</th>
+              <th className="border px-4 py-2 text-center">Content</th>
+              <th className="border px-4 py-2 text-center">Quiz Points</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sortedContributors.map((c, index) => (
+              <tr
+                key={c.id}
+                className={`${
+                  index < 3 ? "bg-yellow-100 font-semibold" : index % 2 === 0 ? "bg-white" : "bg-gray-50"
+                }`}
+              >
+                <td className="border px-4 py-2">{c.name}</td>
+                <td className="border px-4 py-2 text-center">{c.commits}</td>
+                <td className="border px-4 py-2 text-center">{c.content}</td>
+                <td className="border px-4 py-2 text-center">{c.quizPoints}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default ContributorBoard;


### PR DESCRIPTION
Which issue does this PR close?

Closes #946

Rationale for this change

The Contributor Leaderboard was previously static, making it difficult to see contributors ranked by their impact.
This change introduces a dynamic leaderboard with sorting and ordering options, improving transparency and engagement in the community.

What changes are included in this PR?

Added a new ContributorBoard.jsx page.

Integrated data from contributors.js.

Implemented sorting by Commits, Content, and Quiz Points.

Added ascending/descending toggle for sorting order.

Highlighted top contributors visually for better recognition.

Added new route /contributor-board to App.jsx.

Are these changes tested?

Yes, manually tested in the dev environment:

Sorting by commits, content, and quiz points works correctly.

Order toggle updates the leaderboard dynamically.

Top contributors are highlighted.

Are there any user-facing changes?

✅ New page available at /contributor-board.

✅ New link can optionally be added to the navigation menu.

✅ Users can sort/filter leaderboard dynamically.


@RhythmPahwa14 Fixes the assign issue #946 number 

<img width="1920" height="968" alt="Screenshot (749)" src="https://github.com/user-attachments/assets/149c5736-6f5f-4602-a2b8-4e4aa8551125" />
