### PR TITLE
🐞 Bug: "View Leaderboard" Button Redirects to Wrong Page Fixed 

### DIFF
--- a/src/pages/CommunityLanding.jsx
+++ b/src/pages/CommunityLanding.jsx
@@ -623,7 +623,7 @@ const CommunityLanding = () => {
 
               <div style={{ marginTop: "auto" }}>
                 <Link
-                  to="/ContributorLeaderboard"
+                  to="/contributor-leaderboard"
                   className="btn btn-secondary"
                   style={{
                     display: "inline-flex",


### PR DESCRIPTION
## Which issue does this PR close?

- Closes : #1220 


https://github.com/user-attachments/assets/e61537d8-f3a0-4989-b71b-7477cffef440


## What changes are included in this PR?

Fixed the path of 
Community Page → Bottom Section → Leaderboard Panel → View Leaderboard button

## Are these changes tested?

Tested in chrome brower

## Are there any user-facing changes?

Yes, now the page correctly redirect to the Gssoc Leaderboard