### PR TITLE
Added Heap and Bucket sort in the "Algorithm Documentation"  page

### DIFF
--- a/src/pages/Documentation.jsx
+++ b/src/pages/Documentation.jsx
@@ -137,6 +137,30 @@ const algorithmDatabase = {
         inPlace: true,
         adaptivity: "Not Adaptive",
         implemented: true
+      },
+      {
+        name: "Heap Sort",
+        id: "heapSort",
+        description:
+          "Builds a max heap from the input data, then repeatedly extracts the maximum element and rebuilds the heap. Performs well for large datasets but is unstable.",
+        timeComplexity: { best: "O(n log n)", average: "O(n log n)", worst: "O(n log n)" },
+        spaceComplexity: "O(1)",
+        stability: "Unstable",
+        inPlace: true,
+        adaptivity: "Not Adaptive",
+        implemented: true
+      },
+      {
+        name: "Bucket Sort",
+        id: "bucketSort",
+        description:
+          "Distributes elements into buckets, sorts each bucket individually (often using insertion sort), then concatenates them. Works best for uniformly distributed data.",
+        timeComplexity: { best: "O(n + k)", average: "O(n + k)", worst: "O(n²)" },
+        spaceComplexity: "O(n + k)",
+        stability: "Stable (depends on bucket sort used)",
+        inPlace: false,
+        adaptivity: "Adaptive (depends on data distribution)",
+        implemented: true
       }
     ]
   },


### PR DESCRIPTION
## Which issue does this PR close?

- Closes :  
   #1465
   #1466 

_Please add both the issue points_

## What changes are included in this PR?

This PR inluced the changes made in the "Algorithm Documentation"  page by adding the Heap Sort and Bucket sort page

## Are these changes tested?
Yes

<img width="1574" height="958" alt="Screenshot 2025-10-18 162958" src="https://github.com/user-attachments/assets/30c79d5a-67d2-41ec-87c9-162e85116803" />
