### PR TITLE
Fix: Corrected the answer of binary search question(id:56)

### DIFF
--- a/src/data/quizQuestions.json
+++ b/src/data/quizQuestions.json
@@ -836,7 +836,7 @@
             "O(n log n)",
             "O(n\u00b2)"
         ],
-        "correctAnswer": 1,
+        "correctAnswer": 0,
         "explanation": "In the best case, Binary Search can often achieve O(1), especially when data is already partially structured."
     },
     {


### PR DESCRIPTION
## Which issue does this PR close?
- Closes #1170

## Rationale for this change
In the Searching Quiz (Binary Search question), the correct answer(O(1)) was being marked incorrect due to a mismatch in answer validation logic.The answer earlier marked correct was O(N).
This created confusion for users attempting the quiz, as the explanation showed the correct answer but it was not validated properly.

## What changes are included in this PR?
- Fixed the incorrect `correctAnswer` index in the `quiz.js` file for the Binary Search question.  
- Verified that the answer now aligns correctly with the explanation.

## Are these changes tested?
Yes ✅  
Tested locally in the browser — the correct Binary Search answer now validates as expected and displays the right explanation.
Below is the proof:
<img width="953" height="371" alt="image" src="https://github.com/user-attachments/assets/ca0d8b5b-2edb-45ff-a043-7088784645c4" />


## Are there any user-facing changes?
Yes —  
Users will now see accurate answer validation in the **Binary Search** quiz question, improving learning accuracy and user experience.
 