### PR TITLE
fix: remove orange highlight blocking text in overview pages(#1385)

### DIFF
--- a/src/pages/BacktrackingOverview.jsx
+++ b/src/pages/BacktrackingOverview.jsx
@@ -9,7 +9,7 @@ const BacktrackingOverview = () => {
   return (
     <div className="theme-container" data-aos="fade-up" data-aos-duration="1000">
       <h1 className="theme-title" style={{ marginTop: "4rem" }}>
-        Guide to <span className="highlight">Backtracking</span>
+        Guide to <span style={{ color: "var(--accent-primary)" }}>Backtracking</span>
       </h1>
 
       <p

--- a/src/pages/BranchBoundOverview.jsx
+++ b/src/pages/BranchBoundOverview.jsx
@@ -120,7 +120,7 @@ const BranchBoundOverview = () => {
         data-aos="fade-up"
         data-aos-delay="100"
       >
-        Guide to <span className="highlight">Branch and Bound</span>
+        Guide to <span style={{ color: "var(--accent-primary)" }}>Branch and Bound</span>
       </h1>
 
       <p

--- a/src/pages/DCOverview.jsx
+++ b/src/pages/DCOverview.jsx
@@ -9,7 +9,7 @@ const DCOverview = () => {
   return (
     <div className="theme-container" data-aos="fade-up" data-aos-duration="1000">
       <h1 className="theme-title" style={{ marginTop: "4rem" }}>
-        Guide to <span className="highlight">Divide & Conquer</span>
+        Guide to <span style={{ color: "var(--accent-primary)" }}>Divide & Conquer</span>
       </h1>
 
       <p

--- a/src/pages/DPOverview.jsx
+++ b/src/pages/DPOverview.jsx
@@ -9,7 +9,7 @@ const DPOverview = () => {
   return (
     <div className="theme-container" data-aos="fade-up" data-aos-duration="1000">
       <h1 className="theme-title" style={{ marginTop: "4rem" }}>
-        Guide to <span className="highlight">Dynamic Programming</span>
+        Guide to <span style={{ color: "var(--accent-primary)" }}>Dynamic Programming</span>
       </h1>
 
       <p

--- a/src/pages/GameSearchOverview.jsx
+++ b/src/pages/GameSearchOverview.jsx
@@ -9,7 +9,7 @@ const GameSearchOverview = () => {
   return (
     <div className="theme-container" data-aos="fade-up" data-aos-duration="1000">
       <h1 className="theme-title" style={{ marginTop: "4rem" }}>
-        Guide to <span className="highlight">Game Search Algorithms</span>
+        Guide to <span style={{ color: "var(--accent-primary)" }}>Game Search Algorithms</span>
       </h1>
 
       <p

--- a/src/pages/GreedyOverview.jsx
+++ b/src/pages/GreedyOverview.jsx
@@ -7,7 +7,7 @@ const GreedyOverview = () => {
   return (
     <div className="theme-container">
       <h1 className="theme-title" style={{ marginTop: "4rem" }}>
-        Guide to <span className="highlight">Greedy Algorithms</span>
+        Guide to <span style={{ color: "var(--accent-primary)" }}>Greedy Algorithms</span>
       </h1>
 
       <p

--- a/src/pages/HashingOverview.jsx
+++ b/src/pages/HashingOverview.jsx
@@ -9,7 +9,7 @@ const HashingOverview = () => {
   return (
     <div className="theme-container" data-aos="fade-up" data-aos-duration="1000">
       <h1 className="theme-title" style={{ marginTop: "4rem" }}>
-        Guide to <span className="highlight">Hashing</span>
+        Guide to <span style={{ color: "var(--accent-primary)" }}>Hashing</span>
       </h1>
 
       <p

--- a/src/pages/SearchingOverview.jsx
+++ b/src/pages/SearchingOverview.jsx
@@ -2,9 +2,9 @@ import "../styles/global-theme.css";
 import Searching from "./Searching";
 const SearchingOverview = () => {
   return (
-    <div className="theme -container">
+    <div className="theme-container">
       <h1 className="theme-title" style={{ marginTop: "4rem" }}>
-        Guide to <span className="highlight">Searching</span>{" "}
+        Guide to <span style={{ color: "var(--accent-primary)" }}>Searching</span>
       </h1>
       <p
         style={{

--- a/src/pages/StringOverview.jsx
+++ b/src/pages/StringOverview.jsx
@@ -9,7 +9,7 @@ const StringOverview = () => {
   return (
     <div className="theme-container" data-aos="fade-up" data-aos-duration="1000">
       <h1 className="theme-title" style={{ marginTop: "4rem" }}>
-        Guide to <span className="highlight">String Algorithms</span>
+        Guide to <span style={{ color: "var(--accent-primary)" }}>String Algorithms</span>
       </h1>
 
       <p

--- a/src/pages/TreeOverview.jsx
+++ b/src/pages/TreeOverview.jsx
@@ -7,7 +7,7 @@ const TreeOverview = () => {
   return (
     <div className="theme-container">
       <h1 className="theme-title" style={{ marginTop: "4rem" }}>
-        Guide to <span className="highlight">Tree Algorithms</span>
+        Guide to <span style={{ color: "var(--accent-primary)" }}>Tree Algorithms</span>
       </h1>
 
       <p


### PR DESCRIPTION
## Description
Removed the orange highlight box that was blocking text in all overview pages of the Learn section. This improves readability and ensures a consistent look across all topics.  

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #1385

## Rationale for this change

The previous implementation used `className="highlight"` for topic titles, which applied an orange background that overlapped text content in some cases.  
This made text hard to read and caused inconsistent UI across overview pages.  
Replacing the highlight with inline color styling ensures that all text remains readable, while maintaining visual emphasis using the theme color.  

## What changes are included in this PR?
- Removed the orange background box from all topic titles  
- Fixed the text blocking issue across the Learn section overview pages  
- Applied changes to the following 10 overview files:  
  - `SearchingOverview.jsx`  
  - `TreeOverview.jsx`  
  - `BacktrackingOverview.jsx`  
  - `DPOverview.jsx`  
  - `GreedyOverview.jsx`  
  - `DCOverview.jsx`  
  - `StringOverview.jsx`  
  - `HashingOverview.jsx`  
  - `GameSearchOverview.jsx`  
  - `BranchAndBoundOverview.jsx`  
  - 
Fixes #1385
