### PR TITLE
Move social media icons to the left section under tech stack badges

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -218,6 +218,17 @@ const Footer = () => {
                 </TechPill>
               ))}
             </div>
+
+            <div className="social-links brand-social-links">
+              {socialLinks.map((link, index) => (
+                <SocialLink
+                  key={index}
+                  href={link.href}
+                  icon={link.icon}
+                  title={link.title}
+                />
+              ))}
+            </div>
           </div>
 
           {/* Quick Links */}
@@ -283,17 +294,6 @@ const Footer = () => {
               handleSubmit={handleSubmit}
               isSubscribed={isSubscribed}
             />
-
-            <div className="social-links">
-              {socialLinks.map((link, index) => (
-                <SocialLink
-                  key={index}
-                  href={link.href}
-                  icon={link.icon}
-                  title={link.title}
-                />
-              ))}
-            </div>
           </div>
         </div>
 

--- a/src/styles/footer.css
+++ b/src/styles/footer.css
@@ -84,6 +84,13 @@
   padding-right: 20px;
 }
 
+/* Social links in brand column */
+.brand-social-links {
+  display: flex;
+  gap: 15px;
+  margin-top: 20px;
+}
+
 /* Brand Section */
 .brand-header {
   margin-bottom: 25px;


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #613 

## Rationale for this change

-->Currently, all social media icons (GitHub, LinkedIn, X, Discord, YouTube) are placed on the right side under the “Stay Updated” section.
This layout creates slight visual imbalance and separates related content (the tech stack and social links).

## What changes are included in this PR?

-->Relocated all social media icons (GitHub, LinkedIn, X, Discord, YouTube) from the “Stay Updated” section to just below the tech stack badges.
-Adjusted spacing and alignment for better visual hierarchy.
-Maintained existing hover and clickable functionality for all icons.
-Ensured responsive layout remains intact across all viewports.

## Are these changes tested?

-->✅ Manually tested across desktop and mobile views to verify icon alignment and responsiveness.
-✅ Confirmed that hover effects and links for each social icon continue to function as expected.
-⚙️ No additional automated tests were required since this update only involves layout and UI adjustments.

## Are there any user-facing changes?

-->✅ Yes — users will now see the social media icons directly below the technology stack badges instead of under the “Stay Updated” section.
-🎨 The new placement improves visual balance and provides a more intuitive, unified footer design.

Screen shot
<img width="1901" height="870" alt="Screenshot (112)" src="https://github.com/user-attachments/assets/ce103f37-65e6-4af4-9d55-d6472d438d2a" />

Ma'am please review this PR and merge it @RhythmPahwa14 
