### PR TITLE
Spacing between Stay Updated Email section

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -52,15 +52,16 @@ const NewsletterForm = ({ email, setEmail, isLoading, handleSubmit, isSubscribed
     <form onSubmit={handleSubmit} className="newsletter-form">
       <div className="input-container">
         <FaEnvelope className="input-icon" />
-        <input
-          type="email"
-          placeholder="Enter your email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          className="newsletter-input"
-          disabled={isLoading}
-        />
       </div>
+      <input
+        type="email"
+        placeholder="    Enter your email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        className="newsletter-input"
+        disabled={isLoading}
+      />
+
       <button
         type="submit"
         className={`newsletter-btn ${isLoading ? "loading" : ""}`}

--- a/src/styles/footer.css
+++ b/src/styles/footer.css
@@ -417,12 +417,14 @@
 .input-container {
   position: relative;
   width: 100%;
+  gap: 10px;
 }
 
 .input-icon {
   position: absolute;
   left: clamp(12px, 2.5vw, 15px);
   top: 50%;
+  margin-top:40px;
   transform: translateY(-50%);
   color: var(--text-muted, #9ca3af);
   font-size: clamp(14px, 3vw, 16px);


### PR DESCRIPTION
Which issue does this PR close?

Closes #1395

Rationale for this change

The "Stay Updated" email input section currently has insufficient spacing between the email icon (FaEnvelope) and the input placeholder text, causing a cluttered and unbalanced UI. Improving spacing enhances readability and maintains consistent design alignment with the rest of the page.

What changes are included in this PR?
Added appropriate spacing between the FaEnvelope icon and the input field inside the "Stay Updated" section.
Updated CSS to include a left margin or gap between the icon and text.
Ensured responsiveness and consistent visual alignment across screen sizes.

Are these changes tested?
Yes.
Verified spacing visually across different browsers and screen resolutions.
Confirmed that input functionality (typing, focus, and placeholder visibility) remains unaffected.

Are there any user-facing changes?
Yes.

Users will see improved spacing between the email icon and input placeholder in the "Stay Updated" section, resulting in a cleaner and more readable interface.