### PR TITLE
Added kruskal algorithm

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -72,6 +72,7 @@ import StringOverview from "./pages/StringOverview";
 import StringPage from "./pages/StringPage";
 import StringRabinKarpPage from "./pages/StringRabinKarpPage";
 import PrimPage from "./pages/PrimPage";
+import KruskalPage from "./pages/KruskalPage";
 
 // Components
 import LinkedListPage from "./components/pages/LinkedListPage";
@@ -205,6 +206,7 @@ const App = () => {
                   <Route path="/string" element={<StringPage />} />
                   <Route path="/string/rabin-karp" element={<StringRabinKarpPage />} />
                   <Route path="/prims" element={<PrimPage />} />
+                  <Route path="/kruskal" element={<KruskalPage />} />
 
                   {/* Data Structures Documentation */}
                   <Route path="/data-structures-docs" element={<DSDocumentation />} />

--- a/src/components/KruskalVisualizer.jsx
+++ b/src/components/KruskalVisualizer.jsx
@@ -1,0 +1,661 @@
+import React, { useState, useRef, useEffect, useCallback } from "react";
+import "../styles/global-theme.css";
+
+// Union-Find (Disjoint Set) implementation
+class UnionFind {
+  constructor(size) {
+    this.parent = Array.from({ length: size }, (_, i) => i);
+    this.rank = Array(size).fill(0);
+  }
+
+  find(x) {
+    if (this.parent[x] !== x) {
+      this.parent[x] = this.find(this.parent[x]); // Path compression
+    }
+    return this.parent[x];
+  }
+
+  union(x, y) {
+    const px = this.find(x), py = this.find(y);
+    if (px !== py) {
+      if (this.rank[px] < this.rank[py]) {
+        this.parent[px] = py;
+      } else if (this.rank[px] > this.rank[py]) {
+        this.parent[py] = px;
+      } else {
+        this.parent[py] = px;
+        this.rank[px]++;
+      }
+      return true; // Union successful
+    }
+    return false; // Already in same set
+  }
+
+  getSets() {
+    const sets = {};
+    for (let i = 0; i < this.parent.length; i++) {
+      const root = this.find(i);
+      if (!sets[root]) sets[root] = [];
+      sets[root].push(i);
+    }
+    return sets;
+  }
+}
+
+// Kruskal's Algorithm implementation
+const kruskalsAlgorithm = (adjacencyMatrix) => {
+  const n = adjacencyMatrix.length;
+  const edges = [];
+
+  // Collect all edges
+  for (let i = 0; i < n; i++) {
+    for (let j = i + 1; j < n; j++) {
+      if (adjacencyMatrix[i][j] > 0) {
+        edges.push({ from: i, to: j, weight: adjacencyMatrix[i][j] });
+      }
+    }
+  }
+
+  // Sort edges by weight
+  edges.sort((a, b) => a.weight - b.weight);
+
+  const steps = [];
+  const uf = new UnionFind(n);
+  const mst = [];
+  let totalCost = 0;
+
+  steps.push({
+    type: 'init',
+    edges: [...edges],
+    sortedEdges: [],
+    currentMST: [],
+    totalCost: 0,
+    uf: new UnionFind(n),
+    currentEdge: null,
+    message: `Collected ${edges.length} edges. Sorting edges by weight.`
+  });
+
+  // Sort edges step by step for visualization
+  const sortedEdges = [];
+  for (let i = 0; i < edges.length; i++) {
+    sortedEdges.push(edges[i]);
+    steps.push({
+      type: 'sorting',
+      edges: [...edges],
+      sortedEdges: [...sortedEdges],
+      currentMST: [...mst],
+      totalCost,
+      uf: new UnionFind(n), // Fresh copy for each step
+      currentEdge: null,
+      message: `Sorted ${i + 1}/${edges.length} edges. Current edge: (${edges[i].from}-${edges[i].to}): ${edges[i].weight}`
+    });
+  }
+
+  // Now process each edge
+  for (let i = 0; i < edges.length; i++) {
+    const edge = edges[i];
+    const ufCopy = new UnionFind(n);
+
+    // Restore previous unions
+    for (let j = 0; j < mst.length; j++) {
+      ufCopy.union(mst[j].from, mst[j].to);
+    }
+
+    const fromRoot = ufCopy.find(edge.from);
+    const toRoot = ufCopy.find(edge.to);
+    const willFormCycle = fromRoot === toRoot;
+
+    steps.push({
+      type: 'consider',
+      edges: [...edges],
+      sortedEdges: [...sortedEdges],
+      currentMST: [...mst],
+      totalCost,
+      uf: ufCopy,
+      currentEdge: edge,
+      willFormCycle,
+      message: `Considering edge (${edge.from}-${edge.to}): ${edge.weight}. ${willFormCycle ? 'Would form cycle - skipping.' : 'No cycle - adding to MST.'}`
+    });
+
+    if (!willFormCycle) {
+      ufCopy.union(edge.from, edge.to);
+      mst.push(edge);
+      totalCost += edge.weight;
+
+      steps.push({
+        type: 'add',
+        edges: [...edges],
+        sortedEdges: [...sortedEdges],
+        currentMST: [...mst],
+        totalCost,
+        uf: ufCopy,
+        currentEdge: edge,
+        message: `Added edge (${edge.from}-${edge.to}): ${edge.weight} to MST. Current cost: ${totalCost}`
+      });
+    } else {
+      steps.push({
+        type: 'skip',
+        edges: [...edges],
+        sortedEdges: [...sortedEdges],
+        currentMST: [...mst],
+        totalCost,
+        uf: ufCopy,
+        currentEdge: edge,
+        message: `Skipped edge (${edge.from}-${edge.to}): ${edge.weight} - would form cycle.`
+      });
+    }
+
+    // Check if MST is complete
+    if (mst.length === n - 1) {
+      steps.push({
+        type: 'complete',
+        edges: [...edges],
+        sortedEdges: [...sortedEdges],
+        currentMST: [...mst],
+        totalCost,
+        uf: ufCopy,
+        currentEdge: null,
+        message: `MST complete! Total cost: ${totalCost}`
+      });
+      break;
+    }
+  }
+
+  return steps;
+};
+
+// Generate random graph
+const generateRandomGraph = (numNodes) => {
+  const matrix = Array(numNodes).fill().map(() => Array(numNodes).fill(0));
+
+  // Create a connected graph
+  for (let i = 0; i < numNodes - 1; i++) {
+    const weight = Math.floor(Math.random() * 20) + 1;
+    matrix[i][i + 1] = weight;
+    matrix[i + 1][i] = weight;
+  }
+
+  // Add some random edges
+  for (let i = 0; i < numNodes; i++) {
+    for (let j = i + 2; j < numNodes; j++) {
+      if (Math.random() < 0.3) { // 30% chance
+        const weight = Math.floor(Math.random() * 20) + 1;
+        matrix[i][j] = weight;
+        matrix[j][i] = weight;
+      }
+    }
+  }
+
+  return matrix;
+};
+
+// Default example graph
+const DEFAULT_GRAPH = [
+  [0, 2, 0, 6, 0],
+  [2, 0, 3, 8, 5],
+  [0, 3, 0, 0, 7],
+  [6, 8, 0, 0, 9],
+  [0, 5, 7, 9, 0]
+];
+
+const KruskalVisualizer = () => {
+  const [adjacencyMatrix, setAdjacencyMatrix] = useState(DEFAULT_GRAPH);
+  const [steps, setSteps] = useState([]);
+  const [currentStep, setCurrentStep] = useState(0);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [isComplete, setIsComplete] = useState(false);
+  const [message, setMessage] = useState("Run Kruskal's algorithm to see the visualization");
+  const [numNodes, setNumNodes] = useState(5);
+  const canvasRef = useRef(null);
+  const animationRef = useRef(null);
+
+  // Node positions for visualization (supporting up to 7 nodes)
+  const getNodePositions = (numNodes) => {
+    const positions = [
+      { x: 200, y: 150 }, // Node 0
+      { x: 400, y: 100 }, // Node 1
+      { x: 500, y: 250 }, // Node 2
+      { x: 300, y: 350 }, // Node 3
+      { x: 100, y: 300 }, // Node 4
+      { x: 350, y: 50 },  // Node 5
+      { x: 150, y: 50 }   // Node 6
+    ];
+    return positions.slice(0, numNodes);
+  };
+
+  // Draw the graph
+  const drawGraph = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+    const n = adjacencyMatrix.length;
+    const nodePositions = getNodePositions(n);
+    const currentState = steps[currentStep] || {
+      currentMST: [],
+      currentEdge: null,
+      uf: new UnionFind(n)
+    };
+
+    // Draw edges
+    for (let i = 0; i < n; i++) {
+      for (let j = i + 1; j < n; j++) {
+        if (adjacencyMatrix[i][j] > 0) {
+          const start = nodePositions[i];
+          const end = nodePositions[j];
+
+          ctx.beginPath();
+          ctx.moveTo(start.x, start.y);
+          ctx.lineTo(end.x, end.y);
+
+          // Check edge status
+          const isInMST = currentState.currentMST.some(
+            edge => (edge.from === i && edge.to === j) || (edge.from === j && edge.to === i)
+          );
+          const isCurrentEdge = currentState.currentEdge &&
+            ((currentState.currentEdge.from === i && currentState.currentEdge.to === j) ||
+             (currentState.currentEdge.from === j && currentState.currentEdge.to === i));
+
+          if (isInMST) {
+            ctx.strokeStyle = '#4ade80'; // Green for MST edges
+            ctx.lineWidth = 4;
+          } else if (isCurrentEdge) {
+            if (currentState.willFormCycle) {
+              ctx.strokeStyle = '#ef4444'; // Red for edges that would form cycle
+            } else {
+              ctx.strokeStyle = '#ffd93d'; // Yellow for edges being considered
+            }
+            ctx.lineWidth = 3;
+          } else {
+            ctx.strokeStyle = '#94a3b8'; // Gray for unused edges
+            ctx.lineWidth = 2;
+          }
+
+          ctx.stroke();
+
+          // Draw edge weight
+          const midX = (start.x + end.x) / 2;
+          const midY = (start.y + end.y) / 2;
+          ctx.fillStyle = '#1e293b';
+          ctx.font = '14px Arial';
+          ctx.textAlign = 'center';
+          ctx.fillText(adjacencyMatrix[i][j], midX, midY - 5);
+        }
+      }
+    }
+
+    // Draw nodes with set coloring
+    const sets = currentState.uf ? currentState.uf.getSets() : {};
+    const setColors = ['#66ccff', '#ff6b6b', '#ffd93d', '#4ade80', '#a855f7', '#f97316', '#06b6d4'];
+
+    for (let i = 0; i < n; i++) {
+      const node = nodePositions[i];
+      ctx.beginPath();
+      ctx.arc(node.x, node.y, 25, 0, 2 * Math.PI);
+
+      // Color based on union-find set
+      let nodeColor = '#94a3b8'; // Default gray
+      for (const [root, members] of Object.entries(sets)) {
+        if (members.includes(i)) {
+          nodeColor = setColors[parseInt(root) % setColors.length];
+          break;
+        }
+      }
+
+      ctx.fillStyle = nodeColor;
+      ctx.fill();
+      ctx.strokeStyle = '#1e293b';
+      ctx.lineWidth = 2;
+      ctx.stroke();
+
+      // Draw node number
+      ctx.fillStyle = '#ffffff';
+      ctx.font = '16px Arial';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(i, node.x, node.y);
+    }
+  }, [adjacencyMatrix, steps, currentStep]);
+
+  useEffect(() => {
+    drawGraph();
+  }, [drawGraph]);
+
+  // Handle changes in number of nodes
+  useEffect(() => {
+    const newMatrix = Array(numNodes).fill().map(() => Array(numNodes).fill(0));
+
+    // Copy existing values where possible
+    const minSize = Math.min(numNodes, adjacencyMatrix.length);
+    for (let i = 0; i < minSize; i++) {
+      for (let j = 0; j < minSize; j++) {
+        newMatrix[i][j] = adjacencyMatrix[i][j];
+      }
+    }
+
+    setAdjacencyMatrix(newMatrix);
+
+    // Clear any existing algorithm steps
+    setSteps([]);
+    setCurrentStep(0);
+    setIsComplete(false);
+    setMessage("Graph size changed. Run Kruskal's algorithm to see the visualization");
+  }, [numNodes]);
+
+  const runAlgorithm = () => {
+    const algorithmSteps = kruskalsAlgorithm(adjacencyMatrix);
+    setSteps(algorithmSteps);
+    setCurrentStep(0);
+    setIsComplete(false);
+    setMessage(algorithmSteps[0].message);
+  };
+
+  const play = () => {
+    if (isPlaying) {
+      setIsPlaying(false);
+      if (animationRef.current) {
+        clearInterval(animationRef.current);
+      }
+      return;
+    }
+
+    setIsPlaying(true);
+    animationRef.current = setInterval(() => {
+      setCurrentStep(prev => {
+        if (prev >= steps.length - 1) {
+          setIsPlaying(false);
+          setIsComplete(true);
+          clearInterval(animationRef.current);
+          return prev;
+        }
+        setMessage(steps[prev + 1].message);
+        return prev + 1;
+      });
+    }, 2000);
+  };
+
+  const stepForward = () => {
+    if (currentStep < steps.length - 1) {
+      setCurrentStep(prev => prev + 1);
+      setMessage(steps[currentStep + 1].message);
+    }
+  };
+
+  const stepBackward = () => {
+    if (currentStep > 0) {
+      setCurrentStep(prev => prev - 1);
+      setMessage(steps[currentStep - 1].message);
+    }
+  };
+
+  const reset = () => {
+    setCurrentStep(0);
+    setIsPlaying(false);
+    setIsComplete(false);
+    setMessage("Run Kruskal's algorithm to see the visualization");
+    if (animationRef.current) {
+      clearInterval(animationRef.current);
+    }
+  };
+
+  const generateNewGraph = () => {
+    const newGraph = generateRandomGraph(numNodes);
+    setAdjacencyMatrix(newGraph);
+    setSteps([]);
+    setCurrentStep(0);
+    setIsComplete(false);
+    setMessage("New graph generated. Run Kruskal's algorithm to see the visualization");
+  };
+
+  const updateMatrixCell = (i, j, value) => {
+    const newMatrix = adjacencyMatrix.map(row => [...row]);
+    newMatrix[i][j] = parseInt(value) || 0;
+    newMatrix[j][i] = parseInt(value) || 0; // Keep it symmetric
+    setAdjacencyMatrix(newMatrix);
+  };
+
+  const currentState = steps[currentStep] || { currentMST: [], totalCost: 0, sortedEdges: [] };
+
+  return (
+    <div className="kruskal-visualizer">
+      <div className="visualizer-header">
+        <h3>Kruskal's Algorithm Visualization</h3>
+        <p>Watch how Kruskal's algorithm builds a Minimum Spanning Tree by sorting edges and using Union-Find.</p>
+      </div>
+
+      <div className="controls-section">
+        <div className="control-group">
+          <label>Number of Nodes:</label>
+          <select
+            value={numNodes}
+            onChange={(e) => setNumNodes(parseInt(e.target.value))}
+            disabled={isPlaying}
+          >
+            {[3, 4, 5, 6, 7].map(n => (
+              <option key={n} value={n}>{n}</option>
+            ))}
+          </select>
+        </div>
+
+        <div className="control-buttons">
+          <button
+            className="btn btn-secondary"
+            onClick={generateNewGraph}
+            disabled={isPlaying}
+          >
+            Generate Graph
+          </button>
+          <button
+            className="btn btn-primary"
+            onClick={runAlgorithm}
+            disabled={isPlaying}
+          >
+            Run Algorithm
+          </button>
+          <button
+            className="btn btn-secondary"
+            onClick={play}
+            disabled={steps.length === 0}
+          >
+            {isPlaying ? 'Pause' : 'Play'}
+          </button>
+          <button
+            className="btn btn-secondary"
+            onClick={stepBackward}
+            disabled={currentStep === 0 || isPlaying}
+          >
+            Step Back
+          </button>
+          <button
+            className="btn btn-secondary"
+            onClick={stepForward}
+            disabled={currentStep >= steps.length - 1 || isPlaying}
+          >
+            Step Forward
+          </button>
+          <button
+            className="btn btn-secondary"
+            onClick={reset}
+            disabled={isPlaying}
+          >
+            Reset
+          </button>
+        </div>
+      </div>
+
+      <div className="visualization-section">
+        <div className="canvas-container">
+          <canvas
+            ref={canvasRef}
+            width={600}
+            height={400}
+            className="graph-canvas"
+          />
+        </div>
+
+        <div className="info-panel">
+          <div className="current-cost">
+            <h4>Current MST Cost: {currentState.totalCost}</h4>
+          </div>
+
+          <div className="sorted-edges">
+            <h4>Sorted Edges ({currentState.sortedEdges.length})</h4>
+            <div className="edges-list">
+              {currentState.sortedEdges.map((edge, index) => (
+                <div key={index} className={`edge-item ${currentState.currentEdge === edge ? 'current' : ''}`}>
+                  ({edge.from} → {edge.to}): {edge.weight}
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="adjacency-matrix">
+            <h4>Adjacency Matrix</h4>
+            <div className="matrix-container">
+              <table>
+                <thead>
+                  <tr>
+                    <th></th>
+                    {Array.from({ length: numNodes }, (_, i) => (
+                      <th key={i}>{i}</th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {adjacencyMatrix.map((row, i) => (
+                    <tr key={i}>
+                      <th>{i}</th>
+                      {row.map((cell, j) => (
+                        <td key={j}>
+                          <input
+                            type="number"
+                            value={cell}
+                            onChange={(e) => updateMatrixCell(i, j, e.target.value)}
+                            min="0"
+                            disabled={isPlaying}
+                            className="matrix-input"
+                          />
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          <div className="mst-edges">
+            <h4>MST Edges</h4>
+            <div className="edges-list">
+              {currentState.currentMST.map((edge, index) => (
+                <div key={index} className="edge-item">
+                  ({edge.from} → {edge.to}): {edge.weight}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="message-bar">
+        <p>{message}</p>
+      </div>
+
+      <div className="algorithm-explanation">
+        <h4>About Kruskal's Algorithm</h4>
+
+        <div className="explanation-section">
+          <h5>🔍 What is Kruskal's Algorithm?</h5>
+          <p>
+            Kruskal's algorithm is a <strong>greedy algorithm</strong> that finds a <strong>Minimum Spanning Tree (MST)</strong>
+            for a weighted undirected graph. It builds the MST by adding edges in order of increasing weight,
+            ensuring no cycles are formed using the Union-Find data structure.
+          </p>
+        </div>
+
+        <div className="explanation-section">
+          <h5>⚡ How It Works</h5>
+          <ol>
+            <li><strong>Sort all edges</strong> - Sort edges by weight in ascending order</li>
+            <li><strong>Initialize Union-Find</strong> - Create disjoint sets for each vertex</li>
+            <li><strong>Process edges</strong> - Consider each edge in sorted order</li>
+            <li><strong>Add if no cycle</strong> - Add edge to MST if it connects different components</li>
+            <li><strong>Stop when complete</strong> - Continue until all vertices are connected</li>
+          </ol>
+        </div>
+
+        <div className="explanation-section">
+          <h5>🎯 Key Properties</h5>
+          <div className="properties-grid">
+            <div className="property-item">
+              <strong>Greedy Choice:</strong> Always selects the smallest edge that doesn't form a cycle
+            </div>
+            <div className="property-item">
+              <strong>Union-Find:</strong> Uses disjoint set data structure for cycle detection
+            </div>
+            <div className="property-item">
+              <strong>No Cycles:</strong> Ensures the final tree has no cycles
+            </div>
+            <div className="property-item">
+              <strong>Connected Graph:</strong> Works only on connected graphs
+            </div>
+          </div>
+        </div>
+
+        <div className="explanation-section">
+          <h5>⏱️ Time Complexity</h5>
+          <div className="complexity-info">
+            <div className="complexity-item">
+              <span className="complexity-label">Overall:</span>
+              <span className="complexity-value">O(E log E)</span>
+            </div>
+            <div className="complexity-item">
+              <span className="complexity-label">Sorting:</span>
+              <span className="complexity-value">O(E log E)</span>
+            </div>
+            <div className="complexity-item">
+              <span className="complexity-label">Union-Find:</span>
+              <span className="complexity-value">O(E α(V))</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="explanation-section">
+          <h5>🚀 Applications</h5>
+          <ul className="applications-list">
+            <li><strong>Network Design:</strong> Designing minimum cost networks (telephone, electrical, etc.)</li>
+            <li><strong>Clustering:</strong> Single-linkage clustering in data mining</li>
+            <li><strong>Approximation Algorithms:</strong> Used in solving NP-hard problems</li>
+            <li><strong>Road Networks:</strong> Finding minimum cost to connect cities</li>
+            <li><strong>Biological Networks:</strong> Analyzing protein interaction networks</li>
+          </ul>
+        </div>
+
+        <div className="explanation-section">
+          <h5>📊 Visual Guide</h5>
+          <div className="visual-guide">
+            <div className="guide-item">
+              <div className="color-box green"></div>
+              <span>MST Edges (included in tree)</span>
+            </div>
+            <div className="guide-item">
+              <div className="color-box yellow"></div>
+              <span>Edges being considered (no cycle)</span>
+            </div>
+            <div className="guide-item">
+              <div className="color-box red"></div>
+              <span>Edges that would form cycle</span>
+            </div>
+            <div className="guide-item">
+              <div className="color-box blue"></div>
+              <span>Nodes in same component (same color)</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default KruskalVisualizer;

--- a/src/data/allCodes.js
+++ b/src/data/allCodes.js
@@ -825,6 +825,198 @@ void introSortUtil(vector<int>& arr, int low, int high, int depthLimit) {
   },
 };
 
+export const kruskalAlgorithms = {
+  kruskal: {
+    java: `import java.util.*;
+
+class Edge implements Comparable<Edge> {
+    int src, dest, weight;
+    Edge(int s, int d, int w) {
+        src = s; dest = d; weight = w;
+    }
+    public int compareTo(Edge o) { return this.weight - o.weight; }
+}
+
+class KruskalAlgorithm {
+    static int[] parent, rank;
+
+    static int find(int x) {
+        if (parent[x] != x) parent[x] = find(parent[x]);
+        return parent[x];
+    }
+
+    static void union(int x, int y) {
+        int px = find(x), py = find(y);
+        if (px != py) {
+            if (rank[px] < rank[py]) parent[px] = py;
+            else if (rank[px] > rank[py]) parent[py] = px;
+            else { parent[py] = px; rank[px]++; }
+        }
+    }
+
+    static void kruskalMST(List<Edge> edges, int V) {
+        Collections.sort(edges);
+        parent = new int[V]; rank = new int[V];
+        for (int i = 0; i < V; i++) parent[i] = i;
+
+        List<Edge> mst = new ArrayList<>();
+        int mstWeight = 0;
+
+        for (Edge e : edges) {
+            if (find(e.src) != find(e.dest)) {
+                union(e.src, e.dest);
+                mst.add(e);
+                mstWeight += e.weight;
+            }
+        }
+
+        System.out.println("MST Edges:");
+        for (Edge e : mst) {
+            System.out.println(e.src + " - " + e.dest + " : " + e.weight);
+        }
+        System.out.println("Total MST Weight: " + mstWeight);
+    }
+}`,
+    python: `class UnionFind:
+    def __init__(self, size):
+        self.parent = list(range(size))
+        self.rank = [0] * size
+
+    def find(self, x):
+        if self.parent[x] != x:
+            self.parent[x] = self.find(self.parent[x])
+        return self.parent[x]
+
+    def union(self, x, y):
+        px, py = self.find(x), self.find(y)
+        if px != py:
+            if self.rank[px] < self.rank[py]:
+                self.parent[px] = py
+            elif self.rank[px] > self.rank[py]:
+                self.parent[py] = px
+            else:
+                self.parent[py] = px
+                self.rank[px] += 1
+
+def kruskal_mst(edges, V):
+    edges.sort(key=lambda x: x[2])  # sort by weight
+    uf = UnionFind(V)
+    mst = []
+    mst_weight = 0
+
+    for u, v, w in edges:
+        if uf.find(u) != uf.find(v):
+            uf.union(u, v)
+            mst.append((u, v, w))
+            mst_weight += w
+
+    print("MST Edges:")
+    for u, v, w in mst:
+        print(f"{u} - {v} : {w}")
+    print(f"Total MST Weight: {mst_weight}")
+    return mst`,
+    cpp: `#include <bits/stdc++.h>
+using namespace std;
+
+struct Edge {
+    int src, dest, weight;
+};
+
+bool cmp(Edge a, Edge b) { return a.weight < b.weight; }
+
+class UnionFind {
+    vector<int> parent, rank;
+public:
+    UnionFind(int size) {
+        parent.resize(size); rank.resize(size, 0);
+        for(int i=0; i<size; i++) parent[i] = i;
+    }
+    int find(int x) {
+        if(parent[x] != x) parent[x] = find(parent[x]);
+        return parent[x];
+    }
+    void unionSets(int x, int y) {
+        int px = find(x), py = find(y);
+        if(px != py) {
+            if(rank[px] < rank[py]) parent[px] = py;
+            else if(rank[px] > rank[py]) parent[py] = px;
+            else { parent[py] = px; rank[px]++; }
+        }
+    }
+};
+
+void kruskalMST(vector<Edge>& edges, int V) {
+    sort(edges.begin(), edges.end(), cmp);
+    UnionFind uf(V);
+    vector<Edge> mst;
+    int mstWeight = 0;
+
+    for(auto& e : edges) {
+        if(uf.find(e.src) != uf.find(e.dest)) {
+            uf.unionSets(e.src, e.dest);
+            mst.push_back(e);
+            mstWeight += e.weight;
+        }
+    }
+
+    cout << "MST Edges:\\n";
+    for(auto& e : mst) {
+        cout << e.src << " - " << e.dest << " : " << e.weight << "\\n";
+    }
+    cout << "Total MST Weight: " << mstWeight << endl;
+}`,
+    javascript: `class UnionFind {
+    constructor(size) {
+        this.parent = Array.from({length: size}, (_, i) => i);
+        this.rank = Array(size).fill(0);
+    }
+
+    find(x) {
+        if (this.parent[x] !== x) {
+            this.parent[x] = this.find(this.parent[x]);
+        }
+        return this.parent[x];
+    }
+
+    union(x, y) {
+        const px = this.find(x), py = this.find(y);
+        if (px !== py) {
+            if (this.rank[px] < this.rank[py]) {
+                this.parent[px] = py;
+            } else if (this.rank[px] > this.rank[py]) {
+                this.parent[py] = px;
+            } else {
+                this.parent[py] = px;
+                this.rank[px]++;
+            }
+        }
+    }
+}
+
+function kruskalMST(edges, V) {
+    edges.sort((a, b) => a[2] - b[2]); // sort by weight
+    const uf = new UnionFind(V);
+    const mst = [];
+    let mstWeight = 0;
+
+    for (const [u, v, w] of edges) {
+        if (uf.find(u) !== uf.find(v)) {
+            uf.union(u, v);
+            mst.push([u, v, w]);
+            mstWeight += w;
+        }
+    }
+
+    console.log("MST Edges:");
+    for (const [u, v, w] of mst) {
+        console.log(\`\${u} - \${v} : \${w}\`);
+    }
+    console.log(\`Total MST Weight: \${mstWeight}\`);
+    return mst;
+}`,
+  },
+};
+
 export const primsAlgorithms = {
   prims: {
     java: `import java.util.*;

--- a/src/pages/KruskalPage.jsx
+++ b/src/pages/KruskalPage.jsx
@@ -1,22 +1,22 @@
-// src/pages/PrimPage.jsx
+// src/pages/KruskalPage.jsx
 import React, { useState } from "react";
-import PrimVisualizer from "../components/PrimVisualizer"; // create similar to GreedyVisualizer
-import { primsAlgorithms } from "../data/allCodes";
+import KruskalVisualizer from "../components/KruskalVisualizer"; // create similar to PrimVisualizer
+import { kruskalAlgorithms } from "../data/allCodes";
 import "../styles/global-theme.css";
 
-const PrimPage = () => {
+const KruskalPage = () => {
   const [selectedLanguage, setSelectedLanguage] = useState("java");
 
-  const algorithmData = primsAlgorithms.prims || {};
+  const algorithmData = kruskalAlgorithms.kruskal || {};
 
   return (
     <div className="theme-container">
-      <h1 className="theme-title">Prim's Algorithm Visualizer</h1>
+      <h1 className="theme-title">Kruskal's Algorithm Visualizer</h1>
 
-      {/* Prim's Algorithm Explanation */}
+      {/* Kruskal's Algorithm Explanation */}
       <div className="theme-card" style={{ marginBottom: '2rem' }}>
         <div className="theme-card-header">
-          <h3>Understanding Prim's Algorithm</h3>
+          <h3>Understanding Kruskal's Algorithm</h3>
         </div>
         <div style={{
           padding: '1.5rem',
@@ -25,38 +25,38 @@ const PrimPage = () => {
         }}>
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '2rem', marginBottom: '1.5rem' }}>
             <div>
-              <h4 style={{ color: 'var(--theme-primary)', marginBottom: '0.5rem' }}>🔍 What is Prim's Algorithm?</h4>
+              <h4 style={{ color: 'var(--theme-primary)', marginBottom: '0.5rem' }}>🔍 What is Kruskal's Algorithm?</h4>
               <p style={{ color: 'var(--text-secondary)', lineHeight: '1.6', margin: 0 }}>
-                Prim's algorithm is a greedy algorithm that finds a Minimum Spanning Tree (MST) for a weighted undirected graph. It starts from an arbitrary vertex and grows the MST by repeatedly adding the smallest edge that connects a vertex in the tree to a vertex outside the tree.
+                Kruskal's algorithm is a greedy algorithm that finds a Minimum Spanning Tree (MST) for a weighted undirected graph. It builds the MST by adding edges in order of increasing weight, ensuring no cycles are formed.
               </p>
             </div>
             <div>
               <h4 style={{ color: 'var(--theme-primary)', marginBottom: '0.5rem' }}>🎯 Key Principle</h4>
               <p style={{ color: 'var(--text-secondary)', lineHeight: '1.6', margin: 0 }}>
-                <strong>Greedy Choice Property:</strong> At each step, choose the minimum weight edge that connects the current MST to an unvisited vertex. This ensures the total weight remains minimal.
+                <strong>Greedy Choice Property:</strong> At each step, choose the smallest edge that connects two different components. This ensures the total weight remains minimal while avoiding cycles.
               </p>
             </div>
           </div>
 
           <div style={{ marginBottom: '1.5rem' }}>
-            <h4 style={{ color: 'var(--theme-primary)', marginBottom: '0.5rem' }}>🛠️ How Prim's Algorithm Works</h4>
+            <h4 style={{ color: 'var(--theme-primary)', marginBottom: '0.5rem' }}>🛠️ How Kruskal's Algorithm Works</h4>
             <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '1.5rem' }}>
               <div style={{ background: 'var(--accent-bg)', padding: '1rem', borderRadius: '6px' }}>
-                <h5 style={{ color: 'var(--theme-secondary)', margin: '0 0 0.5rem 0' }}>Phase 1: Initialization</h5>
+                <h5 style={{ color: 'var(--theme-secondary)', margin: '0 0 0.5rem 0' }}>Phase 1: Sort Edges</h5>
                 <ul style={{ color: 'var(--text-secondary)', margin: 0, paddingLeft: '1.2rem', lineHeight: '1.5' }}>
-                  <li>Choose an arbitrary starting vertex</li>
-                  <li>Initialize MST with this single vertex</li>
-                  <li>Create a priority queue of edges from visited vertices</li>
+                  <li>Sort all edges by weight in ascending order</li>
+                  <li>Initialize MST as empty</li>
+                  <li>Create disjoint sets for each vertex</li>
                   <li>Set initial MST cost to 0</li>
                 </ul>
               </div>
               <div style={{ background: 'var(--accent-bg)', padding: '1rem', borderRadius: '6px' }}>
-                <h5 style={{ color: 'var(--theme-secondary)', margin: '0 0 0.5rem 0' }}>Phase 2: Growth</h5>
+                <h5 style={{ color: 'var(--theme-secondary)', margin: '0 0 0.5rem 0' }}>Phase 2: Build MST</h5>
                 <ul style={{ color: 'var(--text-secondary)', margin: 0, paddingLeft: '1.2rem', lineHeight: '1.5' }}>
-                  <li>Find minimum weight edge connecting visited to unvisited vertex</li>
-                  <li>Add this edge and vertex to MST</li>
-                  <li>Update priority queue with new possible edges</li>
-                  <li>Repeat until all vertices are included</li>
+                  <li>Consider edges in sorted order</li>
+                  <li>Add edge if it connects different components</li>
+                  <li>Use Union-Find to merge components</li>
+                  <li>Repeat until all vertices are connected</li>
                 </ul>
               </div>
             </div>
@@ -65,8 +65,8 @@ const PrimPage = () => {
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: '1rem' }}>
             <div style={{ textAlign: 'center', padding: '1rem', background: 'var(--success-bg)', borderRadius: '6px' }}>
               <div style={{ fontSize: '1.5rem', marginBottom: '0.25rem' }}>⏱️</div>
-              <div style={{ fontWeight: 'bold', color: 'var(--theme-primary)' }}>O(V²)</div>
-              <div style={{ fontSize: '0.9rem', color: 'var(--text-secondary)' }}>Adjacency Matrix</div>
+              <div style={{ fontWeight: 'bold', color: 'var(--theme-primary)' }}>O(E log E)</div>
+              <div style={{ fontSize: '0.9rem', color: 'var(--text-secondary)' }}>Time Complexity</div>
             </div>
             <div style={{ textAlign: 'center', padding: '1rem', background: 'var(--warning-bg)', borderRadius: '6px' }}>
               <div style={{ fontSize: '1.5rem', marginBottom: '0.25rem' }}>💾</div>
@@ -84,15 +84,15 @@ const PrimPage = () => {
             <h4 style={{ color: 'var(--theme-primary)', margin: '0 0 0.5rem 0' }}>💡 Key Technical Details</h4>
             <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '1rem' }}>
               <div>
-                <h5 style={{ color: 'var(--theme-secondary)', margin: '0 0 0.25rem 0', fontSize: '0.95rem' }}>Priority Queue Usage</h5>
+                <h5 style={{ color: 'var(--theme-secondary)', margin: '0 0 0.25rem 0', fontSize: '0.95rem' }}>Union-Find Structure</h5>
                 <p style={{ color: 'var(--text-secondary)', fontSize: '0.9rem', margin: 0, lineHeight: '1.4' }}>
-                  Maintains edges from visited to unvisited vertices. Each iteration extracts minimum edge and updates queue with new possibilities.
+                  Uses disjoint set data structure with path compression and union by rank for efficient cycle detection and component merging.
                 </p>
               </div>
               <div>
-                <h5 style={{ color: 'var(--theme-secondary)', margin: '0 0 0.25rem 0', fontSize: '0.95rem' }}>Connected Graphs Only</h5>
+                <h5 style={{ color: 'var(--theme-secondary)', margin: '0 0 0.25rem 0', fontSize: '0.95rem' }}>Edge Sorting</h5>
                 <p style={{ color: 'var(--text-secondary)', fontSize: '0.9rem', margin: 0, lineHeight: '1.4' }}>
-                  Prim's algorithm requires the graph to be connected. For disconnected graphs, it will only span the component containing the start vertex.
+                  Sorting edges by weight is crucial. The algorithm considers edges in increasing order of weight to ensure optimality.
                 </p>
               </div>
             </div>
@@ -127,12 +127,12 @@ const PrimPage = () => {
       </div>
 
       {/* Visualizer Component */}
-      <PrimVisualizer />
+      <KruskalVisualizer />
 
       {/* Code Implementation Section */}
       <div className="theme-card" style={{ marginTop: '2rem' }}>
         <div className="theme-card-header">
-          <h3>Prim's Algorithm - Code Implementation</h3>
+          <h3>Kruskal's Algorithm - Code Implementation</h3>
           <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
             {["java", "python", "cpp", "javascript"].map((lang) => (
               <button
@@ -177,11 +177,11 @@ const PrimPage = () => {
           fontSize: '0.9rem',
           color: 'var(--text-secondary)'
         }}>
-          <strong>Note:</strong> This is the actual implementation code for Prim's algorithm in <strong>{selectedLanguage.toUpperCase()}</strong>. You can copy and use this code in your projects.
+          <strong>Note:</strong> This is the actual implementation code for Kruskal's algorithm in <strong>{selectedLanguage.toUpperCase()}</strong>. You can copy and use this code in your projects.
         </div>
       </div>
     </div>
   );
 };
 
-export default PrimPage;
+export default KruskalPage;

--- a/src/pages/PrimPage.jsx
+++ b/src/pages/PrimPage.jsx
@@ -8,7 +8,6 @@ const PrimPage = () => {
   const [selectedLanguage, setSelectedLanguage] = useState("java");
 
   const algorithmData = primsAlgorithms.prims || {};
-  const algorithmData = primsAlgorithms || {};
 
   return (
     <div className="theme-container">

--- a/src/utils/navigation.js
+++ b/src/utils/navigation.js
@@ -187,6 +187,12 @@ export const learnSections = [
         category: "Paradigms",
         tags: ["prim's", "mst", "minimum spanning tree", "greedy", "graph"],
       },
+      {
+        path: "/kruskal",
+        label: "Kruskal's Algorithm",
+        category: "Paradigms",
+        tags: ["kruskal's", "mst", "minimum spanning tree", "greedy", "graph"],
+      },
     ],
   },
   


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #1140 

## Rationale for this change

- Added **Kruskal's Algorithm visualization** under the Graphs topic as part of Minimum Spanning Tree (MST) support.
- Kruskal's Algorithm is a **greedy algorithm** that builds the MST by sorting all edges by weight and adding the smallest edge that does not form a cycle.
- This complements the existing Prim’s Algorithm and provides users with both major MST approaches for learning and comparison.

## What changes are included in this PR?

- Added **Kruskal's Algorithm** visualization component:
  - Step-by-step edge selection based on ascending weights.
  - Cycle detection visualization using Union-Find/Disjoint Set logic.
  - Real-time MST construction and weight tracking.
- Updated the **Graphs menu** under:
    - Prim’s Algorithm
    - Kruskal’s Algorithm

## Are these changes tested?

- Yes, Kruskal’s Algorithm was tested with various graph inputs to ensure:
  - Correct MST generation
  - Proper cycle detection
  - Smooth visualization transitions
- Verified that menu restructuring does not break existing links or functionality.
<img width="1919" height="903" alt="Screenshot 2025-10-06 220730" src="https://github.com/user-attachments/assets/8bb0976e-9568-43e7-9704-917e2c866710" />


## Are there any user-facing changes?

- Users can now access **Kruskal's Algorithm**
- Clear visualization of edge ordering, cycle checking, and MST formation.
