### PR TITLE
Docs: Added Access Modifier Notes for Java

### DIFF
--- a/src/pages/Notes/Java/Fundamentals.jsx
+++ b/src/pages/Notes/Java/Fundamentals.jsx
@@ -33,6 +33,7 @@ import DataStructuresSection from "./sections/DataStructuresSection";
 import Abstract from "./sections/Abstract";
 import Feature from "./sections/Feature";
 import Annotations from "./sections/Annotations";
+import AccessModifiers from "./sections/AccessModifiers";
 
 import "../../../styles/notesSideBar.css";
 import "../../../styles/fundamentals.css";
@@ -265,7 +266,11 @@ const Fundamentals = () => {
           label: "Abstract",
           component: <Abstract copyCode={copyCode} copiedCode={copiedCode} />,
         },
-        "Access Modifiers",
+        {
+          id: "accessmodifiers",
+          label: "Access Modifiers",
+          component: <AccessModifiers copyCode={copyCode} copiedCode={copiedCode} />,
+        },
       ],
     },
     {

--- a/src/pages/Notes/Java/sections/AccessModifiers.jsx
+++ b/src/pages/Notes/Java/sections/AccessModifiers.jsx
@@ -1,0 +1,265 @@
+import React from "react";
+
+const AccessModifiers = ({ copyCode, copiedCode }) => {
+  return (
+    <div>
+      <div className="card">
+        <h2 style={{ textAlign: "center", fontSize: "2.3rem" }}>
+          Access Modifiers in Java
+        </h2>
+        <p>
+          Access modifiers in Java define how accessible classes, methods, and
+          variables are from other parts of the program. They help you protect
+          data and control visibility — an important part of encapsulation.
+        </p>
+
+        <h3>Types of Access Modifiers</h3>
+        <p>Java provides four access levels:</p>
+        <ul>
+          <li>
+            <strong>public</strong> – accessible everywhere.
+          </li>
+          <li>
+            <strong>protected</strong> – accessible within the same package and
+            subclasses.
+          </li>
+          <li>
+            <strong>default</strong> (no modifier) – accessible within the same
+            package only.
+          </li>
+          <li>
+            <strong>private</strong> – accessible within the same class only.
+          </li>
+        </ul>
+
+        {/* Public Modifier */}
+        <h2>1. Public</h2>
+        <p>
+          A <code>public</code> member can be accessed from anywhere — inside or
+          outside the class, even from other packages.
+        </p>
+        <div className="code-container">
+          <button
+            className={`copy-btn ${
+              copiedCode === "public_code" ? "copied" : ""
+            }`}
+            onClick={() =>
+              copyCode(
+                `public class Car {
+    public String model = "Tesla Model 3";
+
+    public void start() {
+        System.out.println("Car started!");
+    }
+}
+
+public class Main {
+    public static void main(String[] args) {
+        Car car = new Car();
+        System.out.println(car.model);  // Accessible
+        car.start();                    // Accessible
+    }
+}`,
+                "public_code"
+              )
+            }
+          >
+            {copiedCode === "public_code" ? "Copied!" : "Copy"}
+          </button>
+          <pre>
+            {`
+public class Car {
+    public String model = "Tesla Model 3";
+
+    public void start() {
+        System.out.println("Car started!");
+    }
+}
+
+public class Main {
+    public static void main(String[] args) {
+        Car car = new Car();
+        System.out.println(car.model);  // Accessible
+        car.start();                    // Accessible
+    }
+}
+`}
+          </pre>
+        </div>
+
+        {/* Default Modifier */}
+        <h2>2. Default (No Modifier)</h2>
+        <p>
+          If no access modifier is specified, Java gives it{" "}
+          <strong>package-private</strong> visibility — accessible only within
+          the same package.
+        </p>
+        <div className="code-container">
+          <button
+            className={`copy-btn ${
+              copiedCode === "default_code" ? "copied" : ""
+            }`}
+            onClick={() =>
+              copyCode(
+                `class Car {
+    String model = "Honda Civic";  // default access
+
+    void start() {
+        System.out.println("Car started!");
+    }
+}`,
+                "default_code"
+              )
+            }
+          >
+            {copiedCode === "default_code" ? "Copied!" : "Copy"}
+          </button>
+          <pre>
+            {`
+class Car {
+    String model = "Honda Civic";  // default access
+
+    void start() {
+        System.out.println("Car started!");
+    }
+}
+`}
+          </pre>
+        </div>
+
+        {/* Protected Modifier */}
+        <h2>3. Protected</h2>
+        <p>
+          A <code>protected</code> member is visible within the same package and
+          to subclasses, even if they are in different packages.
+        </p>
+        <div className="code-container">
+          <button
+            className={`copy-btn ${
+              copiedCode === "protected_code" ? "copied" : ""
+            }`}
+            onClick={() =>
+              copyCode(
+                `class Vehicle {
+    protected String type = "Electric Vehicle";
+}
+
+class Car extends Vehicle {
+    void displayType() {
+        System.out.println(type);  // Accessible via inheritance
+    }
+}
+
+public class Main {
+    public static void main(String[] args) {
+        Car car = new Car();
+        car.displayType();  // Output: Electric Vehicle
+    }
+}`,
+                "protected_code"
+              )
+            }
+          >
+            {copiedCode === "protected_code" ? "Copied!" : "Copy"}
+          </button>
+          <pre>
+            {`
+class Vehicle {
+    protected String type = "Electric Vehicle";
+}
+
+class Car extends Vehicle {
+    void displayType() {
+        System.out.println(type);  // Accessible via inheritance
+    }
+}
+
+public class Main {
+    public static void main(String[] args) {
+        Car car = new Car();
+        car.displayType();  // Output: Electric Vehicle
+    }
+}
+`}
+          </pre>
+        </div>
+
+        {/* Private Modifier */}
+        <h2>4. Private</h2>
+        <p>
+          A <code>private</code> member is only accessible within its own class.
+          It’s the most restrictive modifier and ensures data encapsulation.
+        </p>
+        <div className="code-container">
+          <button
+            className={`copy-btn ${
+              copiedCode === "private_code" ? "copied" : ""
+            }`}
+            onClick={() =>
+              copyCode(
+                `public class Account {
+    private double balance = 5000.0;
+
+    public void showBalance() {
+        System.out.println("Balance: " + balance);
+    }
+}
+
+public class Main {
+    public static void main(String[] args) {
+        Account acc = new Account();
+        // System.out.println(acc.balance); // Error: balance has private access
+        acc.showBalance();  // Output: Balance: 5000.0
+    }
+}`,
+                "private_code"
+              )
+            }
+          >
+            {copiedCode === "private_code" ? "Copied!" : "Copy"}
+          </button>
+          <pre>
+            {`
+public class Account {
+    private double balance = 5000.0;
+
+    public void showBalance() {
+        System.out.println("Balance: " + balance);
+    }
+}
+
+public class Main {
+    public static void main(String[] args) {
+        Account acc = new Account();
+        // System.out.println(acc.balance); // Error: balance has private access
+        acc.showBalance();  // Output: Balance: 5000.0
+    }
+}
+`}
+          </pre>
+        </div>
+
+        {/* Key Takeaways */}
+        <h3>Key Takeaways</h3>
+
+        <ul>
+          <li>Access modifiers control visibility and encapsulation.</li>
+          <li>Use <code>private</code> for sensitive data.</li>
+          <li>
+            Use <code>public</code> for APIs or methods that should be globally
+            accessible.
+          </li>
+          <li>
+            <code>protected</code> and <code>default</code> are middle levels of
+            access control.
+          </li>
+          <li>
+            Mixing modifiers properly helps you design secure, modular programs.
+          </li>
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+export default AccessModifiers;


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #1278

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

The Access Modifiers section under Java Notes was empty.
This PR adds well-structured, beginner-friendly notes explaining the four Java access modifiers — public, private, protected, and default — along with examples and explanations to make the documentation more complete and helpful for new learners.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Added a new subsection titled “Access Modifiers in Java” in the documentation folder.
- Explained each modifier with clear examples and when to use them.
- Used JSX format consistent with the existing structure of other Java Notes components.
- Ensured code snippets have working copy buttons and styling consistent with other pages.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes — the new notes component was locally previewed in the development environment

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
Yes — the Java Notes section now includes a complete and readable explanation of Access Modifiers
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->