### PR TITLE
Add runtime complexity badges to algorithm pages

### DIFF
--- a/src/components/ComplexityBadge.jsx
+++ b/src/components/ComplexityBadge.jsx
@@ -1,0 +1,81 @@
+import React from "react";
+import "../styles/global-theme.css";
+
+/**
+ * ComplexityBadge - Display time and space complexity as small pill badges
+ * @param {string} time - Time complexity (e.g., "O(n log n)")
+ * @param {string} space - Space complexity (e.g., "O(n)")
+ */
+const ComplexityBadge = ({ time, space }) => {
+  // Return null if no complexity data provided
+  if (!time && !space) {
+    return null;
+  }
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        gap: "0.75rem",
+        flexWrap: "wrap",
+        alignItems: "center",
+      }}
+    >
+      {time && (
+        <div
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: "0.4rem",
+            padding: "0.4rem 0.9rem",
+            background: "var(--success-bg, #e8f5e9)",
+            border: "1px solid var(--success-border, #4caf50)",
+            borderRadius: "20px",
+            fontSize: "0.85rem",
+            fontWeight: "500",
+          }}
+        >
+          <span
+            style={{
+              fontSize: "1rem",
+            }}
+          >
+            ⏱️
+          </span>
+          <span style={{ color: "var(--text-primary)" }}>
+            <strong>Time:</strong> {time}
+          </span>
+        </div>
+      )}
+
+      {space && (
+        <div
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: "0.4rem",
+            padding: "0.4rem 0.9rem",
+            background: "var(--info-bg, #e3f2fd)",
+            border: "1px solid var(--info-border, #2196f3)",
+            borderRadius: "20px",
+            fontSize: "0.85rem",
+            fontWeight: "500",
+          }}
+        >
+          <span
+            style={{
+              fontSize: "1rem",
+            }}
+          >
+            💾
+          </span>
+          <span style={{ color: "var(--text-primary)" }}>
+            <strong>Space:</strong> {space}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ComplexityBadge;

--- a/src/data/algorithmComplexity.js
+++ b/src/data/algorithmComplexity.js
@@ -1,0 +1,197 @@
+// Algorithm complexity metadata
+// Time and space complexity for various algorithms
+
+export const algorithmComplexity = {
+  // Sorting Algorithms
+  bubbleSort: {
+    time: "O(n²)",
+    space: "O(1)",
+  },
+  selectionSort: {
+    time: "O(n²)",
+    space: "O(1)",
+  },
+  insertionSort: {
+    time: "O(n²)",
+    space: "O(1)",
+  },
+  mergeSort: {
+    time: "O(n log n)",
+    space: "O(n)",
+  },
+  quickSort: {
+    time: "O(n log n)",
+    space: "O(log n)",
+  },
+  heapSort: {
+    time: "O(n log n)",
+    space: "O(1)",
+  },
+  timSort: {
+    time: "O(n log n)",
+    space: "O(n)",
+  },
+  cycleSort: {
+    time: "O(n²)",
+    space: "O(1)",
+  },
+  introSort: {
+    time: "O(n log n)",
+    space: "O(log n)",
+  },
+  shellSort: {
+    time: "O(n log n)",
+    space: "O(1)",
+  },
+  radixSort: {
+    time: "O(nk)",
+    space: "O(n + k)",
+  },
+  bucketSort: {
+    time: "O(n + k)",
+    space: "O(n + k)",
+  },
+
+  // Searching Algorithms
+  linearSearch: {
+    time: "O(n)",
+    space: "O(1)",
+  },
+  binarySearch: {
+    time: "O(log n)",
+    space: "O(1)",
+  },
+  ternarySearch: {
+    time: "O(log₃ n)",
+    space: "O(1)",
+  },
+  jumpSearch: {
+    time: "O(√n)",
+    space: "O(1)",
+  },
+  exponentialSearch: {
+    time: "O(log n)",
+    space: "O(1)",
+  },
+
+  // Graph Algorithms
+  BFS: {
+    time: "O(V + E)",
+    space: "O(V)",
+  },
+  DFS: {
+    time: "O(V + E)",
+    space: "O(V)",
+  },
+  dijkstra: {
+    time: "O((V + E) log V)",
+    space: "O(V)",
+  },
+  aStar: {
+    time: "O(E)",
+    space: "O(V)",
+  },
+  prims: {
+    time: "O(E log V)",
+    space: "O(V)",
+  },
+  kruskal: {
+    time: "O(E log E)",
+    space: "O(V)",
+  },
+
+  // String Algorithms
+  KMP: {
+    time: "O(n + m)",
+    space: "O(m)",
+  },
+  rabinKarp: {
+    time: "O(n + m)",
+    space: "O(1)",
+  },
+
+  // Dynamic Programming
+  fibonacci: {
+    time: "O(n)",
+    space: "O(n)",
+  },
+  knapsack: {
+    time: "O(nW)",
+    space: "O(nW)",
+  },
+  longestCommonSubsequence: {
+    time: "O(mn)",
+    space: "O(mn)",
+  },
+  editDistance: {
+    time: "O(mn)",
+    space: "O(mn)",
+  },
+
+  // Greedy Algorithms
+  huffman: {
+    time: "O(n log n)",
+    space: "O(n)",
+  },
+  activitySelection: {
+    time: "O(n log n)",
+    space: "O(1)",
+  },
+
+  // Backtracking
+  nQueens: {
+    time: "O(n!)",
+    space: "O(n²)",
+  },
+  sudoku: {
+    time: "O(9^m)",
+    space: "O(1)",
+  },
+
+  // Hashing
+  hashTable: {
+    time: "O(1) avg",
+    space: "O(n)",
+  },
+
+  // Tree Algorithms
+  binarySearchTree: {
+    time: "O(log n) avg",
+    space: "O(n)",
+  },
+  avlTree: {
+    time: "O(log n)",
+    space: "O(n)",
+  },
+
+  // Divide and Conquer
+  mergeSort_DC: {
+    time: "O(n log n)",
+    space: "O(n)",
+  },
+  quickSort_DC: {
+    time: "O(n log n)",
+    space: "O(log n)",
+  },
+
+  // Branch and Bound
+  travelingSalesman: {
+    time: "O(n!)",
+    space: "O(n)",
+  },
+
+  // Game Search
+  minimax: {
+    time: "O(b^d)",
+    space: "O(bd)",
+  },
+  alphaBeta: {
+    time: "O(b^(d/2))",
+    space: "O(bd)",
+  },
+};
+
+// Helper function to get complexity for an algorithm
+export const getComplexity = (algorithmName) => {
+  return algorithmComplexity[algorithmName] || null;
+};

--- a/src/pages/GraphDijkstra.jsx
+++ b/src/pages/GraphDijkstra.jsx
@@ -3,12 +3,16 @@ import GraphVisualizer from "../components/GraphVisualizer";
 import InputPanel from "../components/InputPanel";
 import { graphAlgorithms } from "../data/allCodes";
 import { getSampleData, getValidationRule } from "../data/sampleData";
+import { getComplexity } from "../data/algorithmComplexity";
+import ComplexityBadge from "../components/ComplexityBadge";
 import "../styles/global-theme.css";
 
 const GraphDijkstra = () => {
   const [selectedLanguage, setSelectedLanguage] = useState("java");
   const [customGraph, setCustomGraph] = useState(null);
   const [inputText, setInputText] = useState("");
+  
+  const complexity = getComplexity("dijkstra");
 
   // Enhanced handler for InputPanel
   const handleGraphDataLoaded = (graphData) => {
@@ -36,8 +40,11 @@ const GraphDijkstra = () => {
 
   return (
     <div className="theme-container">
-      <h1 className="theme-title">Dijkstra's Algorithm</h1>
-      <p style={{ textAlign: 'center', maxWidth: '700px', margin: '-2rem auto 2rem auto', color: 'var(--theme-text-secondary)' }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexWrap: 'wrap', gap: '1rem', marginBottom: '0.5rem' }}>
+        <h1 className="theme-title" style={{ margin: 0 }}>Dijkstra's Algorithm</h1>
+        <ComplexityBadge time={complexity?.time} space={complexity?.space} />
+      </div>
+      <p style={{ textAlign: 'center', maxWidth: '700px', margin: '0.5rem auto 2rem auto', color: 'var(--theme-text-secondary)' }}>
         Visualize shortest paths using Dijkstra's algorithm. Use the input panel below to load your own weighted graph data.
       </p>
 

--- a/src/pages/SortingDoc.jsx
+++ b/src/pages/SortingDoc.jsx
@@ -4,6 +4,8 @@ import { useParams, Link } from "react-router-dom";
 import { ALGORITHM_INFO } from "../data/algorithmInfo";
 import { ALGORITHM_PSEUDOCODE as PSEUDO } from "../data/pseudocode";
 import { sortingAlgorithms as CODE } from "../data/allCodes";
+import { getComplexity } from "../data/algorithmComplexity";
+import ComplexityBadge from "../components/ComplexityBadge";
 import "../styles/SortingDoc.css";
 
 /* helpers */
@@ -51,6 +53,7 @@ export default function SortingDoc() {
   const info = resolvedKey ? INFO_ROOT[resolvedKey] : null;
   const pseudo = resolvedKey ? PSEUDO_ROOT?.[resolvedKey] : null;
   const code = resolvedKey ? CODE_ROOT?.[resolvedKey] : null;
+  const complexity = resolvedKey ? getComplexity(resolvedKey) : null;
 
   const title = useMemo(() => toTitle(resolvedKey || algoId || ""), [
     resolvedKey,
@@ -84,6 +87,11 @@ export default function SortingDoc() {
           <h1 className="doc-title">
             {title} <span className="tag">docs</span>
           </h1>
+          {complexity && (
+            <div style={{ marginTop: '0.75rem', marginBottom: '0.75rem' }}>
+              <ComplexityBadge time={complexity.time} space={complexity.space} />
+            </div>
+          )}
           <p className="muted">
             {info.description ?? "No description available."}
           </p>

--- a/src/pages/StringPage.jsx
+++ b/src/pages/StringPage.jsx
@@ -2,6 +2,8 @@
 import React, { useState } from "react";
 import StringVisualizer from "../components/StringVisualizer";
 import { stringAlgorithms } from "../data/allCodes";
+import { getComplexity } from "../data/algorithmComplexity";
+import ComplexityBadge from "../components/ComplexityBadge";
 import "../styles/global-theme.css";
 import AOS from 'aos';
 import 'aos/dist/aos.css';
@@ -10,10 +12,14 @@ const StringPage = () => {
   const [selectedLanguage, setSelectedLanguage] = useState("java");
 
   const algorithmData = stringAlgorithms["KMP"] || {};
+  const complexity = getComplexity("KMP");
 
   return (
     <div className="theme-container" data-aos="fade-up" data-aos-duration="1000">
-      <h1 className="theme-title">KMP String Matching Algorithm</h1>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexWrap: 'wrap', gap: '1rem', marginBottom: '1rem' }}>
+        <h1 className="theme-title" style={{ margin: 0 }}>KMP String Matching Algorithm</h1>
+        <ComplexityBadge time={complexity?.time} space={complexity?.space} />
+      </div>
 
       {/* KMP Algorithm Explanation */}
       <div className="theme-card" style={{ marginBottom: '2rem' }} data-aos="fade-up" data-aos-delay="100">


### PR DESCRIPTION
**Title:** Add runtime complexity badges to algorithm pages

Closes issue #1237

**Description:**

### Problem
Algorithm pages don't display time and space complexity information prominently, making it harder for users to quickly understand the performance characteristics of algorithms.

### Solution
Add visual complexity badges (pill-style) showing Big-O notation for time and space complexity on algorithm pages.

### Implementation
- Created reusable `ComplexityBadge` component
- Added central `algorithmComplexity.js` metadata file with 40+ algorithms
- Integrated badges into KMP, sorting documentation, and Dijkstra pages
- Graceful degradation when complexity data unavailable

### Benefits
- Quick visual reference for algorithm complexity
- Educational value for learning Big-O notation
- Improved UX with clear, scannable information
- Easy to extend to more algorithms

### Files Modified/Created
- `src/components/ComplexityBadge.jsx` (new)
- `src/data/algorithmComplexity.js` (new)
- `src/pages/StringPage.jsx`
- `src/pages/SortingDoc.jsx`
- `src/pages/GraphDijkstra.jsx`
- `COMPLEXITY_BADGE_DOCS.md` (new)