### PR TITLE
Add Algorithm Analytics Dashboard

### DIFF
--- a/public/sample-data/analytics-events.json
+++ b/public/sample-data/analytics-events.json
@@ -1,0 +1,87 @@
+[
+  {
+    "event": "session_start",
+    "algorithm": "Bubble Sort",
+    "timestamp": "2025-10-15T10:00:00.000Z",
+    "sessionId": "s1"
+  },
+  {
+    "event": "step_complete",
+    "algorithm": "Bubble Sort",
+    "timestamp": "2025-10-15T10:00:20.000Z",
+    "sessionId": "s1",
+    "step": 1
+  },
+  {
+    "event": "step_complete",
+    "algorithm": "Bubble Sort",
+    "timestamp": "2025-10-15T10:00:45.000Z",
+    "sessionId": "s1",
+    "step": 2
+  },
+  {
+    "event": "session_end",
+    "algorithm": "Bubble Sort",
+    "timestamp": "2025-10-15T10:01:30.000Z",
+    "sessionId": "s1",
+    "durationSec": 90
+  },
+  {
+    "event": "session_start",
+    "algorithm": "Quick Sort",
+    "timestamp": "2025-10-15T11:00:00.000Z",
+    "sessionId": "s2"
+  },
+  {
+    "event": "session_end",
+    "algorithm": "Quick Sort",
+    "timestamp": "2025-10-15T11:00:12.000Z",
+    "sessionId": "s2",
+    "durationSec": 12
+  },
+  {
+    "event": "session_start",
+    "algorithm": "Bubble Sort",
+    "timestamp": "2025-10-16T09:20:00.000Z",
+    "sessionId": "s3"
+  },
+  {
+    "event": "session_end",
+    "algorithm": "Bubble Sort",
+    "timestamp": "2025-10-16T09:23:00.000Z",
+    "sessionId": "s3",
+    "durationSec": 180
+  },
+  {
+    "event": "session_start",
+    "algorithm": "Merge Sort",
+    "timestamp": "2025-10-16T12:00:00.000Z",
+    "sessionId": "s4"
+  },
+  {
+    "event": "session_end",
+    "algorithm": "Merge Sort",
+    "timestamp": "2025-10-16T12:00:15.000Z",
+    "sessionId": "s4",
+    "durationSec": 15
+  },
+  {
+    "event": "session_start",
+    "algorithm": "Bubble Sort",
+    "timestamp": "2025-10-17T08:00:00.000Z",
+    "sessionId": "s5"
+  },
+  {
+    "event": "retry",
+    "algorithm": "Bubble Sort",
+    "timestamp": "2025-10-17T08:01:00.000Z",
+    "sessionId": "s5"
+  },
+  {
+    "event": "session_end",
+    "algorithm": "Bubble Sort",
+    "timestamp": "2025-10-17T08:05:00.000Z",
+    "sessionId": "s5",
+    "durationSec": 300
+  }
+]

--- a/public/sample-data/sample-analytics-legacy.json
+++ b/public/sample-data/sample-analytics-legacy.json
@@ -1,0 +1,26 @@
+{
+  "avgTime": [
+    { "algorithm": "Bubble Sort", "seconds": 45 },
+    { "algorithm": "Quick Sort", "seconds": 12 },
+    { "algorithm": "Merge Sort", "seconds": 15 },
+    { "algorithm": "Binary Search", "seconds": 6 }
+  ],
+  "retries": [
+    { "algorithm": "Bubble Sort", "count": 120 },
+    { "algorithm": "Quick Sort", "count": 40 },
+    { "algorithm": "Merge Sort", "count": 55 },
+    { "algorithm": "Binary Search", "count": 20 }
+  ],
+  "completionRates": [
+    {
+      "algorithm": "Bubble Sort",
+      "step": "1",
+      "rates": [100, 90, 70, 55, 40]
+    },
+    {
+      "algorithm": "Quick Sort",
+      "step": "1",
+      "rates": [100, 95, 85, 80, 78]
+    }
+  ]
+}

--- a/public/sample-data/sample-analytics.json
+++ b/public/sample-data/sample-analytics.json
@@ -1,0 +1,26 @@
+{
+  "avgTime": [
+    { "algorithm": "Bubble Sort", "seconds": 45 },
+    { "algorithm": "Quick Sort", "seconds": 12 },
+    { "algorithm": "Merge Sort", "seconds": 15 },
+    { "algorithm": "Binary Search", "seconds": 6 }
+  ],
+  "retries": [
+    { "algorithm": "Bubble Sort", "count": 120 },
+    { "algorithm": "Quick Sort", "count": 40 },
+    { "algorithm": "Merge Sort", "count": 55 },
+    { "algorithm": "Binary Search", "count": 20 }
+  ],
+  "completionRates": [
+    {
+      "algorithm": "Bubble Sort",
+      "step": "1",
+      "rates": [100, 90, 70, 55, 40]
+    },
+    {
+      "algorithm": "Quick Sort",
+      "step": "1",
+      "rates": [100, 95, 85, 80, 78]
+    }
+  ]
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -117,6 +117,7 @@ import AlgorithmComparisonTable from './components/AlgorithmComparisonTable';
 // Performance Dashboard
 import PerformanceDashboard from "./components/PerformanceDashboard";
 import PerformanceDocs from "./pages/PerformanceDocs";
+import AnalyticsDashboard from "./pages/AnalyticsDashboard";
 
 // Static / Info Pages
 import Login from "./pages/Login";
@@ -298,6 +299,7 @@ const App = () => {
                   {/* Performance Dashboard */}
                   <Route path="/performance" element={<PerformanceDashboard />} />
                   <Route path="/performance/docs" element={<PerformanceDocs />} />
+                  <Route path="/analytics" element={<AnalyticsDashboard />} />
 
                   {/* Other Pages */}
                   <Route path="/quiz" element={<Quiz />} />

--- a/src/pages/AnalyticsDashboard.jsx
+++ b/src/pages/AnalyticsDashboard.jsx
@@ -1,0 +1,310 @@
+import React, { useEffect, useMemo, useState } from "react";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  PieChart,
+  Pie,
+  Cell,
+  Legend,
+  LineChart,
+  Line,
+  CartesianGrid,
+} from "recharts";
+
+const EVENTS_URL = "/sample-data/analytics-events.json";
+
+const COLORS = ["#0088FE", "#00C49F", "#FFBB28", "#FF8042", "#AA336A"];
+
+const parseISO = (iso) => new Date(iso);
+
+const formatDateLocal = (d) => d.toISOString().slice(0, 10);
+
+const exportCSV = (rows, filename = "analytics-export.csv") => {
+  if (!rows || rows.length === 0) return;
+  const headers = Object.keys(rows[0]);
+  const csv = [headers.join(","), ...rows.map((r) => headers.map((h) => JSON.stringify(r[h] ?? "")).join(","))].join("\n");
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+};
+
+const fetchEvents = async () => {
+  const res = await fetch(EVENTS_URL);
+  return res.json();
+};
+
+const AnalyticsDashboard = () => {
+  const [events, setEvents] = useState(null);
+  const [algorithmFilter, setAlgorithmFilter] = useState("all");
+  const [fromDate, setFromDate] = useState("");
+  const [toDate, setToDate] = useState("");
+
+  useEffect(() => {
+    fetchEvents().then(setEvents).catch(console.error);
+  }, []);
+
+  const algorithms = useMemo(() => {
+    if (!events) return [];
+    return Array.from(new Set(events.map((e) => e.algorithm))).filter(Boolean);
+  }, [events]);
+
+  const filtered = useMemo(() => {
+    if (!events) return [];
+    return events.filter((e) => {
+      if (algorithmFilter !== "all" && e.algorithm !== algorithmFilter) return false;
+      if (fromDate) {
+        const from = new Date(fromDate + "T00:00:00Z");
+        if (parseISO(e.timestamp) < from) return false;
+      }
+      if (toDate) {
+        const to = new Date(toDate + "T23:59:59Z");
+        if (parseISO(e.timestamp) > to) return false;
+      }
+      return true;
+    });
+  }, [events, algorithmFilter, fromDate, toDate]);
+
+  const metrics = useMemo(() => {
+    if (!filtered) return { avgTime: 0, sessions: 0, retries: 0, avgCompletionStep: 0 };
+
+    const sessions = {};
+    let totalDuration = 0;
+    let durationCount = 0;
+    let retryCount = 0;
+
+    filtered.forEach((e) => {
+      if (e.event === "session_start") {
+        sessions[e.sessionId] = sessions[e.sessionId] || { algorithm: e.algorithm, steps: 0 };
+      }
+      if (e.event === "step_complete") {
+        sessions[e.sessionId] = sessions[e.sessionId] || { algorithm: e.algorithm, steps: 0 };
+        sessions[e.sessionId].steps = (sessions[e.sessionId].steps || 0) + 1;
+      }
+      if (e.event === "session_end" && typeof e.durationSec === "number") {
+        totalDuration += e.durationSec;
+        durationCount += 1;
+      }
+      if (e.event === "retry") retryCount++;
+    });
+
+    const sessionCount = durationCount; // sessions with end+duration
+    const avgTime = durationCount > 0 ? totalDuration / durationCount : 0;
+
+    // average completion = average steps across sessions
+    const stepCounts = Object.values(sessions).map((s) => s.steps || 0);
+    const avgCompletionStep = stepCounts.length ? stepCounts.reduce((a, b) => a + b, 0) / stepCounts.length : 0;
+
+    return { avgTime, sessions: sessionCount, retries: retryCount, avgCompletionStep };
+  }, [filtered]);
+
+  const avgTimePerAlgo = useMemo(() => {
+    if (!events) return [];
+    const map = {};
+    events.forEach((e) => {
+      if (e.event === "session_end" && typeof e.durationSec === "number") {
+        map[e.algorithm] = map[e.algorithm] || { total: 0, count: 0 };
+        map[e.algorithm].total += e.durationSec;
+        map[e.algorithm].count += 1;
+      }
+    });
+    return Object.keys(map).map((k) => ({ name: k, seconds: map[k].total / map[k].count }));
+  }, [events]);
+
+  const retriesPerAlgo = useMemo(() => {
+    if (!events) return [];
+    const map = {};
+    events.forEach((e) => {
+      if (e.event === "retry") {
+        map[e.algorithm] = (map[e.algorithm] || 0) + 1;
+      }
+    });
+    return Object.keys(map).map((k) => ({ name: k, value: map[k] }));
+  }, [events]);
+
+  const completionChartData = useMemo(() => {
+    if (!events) return [];
+    // Build steps progression for each algorithm per session
+    const algSessions = {};
+    events.forEach((e) => {
+      if (!e.sessionId || !e.algorithm) return;
+      algSessions[e.sessionId] = algSessions[e.sessionId] || { algorithm: e.algorithm, steps: [] };
+      if (e.event === "step_complete") algSessions[e.sessionId].steps.push(e.step || null);
+    });
+
+    // Build average step completion per step index across algorithms
+    const perAlgo = {};
+    Object.values(algSessions).forEach((s) => {
+      perAlgo[s.algorithm] = perAlgo[s.algorithm] || [];
+      s.steps.forEach((_, idx) => {
+        perAlgo[s.algorithm][idx] = (perAlgo[s.algorithm][idx] || 0) + 1; // count sessions reaching this step
+      });
+    });
+
+    const result = [];
+    Object.keys(perAlgo).forEach((alg) => {
+      result.push({ algorithm: alg, counts: perAlgo[alg] });
+    });
+    return result;
+  }, [events]);
+
+  if (!events) return <div>Loading analytics...</div>;
+
+  return (
+    <div style={{ padding: "1rem" }}>
+      <h1>Algorithm Analytics Dashboard</h1>
+
+      <div style={{ display: "flex", gap: 12, alignItems: "center", margin: "1rem 0" }}>
+        <label>
+          Algorithm:
+          <select value={algorithmFilter} onChange={(e) => setAlgorithmFilter(e.target.value)} style={{ marginLeft: 8 }}>
+            <option value="all">All</option>
+            {algorithms.map((a) => (
+              <option key={a} value={a}>{a}</option>
+            ))}
+          </select>
+        </label>
+
+        <label>
+          From:
+          <input type="date" value={fromDate} onChange={(e) => setFromDate(e.target.value)} style={{ marginLeft: 8 }} />
+        </label>
+
+        <label>
+          To:
+          <input type="date" value={toDate} onChange={(e) => setToDate(e.target.value)} style={{ marginLeft: 8 }} />
+        </label>
+
+        <ShowResultsButton filtered={filtered} />
+      </div>
+
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 360px", gap: 16 }}>
+        <div>
+          <section style={{ height: 320, margin: "1rem 0" }}>
+            <h3>Average Time Spent (per algorithm)</h3>
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={avgTimePerAlgo} margin={{ top: 20, right: 30, left: 0, bottom: 5 }}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="name" />
+                <YAxis />
+                <Tooltip />
+                <Bar dataKey="seconds" fill="#8884d8" />
+              </BarChart>
+            </ResponsiveContainer>
+          </section>
+
+          <section style={{ height: 320, margin: "1rem 0" }}>
+            <h3>Step Completion (sessions reaching step index)</h3>
+            <div style={{ height: 300 }}>
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={completionChartData.reduce((acc, alg) => {
+                  alg.counts.forEach((count, idx) => {
+                    acc[idx] = acc[idx] || { step: `Step ${idx + 1}` };
+                    acc[idx][alg.algorithm] = count;
+                  });
+                  return acc;
+                }, [])}>
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="step" />
+                  <YAxis />
+                  <Tooltip />
+                  <Legend />
+                  {completionChartData.map((alg, idx) => (
+                    <Line key={alg.algorithm} type="monotone" dataKey={alg.algorithm} stroke={COLORS[idx % COLORS.length]} />
+                  ))}
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          </section>
+        </div>
+
+        <aside>
+          <section style={{ marginBottom: 16 }}>
+            <h3>Key Metrics</h3>
+            <div>Average Time (s): {metrics.avgTime.toFixed(2)}</div>
+            <div>Sessions (with duration): {metrics.sessions}</div>
+            <div>Retries: {metrics.retries}</div>
+            <div>Avg Steps Completed: {metrics.avgCompletionStep.toFixed(2)}</div>
+          </section>
+
+          <section>
+            <h3>Most Retried</h3>
+            <div style={{ height: 220 }}>
+              <ResponsiveContainer width="100%" height="100%">
+                <PieChart>
+                  <Pie data={retriesPerAlgo} dataKey="value" nameKey="name" cx="50%" cy="50%" outerRadius={80} label>
+                    {retriesPerAlgo.map((entry, index) => (
+                      <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                    ))}
+                  </Pie>
+                  <Legend />
+                  <Tooltip />
+                </PieChart>
+              </ResponsiveContainer>
+            </div>
+          </section>
+        </aside>
+      </div>
+
+      <ResultsSection filtered={filtered} />
+    </div>
+  );
+};
+
+const ShowResultsButton = ({ filtered }) => {
+  const [show, setShow] = useState(false);
+  return (
+    <>
+      <button onClick={() => setShow((s) => !s)} style={{ marginLeft: 12 }}>
+        {show ? "Hide Results" : `Show Results (${filtered.length})`}
+      </button>
+      {show && <ResultsTable filtered={filtered} />}
+    </>
+  );
+};
+
+const ResultsSection = ({ filtered }) => {
+  return (
+    <section style={{ marginTop: 24 }}>
+      <h3>Filtered Events</h3>
+      <ResultsTable filtered={filtered} />
+    </section>
+  );
+};
+
+const ResultsTable = ({ filtered }) => {
+  return (
+    <div style={{ maxHeight: 360, overflow: "auto", border: "1px solid #eee", borderRadius: 6 }}>
+      <table style={{ width: "100%", borderCollapse: "collapse" }}>
+        <thead>
+          <tr>
+            <th style={{ textAlign: "left", borderBottom: "1px solid #ddd", padding: 8 }}>Timestamp</th>
+            <th style={{ textAlign: "left", borderBottom: "1px solid #ddd", padding: 8 }}>Event</th>
+            <th style={{ textAlign: "left", borderBottom: "1px solid #ddd", padding: 8 }}>Algorithm</th>
+            <th style={{ textAlign: "left", borderBottom: "1px solid #ddd", padding: 8 }}>Session</th>
+            <th style={{ textAlign: "left", borderBottom: "1px solid #ddd", padding: 8 }}>Details</th>
+          </tr>
+        </thead>
+        <tbody>
+          {filtered.map((e, idx) => (
+            <tr key={idx}>
+              <td style={{ padding: "8px 4px" }}>{new Date(e.timestamp).toLocaleString()}</td>
+              <td style={{ padding: "8px 4px" }}>{e.event}</td>
+              <td style={{ padding: "8px 4px" }}>{e.algorithm}</td>
+              <td style={{ padding: "8px 4px" }}>{e.sessionId}</td>
+              <td style={{ padding: "8px 4px" }}>{JSON.stringify({ durationSec: e.durationSec, step: e.step })}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+    export default AnalyticsDashboard;

--- a/src/utils/navigation.js
+++ b/src/utils/navigation.js
@@ -40,9 +40,11 @@ export const navbarNavigationItems = [
     icon: "Cpu",
     dropdown: [
       { path: "/performance", label: "Performance Analyzer" },
+      { path: "/analytics", label: "Analytics Dashboard" },
       { path: "/performance/docs", label: "Performance Docs" },
     ],
   },
+  { path: "/analytics", label: "Analytics", icon: "BarChart3" },
   {
     label: "Notes",
     icon: "BookOpen",


### PR DESCRIPTION
## Which issue does this PR close?

Adds an interactive Algorithm Analytics Dashboard that provides visibility into how users engage with algorithm visualizers. The dashboard currently consumes a demo event dataset and computes metrics client-side.

- Closes #1491 

## Rationale for this change

Learners and educators need visibility into how algorithm visualizers are used. This dashboard provides initial analytics (average time spent, retry counts, and step-completion progress) so instructors can identify difficult algorithms and product owners can make data-driven improvements. The UI ships with event-level demo data to demonstrate how the dashboard will behave when hooked to real telemetry.

## What changes are included in this PR?

Added a new analytics dashboard page and route:
— interactive analytics UI with:
Algorithm/date filters
Computed metrics (average session time, sessions with durations, retries, average steps completed)
Charts (avg time per algorithm, step-completion progress, retries pie)
Inline results table for filtered event data
Client-side logic to compute metrics from event-level records (demo)

## Are these changes tested?

Verified the code compiles / no syntax errors (ran project error check).
Confirmed the page loads locally and filters/tables render using the bundled sample data.


<img width="1345" height="590" alt="Screenshot 2025-10-17 152245" src="https://github.com/user-attachments/assets/edcef93f-4302-42fc-b8fd-e1c285f358cf" />

<img width="1330" height="591" alt="Screenshot 2025-10-17 153001" src="https://github.com/user-attachments/assets/1e06d810-5c4e-4c3a-9e09-28009ef747d9" />
