### PR TITLE
Fix stack visualization readability in light mode

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -182,38 +182,40 @@ const Navbar = () => {
               getIcon={getIcon}
             />
           ))}
+          
+          <div className="flex items-center gap-1">
+            {/* Notes desktop */}
+            <div className="navbar-item dropdown">
+              <button
+                className={`dropdown-toggle ${desktopNotesOpen ? "active" : ""}`}
+                onClick={() => setDesktopNotesOpen(!desktopNotesOpen)}
+              >
+                <BookOpen size={18} className="drop-icon" />
+                <span>Notes</span>
+                <ChevronDown size={16} className={`${desktopNotesOpen ? "rotated" : ""}`} />
+              </button>
+              {desktopNotesOpen && (
+                <div className="dropdown-menu">
+                  <Link
+                    to="/notes/java"
+                    className={`dropdown-item ${isActive("/notes/java") ? "active" : ""}`}
+                    onClick={() => setDesktopNotesOpen(false)}
+                  >
+                    Java
+                  </Link>
+                  <Link
+                    to="/notes/python"
+                    className={`dropdown-item ${isActive("/notes/python") ? "active" : ""}`}
+                    onClick={() => setDesktopNotesOpen(false)}
+                  >
+                    Python
+                  </Link>
+                </div>
+              )}
+            </div>
 
-          {/* Notes desktop */}
-          <div className="navbar-item dropdown">
-            <button
-              className={`dropdown-toggle ${desktopNotesOpen ? "active" : ""}`}
-              onClick={() => setDesktopNotesOpen(!desktopNotesOpen)}
-            >
-              <BookOpen size={18} className="drop-icon" />
-              <span>Notes</span>
-              <ChevronDown size={16} className={`${desktopNotesOpen ? "rotated" : ""}`} />
-            </button>
-            {desktopNotesOpen && (
-              <div className="dropdown-menu">
-                <Link
-                  to="/notes/java"
-                  className={`dropdown-item ${isActive("/notes/java") ? "active" : ""}`}
-                  onClick={() => setDesktopNotesOpen(false)}
-                >
-                  Java
-                </Link>
-                <Link
-                  to="/notes/python"
-                  className={`dropdown-item ${isActive("/notes/python") ? "active" : ""}`}
-                  onClick={() => setDesktopNotesOpen(false)}
-                >
-                  Python
-                </Link>
-              </div>
-            )}
+            <UserDropdown />
           </div>
-
-          <UserDropdown />
         </div>
 
         {/* Mobile Hamburger */}

--- a/src/components/Stack/Stack.css
+++ b/src/components/Stack/Stack.css
@@ -58,10 +58,14 @@
   text-align: center;
   transition: transform .2s ease, background .2s ease, box-shadow .2s ease;
   background: #1f1f1f;
+  color: #fff;            
+  font-weight: 500;      
 }
 .stack-item.top {
   outline: 2px solid #7c3aed;
   box-shadow: 0 0 12px rgba(124,58,237,.4);
+  background: #2a2a2a;   
+  color: #fff;          
 }
 .stack-item.peek {
   transform: translateY(-4px);

--- a/src/components/ThemeToggle.jsx
+++ b/src/components/ThemeToggle.jsx
@@ -26,10 +26,10 @@ const ThemeToggle = () => {
      */
     const getContainerStyles = () => ({
         position: 'fixed',
-        top: '10px',
-        right: '25px',
-        height: '55px',
-        width: '55px',
+        top: '15px',
+        right: '4px',
+        height: '40px',
+        width: '40px',
         borderRadius: '50%',
         backgroundColor: theme === 'dark' ? '#1f2937' : '#f59e0b',
         display: 'flex',


### PR DESCRIPTION
fixes #996 

Enhanced the stack item styles for light mode by ensuring proper text contrast and clearer top element highlighting. 

<img width="1192" height="750" alt="image" src="https://github.com/user-attachments/assets/4bf2f4e3-18ac-476e-8529-fa0abce27fa5" />


This makes pushed values easily visible and improves overall UX in stack visualization.
