### PR TITLE
Add language preference persistence to StringPage component

### DIFF
--- a/src/pages/StringPage.jsx
+++ b/src/pages/StringPage.jsx
@@ -1,5 +1,5 @@
 // src/pages/StringPage.jsx
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import StringVisualizer from "../components/StringVisualizer";
 import { stringAlgorithms } from "../data/allCodes";
 import "../styles/global-theme.css";
@@ -8,6 +8,19 @@ import 'aos/dist/aos.css';
 
 const StringPage = () => {
   const [selectedLanguage, setSelectedLanguage] = useState("java");
+
+  // Restore last selected language on mount
+  useEffect(() => {
+    const savedLanguage = localStorage.getItem("StringPage.selectedLanguage");
+    if (savedLanguage && ["java", "python", "cpp"].includes(savedLanguage)) {
+      setSelectedLanguage(savedLanguage);
+    }
+  }, []);
+
+  // Persist language preference whenever it changes
+  useEffect(() => {
+    localStorage.setItem("StringPage.selectedLanguage", selectedLanguage);
+  }, [selectedLanguage]);
 
   const algorithmData = stringAlgorithms["KMP"] || {};
 


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #1234

## Rationale for this change

Improves user experience by persisting the selected programming language (Java/Python/C++) on the StringPage across page reloads and browser sessions.

## What changes are included in this PR?

- Added `useEffect` hook to restore saved language preference from `localStorage` on component mount
- Added `useEffect` hook to persist language selection to `localStorage` whenever user changes the language tab
- Added validation to ensure only valid language options (java, python, cpp) are restored

## Are these changes tested?

Manual testing:
1. Select a language tab on StringPage
2. Refresh the page or navigate away and return
3. Verify the previously selected language is still active

The change uses browser's native `localStorage` API with validation, minimizing risk of errors.

## Are there any user-facing changes?

**Yes** - Users will now have their language preference remembered automatically. Previously selected language tab will remain active after page refresh, eliminating the need to re-select it every time.