### PR TITLE
Forgot Password Page Styled

### DIFF
--- a/src/pages/ForgotPassword.css
+++ b/src/pages/ForgotPassword.css
@@ -1,0 +1,125 @@
+.forgot-password-container {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 100vh;
+    background: #f8fafc; 
+    font-family: "Poppins", sans-serif;
+  }
+  
+  .forgot-password-form {
+    display: flex;
+    flex-direction: column;
+    align-items: center; 
+    width: 100%;
+  }
+
+  .main-container {
+    background: #ffffff;
+    padding: 40px 50px;
+    border-radius: 12px;
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+    text-align: center;
+    width: 100%;
+    max-width: 380px;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+  }
+  
+  .main-container:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.15);
+  }
+ 
+  h2 {
+    margin-bottom: 25px;
+    color: #1a202c;
+    font-size: 22px;
+    font-weight: 600;
+    display:flex;
+    justify-content: space-around;
+  }
+  .main-container h2 {
+    text-align: center;
+    width: 100%;
+    margin-bottom: 25px;
+  }
+  .label {
+    font-size: 15px;
+    color: #4a5568;
+    margin-bottom: 8px;
+    display: block;
+    text-align: left;
+    display:flex;
+    justify-content: space-around;  
+  }
+
+  input[type="email"] {
+    width: 100%;
+    padding: 12px 15px;
+    border: 1px solid #cbd5e0;
+    border-radius: 6px;
+    outline: none;
+    font-size: 15px;
+    transition: border-color 0.3s ease, box-shadow 0.3s ease;
+    width: 100%;
+    max-width: 280px;
+  }
+  
+  input[type="email"]:focus {
+    border-color: #3182ce;
+    box-shadow: 0 0 0 3px rgba(49, 130, 206, 0.2);
+  }
+
+  button {
+    width: 100%;
+    padding: 12px 0;
+    font-size: 16px;
+    color: #fff;
+    background-color: #007bff;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: background-color 0.3s ease, transform 0.2s ease;
+    width: 100%;
+    max-width: 280px;
+  }
+  
+  button:hover {
+    background-color: #0056b3;
+    transform: scale(1.03);
+  }
+  
+  button:disabled {
+    background-color: #9ca3af;
+    cursor: not-allowed;
+  }
+
+  .success-message {
+    color: #16a34a;
+    background: #dcfce7;
+    padding: 10px;
+    border-radius: 6px;
+    margin-top: 15px;
+    font-size: 14px;
+  }
+  
+  .error-message {
+    color: #dc2626;
+    background: #fee2e2;
+    padding: 10px;
+    border-radius: 6px;
+    margin-top: 15px;
+    font-size: 14px;
+  }
+
+  @media (max-width: 480px) {
+    .main-container {
+      padding: 30px 25px;
+      max-width: 90%;
+    }
+  
+    h2 {
+      font-size: 20px;
+    }
+  }
+  

--- a/src/pages/ForgotPassword.jsx
+++ b/src/pages/ForgotPassword.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import authService from "../services/authService"; 
+import "./ForgotPassword.css";
 
 const ForgotPassword = () => {
   const [email, setEmail] = useState("");
@@ -31,9 +32,10 @@ const ForgotPassword = () => {
 
   return (
     <div className="forgot-password-container">
-      <h2>Forgot Password</h2>
+      <div class="main-container">
+      <h2><b>Forgot Password</b></h2>
       <form onSubmit={handleSubmit} className="forgot-password-form">
-        <label htmlFor="email">Enter your registered email:</label>
+        <label class="label" htmlFor="email">Enter your registered email</label><br></br>
         <input
           type="email"
           id="email"
@@ -41,7 +43,7 @@ const ForgotPassword = () => {
           placeholder="example@gmail.com"
           onChange={(e) => setEmail(e.target.value)}
           required
-        />
+        /> <br></br>
         <button type="submit" disabled={loading}>
           {loading ? "Sending..." : "Send Reset Link"}
         </button>
@@ -50,6 +52,7 @@ const ForgotPassword = () => {
       {/* Display messages */}
       {message && <p className="success-message">{message}</p>}
       {error && <p className="error-message">{error}</p>}
+    </div>
     </div>
   );
 };


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #1362 .

## Rationale for this change

Earlier, the forgot password page was not having the styling instead all the options were at the extreme left. But, now the the perfect styling is done which is very similar to the login page , so that they would look same.   

## What changes are included in this PR?
1. Improved overall layout of the Forgot Password page for cleaner and modern UI.
2. Centered the “Forgot Password” heading properly.
3. Centered the form elements (email input & button) inside the card.
4. Made the button and input field same width for better alignment.
5. Added spacing and consistent margins between elements.
6. Added hover effect and subtle card shadow for better visual feedback.
7. Improved responsiveness for smaller screens.

## Are these changes tested?

Yes , all the changes are tested on the localhost.

## Are there any user-facing changes?
The Forgot Password section now looks centered, responsive, and consistent with the project’s theme.

Image of the forgot password styled page:-
<img width="1366" height="684" alt="iphone 1" src="https://github.com/user-attachments/assets/ca56ec03-2b23-4acc-985c-73dc7fadd381" />
<img width="1366" height="683" alt="iphone 2" src="https://github.com/user-attachments/assets/f6c385e1-ee00-49c1-a10d-1890b80681d0" />

