### PR TITLE
Navbar Dropdown Working implemented

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -54,6 +54,8 @@ const DesktopNavItem = ({
   toggleDropdown,
   isActive,
   getIcon,
+  selectedCommunity,
+  setSelectedCommunity
 }) => {
   if (item.dropdown) {
     return (
@@ -67,7 +69,7 @@ const DesktopNavItem = ({
               size: 18,
               className: "drop-icon",
             })}
-          <span>{item.label}</span>
+          <span>{item.label === "Community" ? selectedCommunity : item.label}</span>
           <ChevronDown
             size={16}
             className={`dropdown-arrow ${isOpen === index ? "rotated" : ""}`}
@@ -82,7 +84,9 @@ const DesktopNavItem = ({
                 className={`dropdown-item ${
                   isActive(sub.path) ? "active" : ""
                 }`}
-                onClick={() => toggleDropdown(null)}
+                onClick={() => {if (item.label === "Community") setSelectedCommunity(sub.label);
+                  toggleDropdown(null);
+                }}
               >
                 {sub.label}
               </Link>
@@ -186,6 +190,8 @@ const Navbar = () => {
   const [mobileDropdownOpen, setMobileDropdownOpen] = useState(null);
   const [desktopNotesOpen, setDesktopNotesOpen] = useState(false);
   const [mobileNotesOpen, setMobileNotesOpen] = useState(false);
+  const [selectedCommunity, setSelectedCommunity] = useState("Community");
+  const [selectedNotes, setSelectedNotes] = useState("Notes");
 
   const location = useLocation();
   const { theme } = useTheme();
@@ -240,6 +246,8 @@ const Navbar = () => {
                 toggleDropdown={toggleDesktopDropdown}
                 isActive={isActive}
                 getIcon={getIcon}
+                selectedCommunity={selectedCommunity}
+                setSelectedCommunity={setSelectedCommunity}
               />
             ))}
 
@@ -251,7 +259,7 @@ const Navbar = () => {
                 onClick={() => setDesktopNotesOpen(!desktopNotesOpen)}
               >
                 <BookOpen size={18} className="drop-icon" />
-                <span>Notes</span>
+                <span>{selectedNotes}</span>
                 <ChevronDown
                   size={16}
                   className={`${desktopNotesOpen ? "rotated" : ""}`}
@@ -264,7 +272,10 @@ const Navbar = () => {
                     className={`dropdown-item ${
                       isActive("/notes/java") ? "active" : ""
                     }`}
-                    onClick={() => setDesktopNotesOpen(false)}
+                    onClick={() => {
+                      setSelectedNotes("Java");
+                      setDesktopNotesOpen(false);
+                    }}
                   >
                     Java
                   </Link>
@@ -273,7 +284,10 @@ const Navbar = () => {
                     className={`dropdown-item ${
                       isActive("/notes/python") ? "active" : ""
                     }`}
-                    onClick={() => setDesktopNotesOpen(false)}
+                    onClick={() => {
+                      setSelectedNotes("Python");
+                      setDesktopNotesOpen(false);
+                    }}
                   >
                     Python
                   </Link>
@@ -282,7 +296,10 @@ const Navbar = () => {
                     className={`dropdown-item ${
                       isActive("/notes/cpp") ? "active" : ""
                     }`}
-                    onClick={() => setDesktopNotesOpen(false)}
+                    onClick={() => {
+                      setSelectedNotes("C++");
+                      setDesktopNotesOpen(false);
+                    }}
                   >
                     C++
                   </Link>
@@ -291,7 +308,10 @@ const Navbar = () => {
                     className={`dropdown-item ${
                       isActive("/notes/c") ? "active" : ""
                     }`}
-                    onClick={() => setDesktopNotesOpen(false)}
+                    onClick={() => {
+                      setSelectedNotes("C");
+                      setDesktopNotesOpen(false);
+                    }}
                   >
                     C
                   </Link>
@@ -300,7 +320,10 @@ const Navbar = () => {
                     className={`dropdown-item ${
                       isActive("/notes/javascript") ? "active" : ""
                     }`}
-                    onClick={() => setDesktopNotesOpen(false)}
+                    onClick={() => {
+                      setSelectedNotes("Javascript");
+                      setDesktopNotesOpen(false);
+                    }}
                   >
                     JavaScript
                   </Link>
@@ -309,7 +332,10 @@ const Navbar = () => {
                     className={`dropdown-item ${
                       isActive("/notes/MERN/MERNFundamentals") ? "active" : ""
                     }`}
-                    onClick={() => setDesktopNotesOpen(false)}
+                    onClick={() => {
+                      setSelectedNotes("MERN");
+                      setDesktopNotesOpen(false);
+                    }}
                   >
                     MERN
                   </Link>
@@ -319,7 +345,10 @@ const Navbar = () => {
                     target="_blank"
                     rel="noopener noreferrer"
                     className="dropdown-item"
-                    onClick={() => setDesktopNotesOpen(false)}
+                    onClick={() => {
+                      setSelectedNotes("DSA Sheet  by Shradha Khapra");
+                      setDesktopNotesOpen(false);
+                    }}
                   >
                     DSA Sheet  by Shradha Khapra      
                   </Link>
@@ -328,7 +357,10 @@ const Navbar = () => {
                     target="_blank"
                     rel="noopener noreferrer"
                     className="dropdown-item"
-                    onClick={() => setDesktopNotesOpen(false)}
+                    onClick={() => {
+                      setSelectedNotes("DSA Sheet by NEETCODE");
+                      setDesktopNotesOpen(false);
+                    }}
                   >
                     DSA Sheet by NEETCODE
                   </Link>
@@ -415,7 +447,7 @@ const Navbar = () => {
             onClick={() => setMobileNotesOpen(!mobileNotesOpen)}
           >
             <BookOpen size={18} className="icon" />
-            <span>Notes</span>
+            <span>{selectedNotes}</span>
             <ChevronDown
               size={16}
               className={`${mobileNotesOpen ? "rotated" : ""}`}
@@ -428,6 +460,7 @@ const Navbar = () => {
               to="/notes/java"
               className="mobile-menu-link"
               onClick={() => {
+                setSelectedNotes("Java");
                 setMobileNotesOpen(false);
                 setIsMobileMenuOpen(false);
               }}
@@ -438,6 +471,7 @@ const Navbar = () => {
               to="/notes/python"
               className="mobile-menu-link"
               onClick={() => {
+                setSelectedNotes("Python");
                 setMobileNotesOpen(false);
                 setIsMobileMenuOpen(false);
               }}
@@ -448,6 +482,7 @@ const Navbar = () => {
               to="/notes/cpp"
               className="mobile-menu-link"
               onClick={() => {
+                setSelectedNotes("C++");
                 setMobileNotesOpen(false);
                 setIsMobileMenuOpen(false);
               }}
@@ -458,6 +493,7 @@ const Navbar = () => {
               to="/notes/c"
               className="mobile-menu-link"
               onClick={() => {
+                setSelectedNotes("C");
                 setMobileNotesOpen(false);
                 setIsMobileMenuOpen(false);
               }}
@@ -469,6 +505,7 @@ const Navbar = () => {
               to="/notes/javascript"
               className="mobile-menu-link"
               onClick={() => {
+                setSelectedNotes("JavaScript");
                 setMobileNotesOpen(false);
                 setIsMobileMenuOpen(false);
               }}

--- a/src/styles/navbar-top.css
+++ b/src/styles/navbar-top.css
@@ -298,18 +298,21 @@ body {
   opacity: 1;
 }
 
+.dropdown:hover,
 .navbar-link:hover {
   color: var(--primary-color);
   /* color: green; */
   transform: translateY(-1px);
 }
 
+.dropdown:active,
 .navbar-link.active {
   color: var(--primary-color);
   background: var(--primary-color-alpha);
   /* background-color: green; */
 }
 
+.dropdown.active::before,
 .navbar-link.active::before {
   opacity: 1;
   background: var(--primary-color-alpha);
@@ -346,7 +349,7 @@ body {
   gap: 0.4rem;
   padding: 0.65rem 0.85rem;
   border-radius: 10px;
-  /* background: none; */
+  background: none; 
   border: none;
   color: var(--text-color);
   font-weight: 500;
@@ -365,8 +368,8 @@ body {
   left: 0;
   right: 0;
   bottom: 0;
-  /* background-color: var(--pr); */
-  background: var(--primary-color-alpha);
+  background-color: var(--pr);
+  /* background: var(--primary-color-alpha); */
   border: 2px solid rgb(34, 136, 215);
   opacity: 0;
   transition: opacity 0.3s cubic-bezier(0.4, 0, 0.2, 1);
@@ -380,8 +383,9 @@ body {
 
 .dropdown-toggle:hover,
 .dropdown-toggle.active {
-  background: var(--hover-bg);
-  /* color: var(--primary-color); */
+  /* background: var(--hover-bg); */
+  background: var(--primary-color-alpha);
+  color: var(--primary-color);
   transform: translateY(-1px);
 }
 
@@ -640,4 +644,8 @@ body {
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   width: 100%; /* Full width for underline alignment */
   white-space: nowrap;
+}
+
+.dropdown-toggle:hover{
+  background:#aaa;
 }


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #1399 .

## Rationale for this change

Earlier, in the navbar the background color of the dropdown was not same as the other button of the navbar which was ruining the ui of the navbar,
also, earlier, any option selected in the dropdown "community" and "notes", it use to show same name "community" and "notes" instead of the option which is selected.

## What changes are included in this PR?

Now, the background color of the both dropdown has been changed and made same as the navbar is now having the same UI which is enhancing the UI of the Navbar only.
As well as, the dropdowns are working now, which means, dropdowns show the name of the option which is selected from the dropdown menu. 

## Are these changes tested?

yes, all the changes are tested on the localhost.

## Are there any user-facing changes?

now, the users can have better and enhanced navbar.

Image of the navbar which is having perfect ui after the changes:- 
<img width="1366" height="77" alt="pra 1" src="https://github.com/user-attachments/assets/2e7bf680-223f-4c5e-bab8-ed014e25795d" />

Image of the dropdown, when the "Contributors" is selected in the dropdown:-
<img width="1366" height="648" alt="pra 2" src="https://github.com/user-attachments/assets/568f75db-5b0f-4f01-9657-46ff9f57de0b" />

Image of the dropdown, when "Java" is selected in the "notes" dropdown:-
<img width="1366" height="651" alt="pra 4" src="https://github.com/user-attachments/assets/6c5dc161-07b0-4b86-bff1-df3c83515094" />

Image of the dropdown, when the "Python" is selected in the "notes" dropdown:- 
<img width="1366" height="683" alt="pra 5" src="https://github.com/user-attachments/assets/c3348c58-9636-46b9-ac37-585e5c27ebfa" />
