### PR TITLE
"Have a Doubt" Section UI Improved

### DIFF
--- a/src/styles/doubt.css
+++ b/src/styles/doubt.css
@@ -593,3 +593,64 @@
     min-height: 48px;
   }
 }
+
+.field-group {
+  position: relative;
+  width: 100%;
+  margin-bottom: 1.5rem;
+}
+
+.field-icon {
+  position: absolute;
+  top: 50%;
+  left: 14px;
+  transform: translateY(-50%);
+  font-size: 1.1rem;
+  color: var(--doubt-placeholder);
+  pointer-events: none;
+  opacity: 0.7;
+  transition: color 0.3s ease, opacity 0.3s ease;
+}
+
+.field-input {
+  width: 100%;
+  padding: 12px 16px 12px 44px; 
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--doubt-input-text);
+  font-size: 1rem;
+  transition: all 0.25s ease;
+  outline: none;
+  box-sizing: border-box;
+}
+
+.field-input:focus {
+  border-color: var(--doubt-border-focus);
+  background: rgba(255, 255, 255, 0.15);
+  box-shadow: 0 0 10px rgba(37, 117, 252, 0.4);
+}
+
+.field-input:focus + .field-icon {
+  color: var(--doubt-border-focus);
+  opacity: 1;
+}
+
+.field-input::placeholder {
+  color: var(--doubt-placeholder);
+  opacity: 0.8;
+}
+
+[data-theme="light"] .field-input {
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  color: #222;
+}
+
+[data-theme="light"] .field-input:focus {
+  box-shadow: 0 0 10px rgba(37, 117, 252, 0.4);
+}
+
+[data-theme="light"] .field-icon {
+  color: rgba(0, 0, 0, 0.6);
+}


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #1398

## Rationale for this change

Earlier, the UI of the have a doubt was very messy like the input as well the main container was having same background color, as well as when the doubt was submitted the message was also quite simple.

## What changes are included in this PR?

But, in this pr the some small  are done which are:- 
1. Have a glassmorphism-inspired container with subtle shadow and rounded edges for better depth (used at input to make them look different)
2. Display smooth focus effects on input fields with consistent icon alignment. 
3. Include a visually appealing Submit button (gradient color + hover animation). 
4. Provide feedback messages for both error and successful submissions.

## Are these changes tested?

Yes, these all changes are tested on the localhost.

In Light Mode:-
<img width="1366" height="682" alt="dude 1" src="https://github.com/user-attachments/assets/b8bdfbe0-e6de-46ca-b95d-9551f2270930" />

In Dark Mode:-
<img width="1359" height="683" alt="dude 2" src="https://github.com/user-attachments/assets/a8760401-f38f-4672-b07a-c2099c079d02" />

When the doubt is submitted:-
<img width="1294" height="680" alt="dude 3" src="https://github.com/user-attachments/assets/171ec5c2-04c1-44de-a7f6-bd110f2fa868" />


## Are there any user-facing changes?

Users can notice the doubt container with more UI Improvements