### PR TITLE
Move theme toggle button to top-right of navbar

### DIFF
--- a/src/components/ThemeToggle.jsx
+++ b/src/components/ThemeToggle.jsx
@@ -26,8 +26,8 @@ const ThemeToggle = () => {
      */
     const getContainerStyles = () => ({
         position: 'fixed',
-        left: '25px',
-        bottom: '25px',
+        top: '10px',
+        right: '25px',
         height: '55px',
         width: '55px',
         borderRadius: '50%',
@@ -39,8 +39,9 @@ const ThemeToggle = () => {
         transition: 'all 0.3s ease',
         border: `2px solid ${theme === 'dark' ? '#374151' : '#fbbf24'}`,
         boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',
-        zIndex: 1000
+        zIndex: 9999
     });
+
 
     /**
      * Get icon styles based on current theme


### PR DESCRIPTION
fixes #995 

This PR updates the position of the dark/light mode toggle button from the bottom-left corner to the top-right of the navbar. This improves usability and provides a more intuitive placement consistent with common UI patterns.

<img width="1885" height="943" alt="image" src="https://github.com/user-attachments/assets/93321c48-99a5-483a-b282-d16d90155eff" />
