### PR TITLE
Add Advanced Contribution LeaderBoard

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -81,6 +81,7 @@ import DSDocumentation from "./pages/DSDocumentation";
 // Dynamic Notes Page
 import NotesPage from "./pages/Notes/NotesPage";
 
+// import ContributorBoard from "./pages/ContributorBoard";
 import ContributorBoard from "./pages/ContributorBoard";
 
 const App = () => {
@@ -188,6 +189,8 @@ const App = () => {
               />
 
               <Route path="/contributor-board" element={<ContributorBoard />} />
+              <Route path="/contributor-leaderboard" element={<ContributorBoard />} />
+
 
               {/* Learning & Settings */}
               <Route path="/learn" element={<LearnLanding />} />

--- a/src/data/contributors.jsx
+++ b/src/data/contributors.jsx
@@ -1,6 +1,26 @@
 export const contributors = [
-  { id: 1, name: "Aryan ", commits: 50, content: 30, quizPoints: 80 },
-  { id: 2, name: "krish", commits: 60, content: 20, quizPoints: 70 },
-  { id: 3, name: "John Doe", commits: 40, content: 50, quizPoints: 90 },
-  { id: 4, name: "Jane Smith", commits: 70, content: 25, quizPoints: 60 },
+  {
+    id: 1,
+    name: "Alice",
+    avatar: "https://i.pravatar.cc/150?img=1",
+    commits: 120,
+    content: 30,
+    quizPoints: 200,
+    history: [
+      { date: "2025-09-28", commits: 5, content: 1, quizPoints: 20 },
+      { date: "2025-09-29", commits: 10, content: 0, quizPoints: 15 },
+    ],
+  },
+  {
+    id: 2,
+    name: "Bob",
+    avatar: "https://i.pravatar.cc/150?img=2",
+    commits: 80,
+    content: 50,
+    quizPoints: 150,
+    history: [
+      { date: "2025-09-28", commits: 3, content: 2, quizPoints: 10 },
+      { date: "2025-09-29", commits: 6, content: 1, quizPoints: 20 },
+    ],
+  },
 ];

--- a/src/pages/ContributorBoard.jsx
+++ b/src/pages/ContributorBoard.jsx
@@ -1,18 +1,45 @@
 import React, { useState } from "react";
 import { contributors as initialContributors } from "../data/contributors";
 
+// Helpers for points and levels
+const calculatePoints = (c) => c.commits * 0.4 + c.content * 0.3 + c.quizPoints * 0.3;
+const getLevel = (points) => {
+  if (points >= 601) return "Platinum 🏅";
+  if (points >= 301) return "Gold 🥇";
+  if (points >= 101) return "Silver 🥈";
+  return "Bronze 🥉";
+};
+
+// Assign badges
+const assignBadges = (contributors) => {
+  const badges = {};
+  if (contributors.length === 0) return badges;
+
+  const topCommitter = [...contributors].sort((a, b) => b.commits - a.commits)[0];
+  const quizMaster = [...contributors].sort((a, b) => b.quizPoints - a.quizPoints)[0];
+  const contentCreator = [...contributors].sort((a, b) => b.content - a.content)[0];
+
+  badges[topCommitter.id] = (badges[topCommitter.id] || []).concat("Top Committer 🔥");
+  badges[quizMaster.id] = (badges[quizMaster.id] || []).concat("Quiz Master 🧠");
+  badges[contentCreator.id] = (badges[contentCreator.id] || []).concat("Content Creator ✍️");
+
+  return badges;
+};
+
 const ContributorBoard = () => {
   const [sortBy, setSortBy] = useState("commits");
   const [order, setOrder] = useState("desc");
+  const [selectedContributor, setSelectedContributor] = useState(null);
 
-  // Sorting logic
   const sortedContributors = [...initialContributors].sort((a, b) => {
     if (order === "asc") return a[sortBy] - b[sortBy];
     else return b[sortBy] - a[sortBy];
   });
 
+  const badgesMap = assignBadges(sortedContributors);
+
   return (
-    <div className="p-4 max-w-4xl mx-auto">
+    <div className="p-4 max-w-5xl mx-auto">
       <h2 className="text-2xl font-bold mb-4 text-center">🏆 Top Contributors</h2>
 
       {/* Sort Controls */}
@@ -45,32 +72,100 @@ const ContributorBoard = () => {
 
       {/* Leaderboard Table */}
       <div className="overflow-x-auto">
-        <table className="w-full border-collapse border border-gray-300 rounded-lg overflow-hidden shadow">
+        <table className="w-full border-collapse border border-gray-300 rounded-lg shadow">
           <thead>
             <tr className="bg-gray-100 text-gray-700">
               <th className="border px-4 py-2 text-left">Name</th>
               <th className="border px-4 py-2 text-center">Commits</th>
               <th className="border px-4 py-2 text-center">Content</th>
               <th className="border px-4 py-2 text-center">Quiz Points</th>
+              <th className="border px-4 py-2 text-center">Level</th>
+              <th className="border px-4 py-2 text-center">Badges</th>
             </tr>
           </thead>
           <tbody>
-            {sortedContributors.map((c, index) => (
-              <tr
-                key={c.id}
-                className={`${
-                  index < 3 ? "bg-yellow-100 font-semibold" : index % 2 === 0 ? "bg-white" : "bg-gray-50"
-                }`}
-              >
-                <td className="border px-4 py-2">{c.name}</td>
-                <td className="border px-4 py-2 text-center">{c.commits}</td>
-                <td className="border px-4 py-2 text-center">{c.content}</td>
-                <td className="border px-4 py-2 text-center">{c.quizPoints}</td>
-              </tr>
-            ))}
+            {sortedContributors.map((c, index) => {
+              const totalPoints = calculatePoints(c);
+              const level = getLevel(totalPoints);
+              const contributorBadges = badgesMap[c.id] || [];
+
+              return (
+                <tr
+                  key={c.id}
+                  className={`${
+                    index < 3 ? "bg-yellow-100 font-semibold" : index % 2 === 0 ? "bg-white" : "bg-gray-50"
+                  }`}
+                >
+                  <td
+                    className="border px-4 py-2 cursor-pointer text-blue-600 hover:underline"
+                    onClick={() => setSelectedContributor(c)}
+                  >
+                    {c.name}
+                  </td>
+                  <td className="border px-4 py-2 text-center">{c.commits}</td>
+                  <td className="border px-4 py-2 text-center">{c.content}</td>
+                  <td className="border px-4 py-2 text-center">{c.quizPoints}</td>
+                  <td className="border px-4 py-2 text-center font-medium">{level}</td>
+                  <td className="border px-4 py-2">
+                    {contributorBadges.length > 0
+                      ? contributorBadges.map((badge, i) => (
+                          <span
+                            key={i}
+                            className="bg-yellow-100 text-yellow-800 px-2 py-1 rounded-full text-xs mr-1"
+                          >
+                            {badge}
+                          </span>
+                        ))
+                      : <span className="text-gray-500 text-xs">No Badges</span>}
+                  </td>
+                </tr>
+              );
+            })}
           </tbody>
         </table>
       </div>
+
+      {/* Contributor Modal */}
+      {selectedContributor && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+          <div className="bg-white rounded-lg shadow-lg w-96 p-6 relative">
+            <button
+              className="absolute top-2 right-2 text-gray-600 hover:text-gray-900 font-bold"
+              onClick={() => setSelectedContributor(null)}
+            >
+              ✖
+            </button>
+            <div className="text-center">
+              <img
+                src={selectedContributor.avatar}
+                alt={selectedContributor.name}
+                className="w-24 h-24 rounded-full mx-auto mb-4"
+              />
+              <h3 className="text-xl font-bold mb-2">{selectedContributor.name}</h3>
+              <p className="mb-1">Level: {getLevel(calculatePoints(selectedContributor))}</p>
+              <p className="mb-2">Total Points: {calculatePoints(selectedContributor)}</p>
+              <div className="flex flex-wrap justify-center gap-2 mb-4">
+                {assignBadges([selectedContributor])[selectedContributor.id]?.map((badge, i) => (
+                  <span
+                    key={i}
+                    className="bg-yellow-100 text-yellow-800 px-2 py-1 rounded-full text-xs"
+                  >
+                    {badge}
+                  </span>
+                ))}
+              </div>
+              <h4 className="font-semibold mb-2">Contribution History:</h4>
+              <ul className="text-left text-sm max-h-48 overflow-y-auto">
+                {selectedContributor.history.map((h, i) => (
+                  <li key={i} className="border-b py-1">
+                    {h.date}: Commits {h.commits}, Content {h.content}, Quiz Points {h.quizPoints}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #958

## Rationale for this change

This PR implements personalized contributor profiles in the leaderboard to make the experience more interactive and engaging. Users can now click on a contributor’s name to view their avatar, total points, level, badges, and contribution history in a modal.

## What changes are included in this PR?

- Added `ContributorBoard.jsx` with interactive leaderboard  
- Updated `contributors.js` with avatars, levels, badges, and history  
- Integrated modal component for displaying personalized contributor details  
- Added new route `/contributor-leaderboard` in `App.jsx`  
- Updated styling using Tailwind for responsiveness  

## Are these changes tested?

- Manually tested in browser for modal functionality, sorting, and mobile responsiveness  
- Verified modal opens and closes correctly  
- Verified contributor details render properly from data file  

## Are there any user-facing changes?

- Yes, users now see an updated leaderboard at `/contributor-leaderboard`  
- Clicking a contributor opens a personalized profile modal  
- Enhanced UI with badges, levels, and contribution timeline  

@RhythmPahwa14 Fixes the assign issue #958 number 

<img width="1920" height="965" alt="Screenshot (753)" src="https://github.com/user-attachments/assets/8a4785e5-c036-4a63-ae05-1ee507cfd67e" />
