### PR TITLE
added trie visualizer algorithm

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -72,6 +72,7 @@ import LinkedListPage from "./components/pages/LinkedListPage";
 import Queue from "./components/Queue/Queue";
 import Stack from "./components/Stack/Stack";
 import BinaryTreeVisualizer from "./components/BinaryTree/BinaryTreeVisualizer";
+import TrieVisualizer from "./components/Trie/TrieVisualizer";
 import AlgorithmComparison from "./components/AlgorithmComparison";
 import GraphComparison from "./components/GraphComparison";
 import Contributors from "./components/Contributors";
@@ -156,6 +157,7 @@ const App = () => {
                   <Route path="/data-structures/queue" element={<Queue />} />
                   <Route path="/data-structures/stack" element={<Stack />} />
                   <Route path="/data-structures/binary-tree" element={<BinaryTreeVisualizer />} />
+                  <Route path="/data-structures/trie" element={<TrieVisualizer />} />
 
                   {/* Graph */}
                   <Route path="/graph" element={<Graph />} />

--- a/src/components/Trie/TrieVisualizer.css
+++ b/src/components/Trie/TrieVisualizer.css
@@ -1,0 +1,352 @@
+/* src/components/Trie/TrieVisualizer.css */
+
+:root{
+  --bg:#0b0f1a;
+  --surface:#0f1626;
+  --surface-2:#111b2d;
+  --border:#1d2b49;
+  --muted:#98a2b3;
+  --text:#eef2f8;
+  --primary:#5aa1ff;
+  --accent:#b485ff;
+  --edge:#334569;
+  --path:#ff6b6b;
+  --visited:#ffd166;
+  --end-word:#4ecdc4;
+}
+
+.tv-wrap{
+  width:100%;
+  margin:0 auto;
+  font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Helvetica Neue, Arial;
+  color:var(--text);
+}
+
+/* Trie Introduction Section */
+.tv-intro{
+  margin:12px;
+  padding:20px;
+  background:linear-gradient(135deg, rgba(90,161,255,0.1), rgba(180,133,255,0.1)), var(--surface);
+  border:1px solid var(--border);
+  border-radius:16px;
+  text-align:center;
+  box-shadow: 0 8px 24px rgba(0,0,0,.15);
+}
+
+.tv-intro-content{
+  max-width:800px;
+  margin:0 auto;
+}
+
+.tv-intro-title{
+  color:var(--text);
+  font-size:24px;
+  font-weight:700;
+  margin:0 0 12px 0;
+  background:linear-gradient(135deg, var(--primary), var(--accent));
+  -webkit-background-clip:text;
+  -webkit-text-fill-color:transparent;
+  background-clip:text;
+}
+
+.tv-intro-description{
+  color:var(--muted);
+  font-size:16px;
+  line-height:1.6;
+  margin:0 0 16px 0;
+}
+
+.tv-intro-features{
+  display:flex;
+  flex-wrap:wrap;
+  gap:8px;
+  justify-content:center;
+  align-items:center;
+}
+
+.tv-feature-tag{
+  padding:6px 12px;
+  background:#0b1426;
+  border:1px solid var(--border);
+  border-radius:20px;
+  font-size:13px;
+  font-weight:500;
+  color:var(--primary);
+  white-space:nowrap;
+}
+
+.tv-toolbar{
+  padding:12px;
+  margin:12px;
+  border-radius:16px;
+  background:linear-gradient(180deg, rgba(255,255,255,0.02), transparent), var(--surface);
+  box-shadow: 0 10px 30px rgba(0,0,0,.35), inset 0 1px 0 rgba(255,255,255,.06);
+  border:1px solid var(--border);
+}
+
+.tv-controls .tv-row{
+  display:grid;
+  grid-template-columns:1fr;
+  gap:12px;
+}
+@media (min-width:880px){
+  .tv-controls .tv-row{
+    grid-template-columns: 1fr 1fr 1fr;
+  }
+}
+
+.tv-card{
+  background:var(--surface-2);
+  border:1px solid var(--border);
+  border-radius:14px;
+  padding:12px;
+}
+.tv-card-title{
+  font-size:13px;
+  color:var(--muted);
+  margin-bottom:8px;
+  letter-spacing:.2px;
+}
+
+.tv-input-row{
+  display:flex;
+  gap:8px;
+  align-items:center;
+  flex-wrap:wrap;
+  margin-bottom:8px;
+}
+.tv-input{
+  flex:1 1 140px;
+  padding:12px 12px;
+  background:#0b1426;
+  border:1px solid var(--border);
+  border-radius:12px;
+  color:var(--text);
+  font-size:14px;
+}
+.tv-textarea{ min-height:64px; resize:vertical; }
+
+.tv-btn{
+  padding:11px 14px;
+  background:#0b1426;
+  color:var(--text);
+  border:1px solid var(--border);
+  border-radius:12px;
+  cursor:pointer;
+  transition:transform .05s ease, background .15s ease, border-color .15s ease;
+}
+.tv-btn:active{ transform:translateY(1px); }
+.tv-btn[disabled]{ opacity:.6; cursor:not-allowed; }
+.tv-primary{ border-color:var(--primary); background:rgba(90,161,255,.15); }
+.tv-accent{  border-color:var(--accent);  background:rgba(180,133,255,.16); }
+
+.tv-subtle{ color:var(--muted); font-size:12px; margin:4px 0 6px; }
+
+.tv-toggle-row{ display:flex; gap:10px; align-items:center; flex-wrap:wrap; margin-top:6px; }
+
+.tv-checkbox{ display:inline-flex; gap:8px; align-items:center; color:var(--muted); user-select:none; }
+
+.tv-speed{ display:flex; align-items:center; gap:10px; }
+.tv-speed-label{ color:var(--muted); font-size:12px; }
+
+.tv-hint{ margin-top:8px; color:var(--muted); font-size:12px; }
+
+.tv-actions{ display:flex; gap:8px; flex-wrap:wrap; }
+
+/* Canvas */
+.tv-canvas{
+  margin:12px;
+  background:var(--bg);
+  border:1px solid var(--border);
+  border-radius:16px;
+  overflow:hidden;
+  position:relative;
+}
+.tv-canvas.tv-shake{ animation:tv-shake .42s cubic-bezier(.36,.07,.19,.97) both; }
+@keyframes tv-shake{
+  10%,90%{ transform:translateX(-1px); }
+  20%,80%{ transform:translateX(2px); }
+  30%,50%,70%{ transform:translateX(-4px); }
+  40%,60%{ transform:translateX(4px); }
+}
+
+.tv-svg{ width:100%; height:clamp(320px, 56vh, 620px); display:block; }
+.tv-edge{ stroke:var(--edge); stroke-width:2; }
+
+.tv-node circle{
+  fill:#0f1933;
+  stroke:#2b3b61;
+  stroke-width:2;
+  filter: drop-shadow(0 8px 18px rgba(0,0,0,.35));
+  transition: transform .18s ease, fill .18s ease, stroke .18s ease;
+}
+.tv-node text{
+  fill:#eef2f8; font-weight:700; font-size:13px; text-anchor:middle;
+}
+.tv-node.is-active circle{ fill:rgba(90,161,255,.22); stroke:var(--primary); transform:scale(1.08); }
+.tv-node.in-path circle{ stroke:var(--path); }
+.tv-node.is-visited circle{ stroke:var(--visited); }
+.tv-node.is-end circle{ stroke:var(--end-word); stroke-width:3; }
+
+/* Legend */
+.tv-legend{
+  display:flex; gap:14px; align-items:center;
+  padding:12px 16px 18px;
+  color:var(--muted); font-size:13px;
+}
+.chip{ width:16px; height:8px; border-radius:999px; display:inline-block; margin-right:6px; background:var(--edge); }
+.chip-active{ background:var(--primary); }
+.chip-path{ background:var(--path); }
+.chip-visited{ background:var(--visited); }
+.chip-end{ background:var(--end-word); }
+
+/* Search Result */
+.tv-result{
+  margin: 4px 12px 18px;
+  padding: 12px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+}
+.tv-result-content{
+  font-size:14px;
+  color:var(--text);
+}
+
+/* Prefix Words */
+.tv-words{
+  margin: 4px 12px 18px;
+  padding: 12px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+}
+.tv-words-head{
+  display:flex; align-items:center; justify-content:space-between; gap:12px;
+  margin-bottom:10px;
+}
+.tv-words-title{ font-size:13px; color:var(--muted); letter-spacing:.2px; }
+
+.tv-words-list{
+  display:flex; flex-wrap:wrap; gap:8px; align-items:center;
+}
+.tv-word-pill{
+  padding:6px 10px;
+  background:#0b1426;
+  border:1px solid var(--border);
+  border-radius:999px;
+  font-weight:700; font-size:12px;
+}
+
+/* Info Toggle Button */
+.tv-info-toggle{
+  margin-left:12px;
+  padding:6px 12px;
+  background:#0b1426;
+  color:var(--text);
+  border:1px solid var(--border);
+  border-radius:8px;
+  cursor:pointer;
+  font-size:12px;
+  transition: background .15s ease, border-color .15s ease;
+}
+.tv-info-toggle:hover{ background:#0f1933; }
+
+/* Trie Explanation Section */
+.tv-explanation{
+  margin:12px;
+  padding:16px;
+  background:linear-gradient(180deg, rgba(255,255,255,0.02), transparent), var(--surface);
+  border:1px solid var(--border);
+  border-radius:14px;
+  box-shadow: 0 4px 12px rgba(0,0,0,.15);
+}
+
+.tv-explanation-content{
+  max-width:800px;
+  margin:0 auto;
+}
+
+.tv-explanation-title{
+  color:var(--text);
+  font-size:18px;
+  font-weight:600;
+  margin:0 0 12px 0;
+  text-align:center;
+}
+
+.tv-explanation-text{
+  color:var(--muted);
+  font-size:14px;
+  line-height:1.5;
+  margin:0 0 16px 0;
+  text-align:center;
+}
+
+.tv-explanation-subtitle{
+  color:var(--text);
+  font-size:16px;
+  font-weight:600;
+  margin:16px 0 8px 0;
+}
+
+.tv-explanation-list{
+  list-style: none;
+  padding:0;
+  margin:0 0 16px 0;
+}
+
+.tv-explanation-list li{
+  color:var(--muted);
+  font-size:14px;
+  line-height:1.4;
+  margin:6px 0;
+  padding:8px 12px;
+  background:#0b1426;
+  border:1px solid var(--border);
+  border-radius:8px;
+}
+
+.tv-explanation-list strong{
+  color:var(--primary);
+}
+
+.tv-explanation-note{
+  color:var(--accent);
+  font-size:13px;
+  font-style:italic;
+  text-align:center;
+  margin:12px 0 0 0;
+}
+
+.tv-explanation-workflow{
+  background:#0b1426;
+  border:1px solid var(--border);
+  border-radius:8px;
+  padding:12px;
+  margin:8px 0;
+}
+
+.tv-explanation-workflow p{
+  color:var(--primary);
+  font-weight:600;
+  margin:0 0 8px 0;
+}
+
+.tv-explanation-steps{
+  list-style: decimal;
+  padding-left:20px;
+  margin:0;
+}
+
+.tv-explanation-steps li{
+  color:var(--muted);
+  font-size:13px;
+  line-height:1.4;
+  margin:4px 0;
+}
+
+.tv-explanation-steps li::marker{
+  color:var(--accent);
+  font-weight:600;
+}

--- a/src/components/Trie/TrieVisualizer.jsx
+++ b/src/components/Trie/TrieVisualizer.jsx
@@ -1,0 +1,522 @@
+
+
+/**
+ * Trie (Prefix Tree) implementation with animation steps
+ *
+ * A Trie is a tree-like data structure used to store a dynamic set of strings.
+ * It is particularly efficient for operations involving prefixes, such as searching
+ * for words with a given prefix or autocomplete functionalities.
+ *
+ * Core Components:
+ * - TrieNode: Contains a Map of child nodes and an isEndOfWord flag
+ * - Root Node: Starting point for all operations (doesn't represent a character)
+ *
+ * Key Operations:
+ * - insert(word): Builds the trie structure for the word
+ * - search(word): Checks if the exact word exists
+ * - searchPrefix(prefix): Finds all words starting with the prefix
+ * - delete(word): Removes a word and cleans up unused nodes
+ *
+ * Each node represents a character in the alphabet.
+ */
+
+import React, { useState, useRef, useMemo } from "react";
+import { Trie } from "./trie";
+import { layoutTrie } from "./layout";
+import "./TrieVisualizer.css";
+
+export default function TrieVisualizer() {
+  // Core trie state - using a ref to avoid re-renders on every operation
+  const trieRef = useRef(null);
+  const [trieKey, setTrieKey] = useState(0); // Force re-render key
+
+  // Initialize trie
+  if (!trieRef.current) {
+    trieRef.current = new Trie();
+    trieRef.current.root.id = 0;
+  }
+
+  const trie = trieRef.current;
+
+  // UI state
+  const [word, setWord] = useState("");      // single ops
+  const [bulk, setBulk] = useState("");        // batch insert
+  const [animateInserts, setAnimateInserts] = useState(false);
+  const [stepMode, setStepMode] = useState(false);
+  const [speed, setSpeed] = useState(450);
+  const [isBusy, setIsBusy] = useState(false);
+  const [searchResult, setSearchResult] = useState(null); // null = no result, true/false = word search result
+  const [prefixResult, setPrefixResult] = useState(null); // null = no result, true/false = prefix search result
+  const [lastSearchedWord, setLastSearchedWord] = useState(""); // Store the word that was searched
+  const [prefixWords, setPrefixWords] = useState([]);
+  const [showExplanation, setShowExplanation] = useState(true); // Toggle for Trie explanation (default: shown)
+
+  // Animation state
+  const [activePath, setActivePath] = useState([]);
+  const [activeNodeId, setActiveNodeId] = useState(null);
+  const [visited, setVisited] = useState([]);
+  const [highlightedWords, setHighlightedWords] = useState([]);
+
+  // Layout
+  const laidOut = useMemo(() => layoutTrie(trie), [trieKey, trie.nodeIdCounter]);
+
+  // Step runner
+  const nextResolver = useRef(null);
+  function waitForNextClick() {
+    return new Promise((resolve) => { nextResolver.current = resolve; });
+  }
+  function handleNext() {
+    if (nextResolver.current) {
+      nextResolver.current();
+      nextResolver.current = null;
+    }
+  }
+
+  async function runWithSteps(steps, postApply) {
+    setIsBusy(true);
+    for (let i = 0; i < steps.length; i++) {
+      const s = steps[i];
+      if (s.type === "focus") {
+        setActiveNodeId(s.nodeId);
+        setActivePath((p) => (p[p.length - 1] === s.nodeId ? p : [...p, s.nodeId]));
+      } else if (s.type === "visit") {
+        setVisited((v) => (v[v.length - 1] === s.nodeId ? v : [...v, s.nodeId]));
+      } else if (s.type === "apply") {
+        // Force re-render after trie modification
+        setTrieKey(k => k + 1);
+        if (typeof postApply === "function") postApply();
+      }
+
+      if (stepMode) {
+        await waitForNextClick();
+      } else {
+        await new Promise((r) => setTimeout(r, speed));
+      }
+    }
+    if (typeof postApply === "function") postApply();
+    setIsBusy(false);
+  }
+
+  function resetHighlights() {
+    setActivePath([]);
+    setActiveNodeId(null);
+    setVisited([]);
+    setSearchResult();
+    setPrefixResult(null);
+    setLastSearchedWord("");
+    setPrefixWords([]);
+    setHighlightedWords([]);
+  }
+
+  // Operations
+  async function onInsert(e) {
+    e?.preventDefault?.();
+    if (word === "") return;
+
+    resetHighlights();
+    const { success, steps } = trie.insert(word);
+    if (success) {
+      await runWithSteps(steps);
+    }
+    setWord("");
+  }
+
+  async function onSearch(e) {
+    e?.preventDefault?.();
+    if (word === "") return;
+
+    resetHighlights();
+    const searchWord = word; // Store the word before it gets cleared
+    const { found, steps, substringIn } = trie.search(searchWord);
+
+    await runWithSteps(steps, () => {
+      setSearchResult(found);
+      if (!found) {
+        const wrap = document.querySelector(".tv-canvas");
+        wrap?.classList.add("tv-shake");
+        setTimeout(() => wrap?.classList.remove("tv-shake"), 420);
+      }
+    });
+
+    // Store which word contains the substring for display
+    if (found && substringIn) {
+      setLastSearchedWord(`${searchWord} (found in "${substringIn}")`);
+    } else {
+      setLastSearchedWord(searchWord);
+    }
+  }
+
+  async function onPrefixSearch(e) {
+    e?.preventDefault?.();
+    if (word === "") return;
+
+    resetHighlights();
+    const searchWord = word; // Store the word before it gets cleared
+    const { found, words, steps } = trie.searchPrefix(searchWord);
+
+    await runWithSteps(steps, () => {
+      if (found) {
+        setPrefixWords(words);
+        setHighlightedWords(words);
+      } else {
+        setSearchResult(false); // Show not found for prefix search too
+        const wrap = document.querySelector(".tv-canvas");
+        wrap?.classList.add("tv-shake");
+        setTimeout(() => wrap?.classList.remove("tv-shake"), 420);
+      }
+    });
+  }
+
+  async function onDelete(e) {
+    e?.preventDefault?.();
+    if (word === "") return;
+
+    resetHighlights();
+    const deleteWord = word; // Store the word before it gets cleared
+    const { deleted, steps, deletedWord } = trie.delete(deleteWord);
+
+    if (deleted) {
+      await runWithSteps(steps);
+      // Show which word was actually deleted
+      if (deletedWord) {
+        // Substring deletion - show which word contained the substring
+        setLastSearchedWord(`${deleteWord} (deleted word "${deletedWord}")`);
+      } else {
+        // Exact word deletion
+        setLastSearchedWord(`${deleteWord} (deleted)`);
+      }
+      setSearchResult(true); // Show success message
+    } else {
+      const wrap = document.querySelector(".tv-canvas");
+      wrap?.classList.add("tv-shake");
+      setTimeout(() => wrap?.classList.remove("tv-shake"), 420);
+      setLastSearchedWord(deleteWord);
+      setSearchResult(false); // Show not found message
+    }
+    setWord("");
+  }
+
+  function onInsertMany() {
+    const words = bulk
+      .split(/[\s,]+/)
+      .map((s) => s.trim())
+      .filter(Boolean);
+
+    if (!words.length) return;
+    resetHighlights();
+
+    for (const w of words) {
+      trie.insert(w);
+    }
+
+    // Force re-render
+    setTrieKey(k => k + 1);
+    setBulk("");
+  }
+
+  function onClear() {
+    resetHighlights();
+    // Reset trie
+    trie.root = new Trie().root;
+    trie.root.id = 0;
+    trie.nodeIdCounter = 1;
+    setTrieKey(k => k + 1);
+  }
+
+  // Keyboard shortcuts
+  React.useEffect(() => {
+    function onKey(e) {
+      if (e.key === "Enter" && !e.shiftKey && !e.ctrlKey) onInsert(e);
+      if (e.key === "Enter" && e.shiftKey) onDelete(e);
+      if (e.key === "Enter" && e.ctrlKey) onSearch(e);
+      if ((e.key === "n" || e.key === "N") && stepMode) handleNext();
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [stepMode, word]);
+
+  return (
+    <div className="tv-wrap">
+      {/* TRIE INTRODUCTION */}
+      <section className="tv-intro">
+        <div className="tv-intro-content">
+          <h2 className="tv-intro-title">Trie (Prefix Tree) Visualizer</h2>
+          <p className="tv-intro-description">
+            A Trie is a tree-like data structure that stores strings efficiently. Each node represents a character,
+            making it perfect for prefix-based operations like autocomplete and spell checking.
+          </p>
+          <div className="tv-intro-features">
+            <span className="tv-feature-tag">Insert words</span>
+            <span className="tv-feature-tag">Search exact words</span>
+            <span className="tv-feature-tag">Find substrings</span>
+            <span className="tv-feature-tag">Prefix matching</span>
+            <span className="tv-feature-tag">Delete operations</span>
+          </div>
+        </div>
+      </section>
+
+      {/* TOP BAR */}
+      <header className="tv-toolbar">
+        <div className="tv-controls">
+          <div className="tv-row">
+            {/* Insert */}
+            <div className="tv-card">
+              <div className="tv-card-title">Insert Words</div>
+              <div className="tv-input-row">
+                <input
+                  className="tv-input"
+                  type="text"
+                  placeholder="e.g. hello"
+                  value={word}
+                  onChange={(e) => setWord(e.target.value)}
+                  disabled={isBusy && stepMode}
+                />
+                <button
+                  className="tv-btn tv-primary"
+                  onClick={onInsert}
+                  disabled={isBusy && stepMode}
+                  title="Insert word"
+                >
+                  Insert
+                </button>
+              </div>
+
+              <div className="tv-subtle">Insert multiple words: spaces / commas / newlines</div>
+              <div className="tv-input-row">
+                <textarea
+                  className="tv-input tv-textarea"
+                  placeholder="hello world test"
+                  value={bulk}
+                  onChange={(e) => setBulk(e.target.value)}
+                  rows={2}
+                />
+              </div>
+              <div className="tv-input-row">
+                <button className="tv-btn" onClick={onInsertMany} disabled={isBusy}>
+                  Insert all (instant)
+                </button>
+              </div>
+
+              <label className="tv-checkbox">
+                <input
+                  type="checkbox"
+                  checked={animateInserts}
+                  onChange={(e) => setAnimateInserts(e.target.checked)}
+                />
+                Animate single inserts
+              </label>
+            </div>
+
+            {/* Search / Delete */}
+            <div className="tv-card">
+              <div className="tv-card-title">Search / Delete</div>
+              <div className="tv-input-row">
+                <input
+                  className="tv-input"
+                  type="text"
+                  placeholder="word or prefix"
+                  value={word}
+                  onChange={(e) => setWord(e.target.value)}
+                />
+                <button className="tv-btn" onClick={onSearch} disabled={isBusy && stepMode}>
+                  Search Word
+                </button>
+                <button className="tv-btn" onClick={onPrefixSearch} disabled={isBusy && stepMode}>
+                  Search Prefix
+                </button>
+                <button className="tv-btn" onClick={onDelete} disabled={isBusy && stepMode}>
+                  Delete
+                </button>
+              </div>
+
+              <div className="tv-toggle-row">
+                <label className="tv-checkbox">
+                  <input
+                    type="checkbox"
+                    checked={stepMode}
+                    onChange={(e) => setStepMode(e.target.checked)}
+                  />
+                  Step-by-step
+                </label>
+                <div className="tv-speed">
+                  <label className="tv-speed-label">Speed</label>
+                  <input
+                    type="range"
+                    min="200"
+                    max="1200"
+                    step="50"
+                    value={speed}
+                    onChange={(e) => setSpeed(Number(e.target.value))}
+                    disabled={stepMode}
+                    aria-label="Animation speed"
+                  />
+                </div>
+                {stepMode && (
+                  <button
+                    className="tv-btn tv-accent"
+                    type="button"
+                    onClick={handleNext}
+                    disabled={!isBusy}
+                    title="Next step (N)"
+                  >
+                    Next
+                  </button>
+                )}
+              </div>
+            </div>
+
+            {/* Actions */}
+            <div className="tv-card">
+              <div className="tv-card-title">Actions</div>
+              <div className="tv-actions">
+                <button className="tv-btn" onClick={onClear}>Clear All</button>
+              </div>
+            </div>
+          </div>
+
+          <p className="tv-hint">
+            Insert complete words into the Trie. Search for exact words, substrings, or prefixes.
+            Press <kbd>Enter</kbd> to insert, <kbd>Shift+Enter</kbd> to delete, <kbd>Ctrl+Enter</kbd> to search.
+            Press <kbd>N</kbd> to advance when Step-by-step is on.
+          </p>
+        </div>
+      </header>
+
+      {/* CANVAS */}
+      <section className="tv-canvas" role="region" aria-label="Trie canvas">
+        <svg className="tv-svg" viewBox={laidOut.viewBox.join(" ")} preserveAspectRatio="xMidYMid meet">
+          {/* edges */}
+          {laidOut.edges.map((edge) => (
+            <line
+              key={`${edge.source}-${edge.target}`}
+              x1={edge.sourceNode?.x || 0}
+              y1={edge.sourceNode?.y || 0}
+              x2={edge.targetNode?.x || 0}
+              y2={edge.targetNode?.y || 0}
+              className="tv-edge"
+            />
+          ))}
+          {/* nodes */}
+          {laidOut.nodes.map((node) => {
+            const isActive = node.id === activeNodeId;
+            const inPath = activePath.includes(node.id);
+            const isVisited = visited.includes(node.id);
+            const classes = ["tv-node", isActive && "is-active", inPath && "in-path", isVisited && "is-visited", node.isEndOfWord && "is-end"]
+              .filter(Boolean)
+              .join(" ");
+            return (
+              <g key={node.id} transform={`translate(${node.x},${node.y})`} className={classes}>
+                <circle r="20" />
+                <text dy="6">{node.char || 'root'}</text>
+              </g>
+            );
+          })}
+        </svg>
+      </section>
+
+      {/* LEGEND */}
+      <footer className="tv-legend" aria-label="Legend">
+        <span className="chip chip-active" /> Current
+        <span className="chip chip-path" /> Path
+        <span className="chip chip-visited" /> Visited
+        <span className="chip chip-end" /> End of Word
+        <button
+          className="tv-info-toggle"
+          onClick={() => setShowExplanation(!showExplanation)}
+          aria-label="Toggle Trie explanation"
+        >
+          {showExplanation ? 'Hide' : 'Show'} Info
+        </button>
+      </footer>
+
+      {/* TRIE EXPLANATION */}
+      {showExplanation && (
+        <section className="tv-explanation" aria-label="Trie explanation">
+          <div className="tv-explanation-content">
+            <h3 className="tv-explanation-title">Trie (Prefix Tree) Implementation with Animation Steps</h3>
+            <div className="tv-explanation-text-block">
+              <p className="tv-explanation-text">
+                A Trie is a tree-like data structure used to store a dynamic set of strings.
+                It is particularly efficient for operations involving prefixes, such as searching
+                for words with a given prefix or autocomplete functionalities.
+              </p>
+
+              <h4 className="tv-explanation-subtitle">Core Components:</h4>
+              <ul className="tv-explanation-list">
+                <li><strong>TrieNode:</strong> Contains a Map of child nodes (one for each possible character) and an isEndOfWord boolean flag that marks the end of a complete word</li>
+                <li><strong>Root Node:</strong> The starting point for all operations (typically doesn't represent any character itself)</li>
+                <li><strong>Edges:</strong> Represent the relationship between parent and child nodes, labeled with characters</li>
+              </ul>
+
+              <h4 className="tv-explanation-subtitle">Key Operations:</h4>
+              <ul className="tv-explanation-list">
+                <li><strong>insert(word):</strong> Traverses the trie character by character, creating new nodes as needed, and marks the final node as end-of-word</li>
+                <li><strong>search(word):</strong> Traverses the trie following the word's characters and checks if the final node is marked as end-of-word</li>
+                <li><strong>searchPrefix(prefix):</strong> Traverses to the prefix end and collects all complete words in that subtree</li>
+                <li><strong>delete(word):</strong> Finds the word and removes the end-of-word marking, potentially cleaning up unused nodes</li>
+              </ul>
+
+              <h4 className="tv-explanation-subtitle">Advantages:</h4>
+              <ul className="tv-explanation-list">
+                <li><strong>Efficient Prefix Operations:</strong> O(m) time complexity where m is the length of the prefix</li>
+                <li><strong>Space Efficient:</strong> Shares common prefixes, reducing storage compared to storing complete strings</li>
+                <li><strong>Fast Lookups:</strong> No need to check every stored string - just traverse the tree</li>
+                <li><strong>Autocomplete Ready:</strong> Perfect for implementing autocomplete and spell-checking features</li>
+              </ul>
+
+              <h4 className="tv-explanation-subtitle">Common Use Cases:</h4>
+              <ul className="tv-explanation-list">
+                <li><strong>Autocomplete Systems:</strong> Suggesting words as users type</li>
+                <li><strong>Spell Checkers:</strong> Finding correctly spelled words</li>
+                <li><strong>IP Routing:</strong> Longest prefix matching for network routing</li>
+                <li><strong>Dictionary Implementations:</strong> Fast word lookups and prefix searches</li>
+                <li><strong>Contact Lists:</strong> Searching contacts by name prefixes</li>
+              </ul>
+
+              <h4 className="tv-explanation-subtitle">How It Works:</h4>
+              <div className="tv-explanation-workflow">
+                <p><strong>Example:</strong> Inserting "hello", "help", "world"</p>
+                <ul className="tv-explanation-steps">
+                  <li>Start at root node</li>
+                  <li>For "hello": create path h→e→l→l→o, mark 'o' as end-of-word</li>
+                  <li>For "help": reuse h→e→l→l, then create p, mark 'p' as end-of-word</li>
+                  <li>For "world": create separate path w→o→r→l→d, mark 'd' as end-of-word</li>
+                  <li>Searching "he" finds the prefix exists</li>
+                  <li>Searching "hello" finds the complete word</li>
+                  <li>Searching "help" finds the complete word</li>
+                </ul>
+              </div>
+
+              <p className="tv-explanation-note">
+                <em>Each node represents a character in the alphabet. The root node is empty and serves as the entry point for all operations.</em>
+              </p>
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* SEARCH RESULTS */}
+      {searchResult !== null && (
+        <section className="tv-result" aria-label="Search result">
+          <div className="tv-result-content">
+            {lastSearchedWord} {searchResult ? "found" : "not found"} in Trie
+          </div>
+        </section>
+      )}
+
+      {/* PREFIX WORDS */}
+      {prefixWords.length > 0 && (
+        <section className="tv-words" aria-label="Prefix words">
+          <div className="tv-words-head">
+            <span className="tv-words-title">Words with prefix "{word}"</span>
+          </div>
+          <div className="tv-words-list">
+            {prefixWords.map((w, i) => (
+              <span key={w} className="tv-word-pill">{w}</span>
+            ))}
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/src/components/Trie/layout.js
+++ b/src/components/Trie/layout.js
@@ -1,0 +1,87 @@
+/**
+ * Layout utility for Trie visualization
+ * Positions nodes in a hierarchical manner with proper spacing
+ */
+
+export function layoutTrie(trie) {
+  if (!trie || !trie.root) {
+    return { nodes: [], edges: [], viewBox: [-50, -50, 100, 100] };
+  }
+
+  const rawNodes = trie.getAllNodes();
+  const rawEdges = trie.getAllEdges();
+
+  if (rawNodes.length === 0) {
+    return { nodes: [], edges: [], viewBox: [-50, -50, 100, 100] };
+  }
+
+  // Group nodes by level
+  const levelNodes = new Map();
+  rawNodes.forEach(node => {
+    if (!levelNodes.has(node.level)) {
+      levelNodes.set(node.level, []);
+    }
+    levelNodes.get(node.level).push(node);
+  });
+
+  // Position nodes level by level
+  const positionedNodes = [];
+  const maxLevel = Math.max(...Array.from(levelNodes.keys()));
+
+  for (let level = 0; level <= maxLevel; level++) {
+    const nodesInLevel = levelNodes.get(level);
+    if (!nodesInLevel) continue;
+
+    const y = level * 80;
+    const spacing = 60;
+    const totalWidth = (nodesInLevel.length - 1) * spacing;
+    const startX = -totalWidth / 2;
+
+    nodesInLevel.forEach((node, index) => {
+      const x = startX + index * spacing;
+      positionedNodes.push({
+        ...node,
+        x,
+        y
+      });
+    });
+  }
+
+  // Create node map for edge positioning
+  const nodeMap = new Map();
+  positionedNodes.forEach(node => {
+    nodeMap.set(node.id, node);
+  });
+
+  // Position edges
+  const positionedEdges = rawEdges.map(edge => ({
+    ...edge,
+    sourceNode: nodeMap.get(edge.source),
+    targetNode: nodeMap.get(edge.target)
+  }));
+
+  // Calculate viewBox
+  const minX = Math.min(...positionedNodes.map(n => n.x));
+  const maxX = Math.max(...positionedNodes.map(n => n.x));
+  const minY = Math.min(...positionedNodes.map(n => n.y));
+  const maxY = Math.max(...positionedNodes.map(n => n.y));
+
+  const padding = 60;
+  const width = maxX - minX + padding * 2;
+  const height = maxY - minY + padding * 2;
+
+  // Shift nodes to positive coordinates
+  const shiftX = padding - minX;
+  const shiftY = padding - minY;
+
+  positionedNodes.forEach(node => {
+    node.x += shiftX;
+    node.y += shiftY;
+  });
+
+  return {
+    nodes: positionedNodes,
+    edges: positionedEdges,
+    viewBox: [0, 0, width, height]
+  };
+}

--- a/src/components/Trie/trie.js
+++ b/src/components/Trie/trie.js
@@ -1,0 +1,245 @@
+/**
+ * Trie (Prefix Tree) implementation with animation steps
+ *
+ * A Trie is a tree-like data structure used to store a dynamic set of strings.
+ * It is particularly efficient for operations involving prefixes, such as searching
+ * for words with a given prefix or autocomplete functionalities.
+ *
+ * Core Components:
+ * - TrieNode: Contains a Map of child nodes and an isEndOfWord flag
+ * - Root Node: Starting point for all operations (doesn't represent a character)
+ *
+ * Key Operations:
+ * - insert(word): Builds the trie structure for the word
+ * - search(word): Checks if the exact word exists
+ * - searchPrefix(prefix): Finds all words starting with the prefix
+ * - delete(word): Removes a word and cleans up unused nodes
+ *
+ * Each node represents a character in the alphabet.
+ */
+
+export class TrieNode {
+  constructor(char = '') {
+    this.char = char;
+    this.children = new Map(); // char -> TrieNode
+    this.isEndOfWord = false;
+    this.id = null; // for visualization
+  }
+}
+
+export class Trie {
+  constructor() {
+    this.root = new TrieNode();
+    this.nodeIdCounter = 1;
+  }
+
+  // Generate unique ID for nodes
+  generateId() {
+    return this.nodeIdCounter++;
+  }
+
+  // Clone the entire trie for snapshots
+  cloneTrie(node = this.root, visited = new Map()) {
+    if (visited.has(node)) return visited.get(node);
+
+    const clone = new TrieNode(node.char);
+    clone.isEndOfWord = node.isEndOfWord;
+    clone.id = node.id;
+    visited.set(node, clone);
+
+    for (const [char, child] of node.children) {
+      clone.children.set(char, this.cloneTrie(child, visited));
+    }
+
+    return clone;
+  }
+
+  // Insert word with animation steps
+  insert(word) {
+    const steps = [];
+    let current = this.root;
+
+    for (let i = 0; i < word.length; i++) {
+      const char = word[i];
+      steps.push({ type: "focus", nodeId: current.id });
+
+      if (!current.children.has(char)) {
+        const newNode = new TrieNode(char);
+        newNode.id = this.generateId();
+        current.children.set(char, newNode);
+        steps.push({ type: "apply", snapshot: this.cloneTrie() });
+      }
+
+      current = current.children.get(char);
+    }
+
+    steps.push({ type: "focus", nodeId: current.id });
+    if (!current.isEndOfWord) {
+      current.isEndOfWord = true;
+      steps.push({ type: "apply", snapshot: this.cloneTrie() });
+    }
+
+    return { success: true, steps };
+  }
+
+  // Search for exact word
+  search(word) {
+    const steps = [];
+    let current = this.root;
+
+    for (let i = 0; i < word.length; i++) {
+      const char = word[i];
+      steps.push({ type: "focus", nodeId: current.id });
+
+      if (!current.children.has(char)) {
+        return { found: false, steps, substringIn: null };
+      }
+      current = current.children.get(char);
+    }
+
+    steps.push({ type: "focus", nodeId: current.id });
+    return { found: current.isEndOfWord, steps, substringIn: current.isEndOfWord ? word : null };
+  }
+
+
+
+  // Get all complete words stored in the trie
+  getAllWords() {
+    const words = [];
+    this.collectWords(this.root, "", words);
+    return words;
+  }
+
+  // Search for prefix (returns all words starting with prefix)
+  searchPrefix(prefix) {
+    const steps = [];
+    let current = this.root;
+
+    // Traverse to prefix end
+    for (let i = 0; i < prefix.length; i++) {
+      const char = prefix[i];
+      steps.push({ type: "focus", nodeId: current.id });
+
+      if (!current.children.has(char)) {
+        return { found: false, words: [], steps };
+      }
+      current = current.children.get(char);
+    }
+
+    steps.push({ type: "focus", nodeId: current.id });
+
+    // Collect all words from this node
+    const words = [];
+    this.collectWords(current, prefix, words);
+
+    return { found: true, words, steps };
+  }
+
+  // Helper to collect all words from a node
+  collectWords(node, currentWord, words) {
+    if (node.isEndOfWord) {
+      words.push(currentWord);
+    }
+
+    for (const [char, child] of node.children) {
+      this.collectWords(child, currentWord + char, words);
+    }
+  }
+
+  // Delete prefix (removes all words starting with the given prefix)
+  delete(word) {
+    const steps = [];
+    const result = this.deleteHelper(this.root, word, 0, steps);
+    return { deleted: result.wordDeleted, steps, deletedWord: result.wordDeleted ? word : null };
+  }
+
+  // Helper function for recursive delete
+  // Returns { wordDeleted: boolean, canDeleteNode: boolean }
+  deleteHelper(node, word, depth, steps) {
+    if (!node) {
+      return { wordDeleted: false, canDeleteNode: false };
+    }
+
+    steps.push({ type: "focus", nodeId: node.id });
+
+    if (depth === word.length) {
+      // Delete the prefix: remove end-of-word and clear all children (delete subtree)
+      node.isEndOfWord = false;
+      node.children = new Map();
+      steps.push({ type: "apply", snapshot: this.cloneTrie() });
+      // Prefix deleted, and node can be deleted
+      return { wordDeleted: true, canDeleteNode: true };
+    }
+
+    const char = word[depth];
+    if (!node.children.has(char)) {
+      return { wordDeleted: false, canDeleteNode: false }; // Word not found
+    }
+
+    const child = node.children.get(char);
+    const childResult = this.deleteHelper(child, word, depth + 1, steps);
+
+    if (childResult.canDeleteNode) {
+      node.children.delete(char);
+      steps.push({ type: "apply", snapshot: this.cloneTrie() });
+      // Return whether word was deleted, and if current node can be deleted
+      return {
+        wordDeleted: childResult.wordDeleted,
+        canDeleteNode: node.children.size === 0 && !node.isEndOfWord
+      };
+    }
+
+    // Child not deleted, return word deleted status and false for canDeleteNode
+    return { wordDeleted: childResult.wordDeleted, canDeleteNode: false };
+  }
+
+
+
+  // Get all nodes for visualization (simple traversal)
+  getAllNodes() {
+    const nodes = [];
+    const visited = new Set();
+
+    function traverse(node, level = 0) {
+      if (visited.has(node)) return;
+      visited.add(node);
+
+      nodes.push({
+        id: node.id,
+        char: node.char,
+        isEndOfWord: node.isEndOfWord,
+        level
+      });
+
+      for (const child of node.children.values()) {
+        traverse(child, level + 1);
+      }
+    }
+
+    traverse(this.root);
+    return nodes;
+  }
+
+  // Get all edges for visualization
+  getAllEdges() {
+    const edges = [];
+    const visited = new Set();
+
+    function traverse(node) {
+      if (visited.has(node)) return;
+      visited.add(node);
+
+      for (const child of node.children.values()) {
+        edges.push({
+          source: node.id,
+          target: child.id,
+          char: child.char
+        });
+        traverse(child);
+      }
+    }
+
+    traverse(this.root);
+    return edges;
+  }
+}

--- a/src/pages/DataStructures.jsx
+++ b/src/pages/DataStructures.jsx
@@ -290,6 +290,20 @@ const algorithmDatabase = {
         spaceComplexity: "O(n)",
         implemented: true,
       },
+      {
+        name: "Trie",
+        id: "trie",
+        description:
+          "Prefix tree data structure for efficient string operations like search, insert, and prefix matching.",
+        timeComplexity: {
+          insertion: "O(m)",
+          deletion: "O(m)",
+          search: "O(m)",
+          prefixSearch: "O(m)",
+        },
+        spaceComplexity: "O(N)",
+        implemented: true,
+      },
     ],
   },
 };

--- a/src/utils/navigation.js
+++ b/src/utils/navigation.js
@@ -88,6 +88,7 @@ export const learnSections = [
       { path: "/hashing", label: "Hashing Algorithms", category: "Other", tags: ["hashing", "algorithms"] },
       { path: "/tree-overview", label: "Trees (Overview)", category: "Other", tags: ["trees", "overview"] },
       { path: "/tree", label: "Tree Algorithms", category: "Other", tags: ["tree", "algorithms"] },
+      { path: "/data-structures/trie", label: "Trie Visualizer", category: "Other", tags: ["trie", "prefix tree", "data structure"] },
       { path: "/game-search-overview", label: "Game Search (Overview)", category: "Other", tags: ["game search", "overview"] },
       { path: "/game-search", label: "Game Search Algorithms", category: "Other", tags: ["game search", "algorithms"] },
       { path: "/branchbound-overview", label: "Branch & Bound (Overview)", category: "Other", tags: ["branch and bound", "overview"] },


### PR DESCRIPTION
## Which issue does this PR close?

Closes #1099 

## Rationale for this change

Currently, AlgoVisualizer does not have a visualization for Trie (Prefix Tree) data structure.
Adding this will help users understand how Tries work, including insertion, search, and deletion operations, in an interactive and animated way.

## What changes are included in this PR?

Added a new Trie visualization component with interactive UI.
Implemented animations for node insertion, traversal, and deletion.
Updated AlgoVisualizer menu to include the Trie option.
Ensured responsive design and proper error handling for empty inputs.

## Are these changes tested?

Tested with multiple words and sequences to ensure correct node placement.
Verified animations work for insertion, search, and deletion.

Edge cases (empty string, duplicate insertions) have been handled.
<img width="1919" height="918" alt="Screenshot 2025-10-06 134422" src="https://github.com/user-attachments/assets/ec342308-7cf9-4a11-8362-66d077fa045a" />


## Are there any user-facing changes?
Users can now select Trie from the data structures menu.
Interactive animations for Trie operations are visible on the main visualization panel.