### PR TITLE
Added Preorder Traversal in Documentation.jsx

### DIFF
--- a/src/pages/Documentation.jsx
+++ b/src/pages/Documentation.jsx
@@ -554,6 +554,14 @@ const algorithmDatabase = {
       spaceComplexity: "O(h) (where h is the height of the tree, O(n) in worst case for a skewed tree)",
       implemented: true,
     },
+    {
+      "name": "Preorder Traversal",
+      "id": "preorder-traversal",
+      "description": "Tree traversal method that visits the root node first, then the left subtree, and finally the right subtree (Root → Left → Right).",
+      "timeComplexity": { "best": "O(n)", "average": "O(n)", "worst": "O(n)" },
+      "spaceComplexity": "O(h) (where h is the height of the tree, O(n) in worst case for a skewed tree)",
+      "implemented": true
+    },    
   ],
 },
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #635.

## Rationale for this change
Preorder Traversal was missing from the documentation of tree traversal algorithms. Adding it improves the completeness of the documentation and helps users understand all common traversal methods.
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
Added a new entry for Preorder Traversal in the `algorithmDatabase` object inside `Documentation.jsx`
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
No new tests were added because this change only affects documentation data. Existing UI rendering tests cover this section.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
Yes, the documentation UI now includes Preorder Traversal under the Trees section, providing users with full information about this traversal method.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->