### PR TITLE
Added Number Theory and Sliding Window to advance algo session

### DIFF
--- a/src/data/cheatsheetData.yml
+++ b/src/data/cheatsheetData.yml
@@ -832,6 +832,77 @@ advancedAlgorithms:
         time: "Varies — O(state transitions) or O(n) for classic Nim-type games"
         space: "O(number of states)"
 
+  # Added Game Theory
+    - name: "Number Theory"
+      category: "Technique"
+      description: "Applies mathematical principles to solve computational and modular problems efficiently, used in cryptography, combinatorics, and competitive programming."
+      keyPoints:
+        - "Modular Arithmetic (mod properties, inverse mod)"
+        - "Prime Numbers & Sieve of Eratosthenes"
+        - "GCD & LCM"
+        - "Modular Exponentiation"
+        - "Fermat’s Little Theorem"
+        - "Euler’s Totient Function"
+        - "Chinese Remainder Theorem"
+      examples:
+        - "Count of Prime Numbers up to N"
+        - "Modular Multiplicative Inverse of a Number"
+        - "Big Modulo Exponentiation (a^b % M)"
+        - "Number of Divisors of N"
+      whenToUse:
+        - "When dealing with large numbers under modulo (10^9+7 or similar)"
+        - "When you need to compute powers, inverses, or combinations efficiently"
+        - "When problems involve divisibility, primes, or modular relationships"
+        - "When optimizing mathematical or combinatorial computations"
+      importantFormulas:
+        - "GCD(a, b) = GCD(b, a % b)"
+        - "a^(b) % m → use Binary Exponentiation for O(log b)"
+        - "Fermats Theorem: a^(m-1) ≡ 1 (mod m) if m is prime"
+        - "Modular Inverse: a^(m-2) % m (when m is prime)"
+      patterns:
+        - "Prime-based optimization (precompute primes using Sieve)"
+        - "Combinatorics with modular arithmetic (nCr % mod)"
+        - "Mathematical counting problems"
+        - "Modular inverse and fast exponentiation patterns"
+      complexity:
+        time: "O(n log log n) for sieve; O(log n) for modular operations"
+        space: "O(n) for precomputed arrays (like primes or factorials)"
+
+# Added Sliding Window
+    - name: "Sliding Window"
+      category: "Technique"
+      description: "A technique to efficiently solve problems involving contiguous subarrays or substrings by maintaining a window of elements and moving it across the data structure."
+      keyPoints:
+        - "Fixed-size sliding window"
+        - "Variable-size sliding window"
+        - "Cumulative sum / running sum"
+        - "Two-pointer approach within the window"
+        - "Optimizing nested loops to linear time"
+        - "Variable length window size problems"
+      examples:
+        - "Maximum sum subarray of size K"
+        - "Longest substring without repeating characters"
+        - "Minimum size subarray sum ≥ S"
+        - "Sliding window maximum / minimum"
+        - "Count of anagrams of a pattern in a string"
+      whenToUse:
+        - "When problem involves contiguous elements in arrays or strings"
+        - "When brute-force nested loops are too slow (O(n²))"
+        - "When looking for sums, counts, or patterns within subarrays or substrings"
+        - "When tracking min/max or frequency of elements in a window"
+      importantFormulas:
+        - "Sum of window: maintain running sum; add new element, remove exiting element"
+        - "Frequency map for characters/numbers in window"
+        - "Window size = right - left + 1"
+        - "Check condition while moving left pointer in variable-size window"
+      patterns:
+        - "Fixed-size window: often used for max/min sum or average of subarray of size K"
+        - "Variable-size window: often used for at-least/at-most conditions (like sum ≥ S)"
+        - "Sliding window with hash map: for distinct elements, anagrams, substring patterns"
+        - "Two pointers within a window for dynamic constraints"
+      complexity:
+        time: "O(n) for most single-pass sliding window problems"
+        space: "O(k) for frequency maps or auxiliary data structures, O(1) for simple sum/count"
 
 bigOReference:
   title: "Big-O Complexity Chart"


### PR DESCRIPTION
Goof Evening @SandeepVashishtha  @aleenaharoldpeter , thanks for letting me work on your codebase, wanted to work for more, here by i am Raising my PR, looking forward for getting reviewed and merge it

## Which issue does this PR close?

- Closes #1448

## Rationale for this change

This change enriches the  **cheatsheetdata.yml** file by adding new categorized information that improves documentation clarity and knowledge coverage.
It helps contributors and users access structured data for concepts like algorithms and techniques in a consistent format.

## What changes are included in this PR?
- Added new entry for Number Theory and Sliding Window under Technique category in cheatsheetdata.yml.
- Maintained consistent structure and key naming (name, category, description, keyPoints, etc.)
- Verified YAML syntax and alignment for proper parsing.
- Updated inline documentation/comments for readability.

## Are these changes tested?
Yes
- Verified YAML validity and consistent indentation.
- Ensured that the site/build parses the updated file correctly.
- No runtime or functional code changes were made.

## Are there any user-facing changes?
Yes
The new Number Theory and Sliding window section appears in Advance Techniques session here by attaching the Screenshot

<img width="1107" height="834" alt="image" src="https://github.com/user-attachments/assets/418a83a4-cc03-4ced-aa21-eac343ce0d5f" />

## Asking
Looking forward for getting merge my PR and letting me work for more, thanks for considering my request in advance.

