### PR TITLE
changed Trie into Tree

### DIFF
--- a/src/pages/DataStructures.jsx
+++ b/src/pages/DataStructures.jsx
@@ -343,7 +343,7 @@ const algorithmDatabase = {
         implemented: true,
       },
       {
-        name: "Trie",
+        name: "Tree",
         id: "trie",
         description:
           "Prefix tree data structure for efficient string operations like search, insert, and prefix matching.",


### PR DESCRIPTION
## Which issue does this PR close?


- Closes #1341 .

## Rationale for this change

This PR corrects a minor spelling mistake in the documentation where "trie" was mistakenly used instead of "tree". Accurate terminology is important to avoid confusion, especially for new contributors or readers referencing the documentation.


## What changes are included in this PR?

Corrected the spelling of "trie" to "tree" under the Documentation section.


## Are these changes tested?

Yes 

<img width="1647" height="693" alt="image" src="https://github.com/user-attachments/assets/8776f688-bb28-49ae-9e5c-471db0c3512f" />
