### PR TITLE
fixed colors and spacing in notes pages and fixed data hidden by main content 

### DIFF
--- a/src/pages/Notes/C/Fundamentals.jsx
+++ b/src/pages/Notes/C/Fundamentals.jsx
@@ -70,16 +70,16 @@ const CFundamentals = () => {
       {/* Navigation */}
       <nav
         style={{
-          position: "sticky",
+          position: "relative",
           top: "2rem",
           background:  "var(--card-bg, #ffffff)",
           borderRadius: "12px",
           padding: "1.5rem",
           boxShadow: "0 6px 18px rgba(16,24,40,0.04)",
-          marginBottom: "2rem"
+          marginBottom: "4rem"
         }}
       >
-        <h3 style={{ marginTop: 0, color: "#0f172a" }}>
+        <h3 style={{ marginTop: 0, color: "var(--text-primary)" }}>
           <i className="fas fa-bookmark" style={{ marginRight: "0.5rem", color: "#4f46e5" }}></i>
           Contents
         </h3>

--- a/src/pages/Notes/Cpp/Fundamentals.jsx
+++ b/src/pages/Notes/Cpp/Fundamentals.jsx
@@ -80,16 +80,16 @@ const CppFundamentals = () => {
       {/* Navigation */}
       <nav
         style={{
-          position: "sticky",
+          position: "relative",
           top: "2rem",
           background:  "var(--card-bg, #ffffff)",
           borderRadius: "12px",
           padding: "1.5rem",
           boxShadow: "0 6px 18px rgba(16,24,40,0.04)",
-          marginBottom: "2rem"
+          marginBottom: "4rem"
         }}
       >
-        <h3 style={{ marginTop: 0, color: "#0f172a" }}>
+        <h3 style={{ marginTop: 0, color: "var(--text-primary)" }}>
           <i className="fas fa-bookmark" style={{ marginRight: "0.5rem", color: "#4f46e5" }}></i>
           Contents
         </h3>

--- a/src/pages/Notes/Java/Fundamentals.jsx
+++ b/src/pages/Notes/Java/Fundamentals.jsx
@@ -38,6 +38,7 @@ import AccessModifiers from "./sections/AccessModifiers";
 import "../../../styles/notesSideBar.css";
 import "../../../styles/fundamentals.css";
 import { FaChevronDown, FaChevronRight, FaBook, FaBars, FaTimes  } from "react-icons/fa";
+import { useTheme } from "../../../ThemeContext";
 
 // sideBar content
 const JavaSidebar = ({
@@ -48,6 +49,7 @@ const JavaSidebar = ({
   sections,
 }) => { 
   const [openCategory, setOpenCategory] = useState("intro");
+  const {theme} = useTheme();
 
   const toggleCategory = (title) => {
     setOpenCategory(openCategory === title ? null : title);
@@ -58,7 +60,7 @@ const JavaSidebar = ({
       {isOpen && <div className="overlay" onClick={onClose}></div>}
       <aside className={`sidebar ${isOpen ? "open" : "close"}`}>
         <div className="sidebar-header">
-          <h2 className="sidebar-title">
+          <h2 className={`${theme === 'dark' ? '!text-gray-50' : '!text-gray-900'} whitespace-nowrap 'sidebar-title'`}>
             <FaBook className="mr-2 text-indigo-400" /> Java Topics
           </h2>
           <button className="close-btn" onClick={onClose}>

--- a/src/pages/Notes/Java/sections/IntroSection.jsx
+++ b/src/pages/Notes/Java/sections/IntroSection.jsx
@@ -3,7 +3,7 @@ import React from "react";
 const IntroSection = ({ copyCode, copiedCode }) => (
   <section style={{ marginBottom: "2rem" }}>
     <div className="card">
-      <h2>
+      <h2 style={{color:'var(--text-primary)' , justifyContent:'center' , gap:'1rem'}}>
         <i className="fas fa-play-circle"></i> 1. Introduction to Java
       </h2>
       <p>

--- a/src/pages/Notes/JavaScript/Fundamentals.jsx
+++ b/src/pages/Notes/JavaScript/Fundamentals.jsx
@@ -111,16 +111,16 @@ const Fundamentals = () => {
       {/* Navigation */}
       <nav
         style={{
-          position: "sticky",
+          position: "relative",
           top: "2rem",
           background: "var(--card-bg, #ffffff)",
           borderRadius: "12px",
           padding: "1.5rem",
           boxShadow: "0 6px 18px rgba(16,24,40,0.04)",
-          marginBottom: "2rem",
+          marginBottom: "4rem",
         }}
       >
-        <h3 style={{ marginTop: 0, color: "#0f172a" }}>
+        <h3 style={{ marginTop: 0, color: "var(--text-primary)" }}>
           <i
             className="fas fa-bookmark"
             style={{ marginRight: "0.5rem", color: "#f59e0b" }}

--- a/src/pages/Notes/NextJs/Fundamentals.jsx
+++ b/src/pages/Notes/NextJs/Fundamentals.jsx
@@ -5,10 +5,12 @@ import ApiRoutesSection from "./sections/ApiRoutesSection";
 import MiddlewareSection from "./sections/MiddlewareSection";
 import OptimizationSection from "./sections/OptimizationSection";
 import BestPracticesSection from "./sections/BestPracticesSection";
+import { useTheme } from "../../../ThemeContext";
 
 const Fundamentals = () => {
   const [activeTab, setActiveTab] = useState("intro");
   const [copiedCode, setCopiedCode] = useState("");
+  const {theme} = useTheme();
 
   const copyCode = async (code, identifier) => {
     try {
@@ -60,17 +62,17 @@ const Fundamentals = () => {
     >
       {/* Header */}
       <header
+      className={`${theme === 'dark' ? 'bg-gradient-to-r from-gray-950 via-gray-800 to-gray-300' :'bg-gradient-to-r from-gray-300 via-gray-400 to-gray-200'}`}
         style={{
           textAlign: "center",
           marginBottom: "3rem",
-          padding: "2rem 0",
-          background: "linear-gradient(135deg, #000000, #333333)",
+          padding: "2rem 0", 
           color: "white",
           borderRadius: "12px",
-          boxShadow: "0 10px 25px rgba(0, 0, 0, 0.3)",
+          boxShadow: "0 10px 25px rgba(0, 0, 0, 0.3)", 
         }}
       >
-        <h1 style={{ fontSize: "3rem", marginBottom: "1rem", fontWeight: 800 }}>
+        <h1 style={{ fontSize: "3rem", marginBottom: "1rem", fontWeight: 800}}>
           Next.js Fundamentals
         </h1>
         <p
@@ -100,13 +102,11 @@ const Fundamentals = () => {
           <button
             key={section.id}
             onClick={() => setActiveTab(section.id)}
+            className={`${activeTab === section.id ? '!bg-blue-950 !text-gray-50' : '!bg-gray-800 !text-gray-50'}`}
             style={{
               padding: "0.75rem 1.5rem",
               border: "none",
-              borderRadius: "8px",
-              background:
-                activeTab === section.id ? "#000000" : "#f3f4f6",
-              color: activeTab === section.id ? "white" : "#374151",
+              borderRadius: "8px", 
               fontWeight: "600",
               cursor: "pointer",
               transition: "all 0.2s ease",
@@ -120,8 +120,8 @@ const Fundamentals = () => {
 
       {/* Content */}
       <main
-        style={{
-          background: "white",
+        className={`${theme === 'dark' ? 'bg-gray-950' : 'bg-gray-50'}`}
+        style={{ 
           borderRadius: "12px",
           padding: "2rem",
           boxShadow: "0 4px 6px rgba(0, 0, 0, 0.1)",

--- a/src/pages/Notes/NextJs/sections/ApiRoutesSection.jsx
+++ b/src/pages/Notes/NextJs/sections/ApiRoutesSection.jsx
@@ -1,6 +1,8 @@
 import React from "react";
+import { useTheme } from "../../../../ThemeContext";
 
 const ApiRoutesSection = ({ copyCode, copiedCode }) => {
+  const {theme} = useTheme();
   const basicApiRoute = `// API Routes in Next.js
 // Create API endpoints in pages/api/ directory
 
@@ -157,7 +159,7 @@ export function withAuth(handler) {
 
   return (
     <div>
-      <h2 style={{ color: "#000000", marginBottom: "1.5rem" }}>
+      <h2 className={`${theme === 'dark' ? '!text-gray-50' : '!text-gray-900'}`} style={{ marginBottom: "1.5rem" }}>
         API Routes
       </h2>
       
@@ -169,7 +171,7 @@ export function withAuth(handler) {
       </div>
 
       <div style={{ marginBottom: "2rem" }}>
-        <h3 style={{ color: "#000000", marginBottom: "1rem" }}>Basic API Routes</h3>
+        <h3 style={{  marginBottom: "1rem" }}>Basic API Routes</h3>
         <div style={{ position: "relative" }}>
           <pre
             style={{
@@ -189,9 +191,7 @@ export function withAuth(handler) {
             style={{
               position: "absolute",
               top: "0.5rem",
-              right: "0.5rem",
-              background: "#374151",
-              color: "white",
+              right: "0.5rem", 
               border: "none",
               padding: "0.5rem",
               borderRadius: "4px",
@@ -205,7 +205,7 @@ export function withAuth(handler) {
       </div>
 
       <div style={{ marginBottom: "2rem" }}>
-        <h3 style={{ color: "#000000", marginBottom: "1rem" }}>HTTP Methods</h3>
+        <h3 style={{  marginBottom: "1rem" }}>HTTP Methods</h3>
         <div style={{ position: "relative" }}>
           <pre
             style={{
@@ -225,9 +225,7 @@ export function withAuth(handler) {
             style={{
               position: "absolute",
               top: "0.5rem",
-              right: "0.5rem",
-              background: "#374151",
-              color: "white",
+              right: "0.5rem", 
               border: "none",
               padding: "0.5rem",
               borderRadius: "4px",
@@ -241,7 +239,7 @@ export function withAuth(handler) {
       </div>
 
       <div style={{ marginBottom: "2rem" }}>
-        <h3 style={{ color: "#000000", marginBottom: "1rem" }}>Dynamic API Routes</h3>
+        <h3 style={{  marginBottom: "1rem" }}>Dynamic API Routes</h3>
         <div style={{ position: "relative" }}>
           <pre
             style={{
@@ -261,9 +259,7 @@ export function withAuth(handler) {
             style={{
               position: "absolute",
               top: "0.5rem",
-              right: "0.5rem",
-              background: "#374151",
-              color: "white",
+              right: "0.5rem", 
               border: "none",
               padding: "0.5rem",
               borderRadius: "4px",
@@ -277,7 +273,7 @@ export function withAuth(handler) {
       </div>
 
       <div style={{ marginBottom: "2rem" }}>
-        <h3 style={{ color: "#000000", marginBottom: "1rem" }}>API with Database</h3>
+        <h3 style={{ marginBottom: "1rem" }}>API with Database</h3>
         <div style={{ position: "relative" }}>
           <pre
             style={{
@@ -297,9 +293,7 @@ export function withAuth(handler) {
             style={{
               position: "absolute",
               top: "0.5rem",
-              right: "0.5rem",
-              background: "#374151",
-              color: "white",
+              right: "0.5rem", 
               border: "none",
               padding: "0.5rem",
               borderRadius: "4px",
@@ -313,7 +307,7 @@ export function withAuth(handler) {
       </div>
 
       <div style={{ marginBottom: "2rem" }}>
-        <h3 style={{ color: "#000000", marginBottom: "1rem" }}>API with Middleware</h3>
+        <h3 style={{  marginBottom: "1rem" }}>API with Middleware</h3>
         <div style={{ position: "relative" }}>
           <pre
             style={{
@@ -333,9 +327,7 @@ export function withAuth(handler) {
             style={{
               position: "absolute",
               top: "0.5rem",
-              right: "0.5rem",
-              background: "#374151",
-              color: "white",
+              right: "0.5rem", 
               border: "none",
               padding: "0.5rem",
               borderRadius: "4px",

--- a/src/pages/Notes/NextJs/sections/BestPracticesSection.jsx
+++ b/src/pages/Notes/NextJs/sections/BestPracticesSection.jsx
@@ -1,6 +1,8 @@
-import React from "react";
+import React from "react";{useTheme}
+import { useTheme } from "../../../../ThemeContext";
 
 const BestPracticesSection = ({ copyCode, copiedCode }) => {
+  const {theme} = useTheme();
   const projectStructure = `// Next.js Project Structure Best Practices
 
 my-nextjs-app/
@@ -257,7 +259,7 @@ export default function App({ Component, pageProps }) {
 
   return (
     <div>
-      <h2 style={{ color: "#000000", marginBottom: "1.5rem" }}>
+      <h2 className={`${theme === 'dark' ? '!text-gray-50' : '!text-gray-900'}`} style={{ marginBottom: "1.5rem" }}>
         Best Practices
       </h2>
       
@@ -269,7 +271,7 @@ export default function App({ Component, pageProps }) {
       </div>
 
       <div style={{ marginBottom: "2rem" }}>
-        <h3 style={{ color: "#000000", marginBottom: "1rem" }}>Project Structure</h3>
+        <h3 style={{marginBottom: "1rem" }}>Project Structure</h3>
         <div style={{ position: "relative" }}>
           <pre
             style={{
@@ -289,9 +291,7 @@ export default function App({ Component, pageProps }) {
             style={{
               position: "absolute",
               top: "0.5rem",
-              right: "0.5rem",
-              background: "#374151",
-              color: "white",
+              right: "0.5rem", 
               border: "none",
               padding: "0.5rem",
               borderRadius: "4px",
@@ -305,7 +305,7 @@ export default function App({ Component, pageProps }) {
       </div>
 
       <div style={{ marginBottom: "2rem" }}>
-        <h3 style={{ color: "#000000", marginBottom: "1rem" }}>Code Organization</h3>
+        <h3 style={{  marginBottom: "1rem" }}>Code Organization</h3>
         <div style={{ position: "relative" }}>
           <pre
             style={{
@@ -325,9 +325,7 @@ export default function App({ Component, pageProps }) {
             style={{
               position: "absolute",
               top: "0.5rem",
-              right: "0.5rem",
-              background: "#374151",
-              color: "white",
+              right: "0.5rem", 
               border: "none",
               padding: "0.5rem",
               borderRadius: "4px",
@@ -341,7 +339,7 @@ export default function App({ Component, pageProps }) {
       </div>
 
       <div style={{ marginBottom: "2rem" }}>
-        <h3 style={{ color: "#000000", marginBottom: "1rem" }}>Performance</h3>
+        <h3 style={{ marginBottom: "1rem" }}>Performance</h3>
         <div style={{ position: "relative" }}>
           <pre
             style={{
@@ -361,9 +359,7 @@ export default function App({ Component, pageProps }) {
             style={{
               position: "absolute",
               top: "0.5rem",
-              right: "0.5rem",
-              background: "#374151",
-              color: "white",
+              right: "0.5rem", 
               border: "none",
               padding: "0.5rem",
               borderRadius: "4px",
@@ -377,7 +373,7 @@ export default function App({ Component, pageProps }) {
       </div>
 
       <div style={{ marginBottom: "2rem" }}>
-        <h3 style={{ color: "#000000", marginBottom: "1rem" }}>Security</h3>
+        <h3 style={{ marginBottom: "1rem" }}>Security</h3>
         <div style={{ position: "relative" }}>
           <pre
             style={{
@@ -397,9 +393,7 @@ export default function App({ Component, pageProps }) {
             style={{
               position: "absolute",
               top: "0.5rem",
-              right: "0.5rem",
-              background: "#374151",
-              color: "white",
+              right: "0.5rem", 
               border: "none",
               padding: "0.5rem",
               borderRadius: "4px",
@@ -413,7 +407,7 @@ export default function App({ Component, pageProps }) {
       </div>
 
       <div style={{ marginBottom: "2rem" }}>
-        <h3 style={{ color: "#000000", marginBottom: "1rem" }}>Deployment</h3>
+        <h3 style={{  marginBottom: "1rem" }}>Deployment</h3>
         <div style={{ position: "relative" }}>
           <pre
             style={{
@@ -433,9 +427,7 @@ export default function App({ Component, pageProps }) {
             style={{
               position: "absolute",
               top: "0.5rem",
-              right: "0.5rem",
-              background: "#374151",
-              color: "white",
+              right: "0.5rem", 
               border: "none",
               padding: "0.5rem",
               borderRadius: "4px",

--- a/src/pages/Notes/NextJs/sections/IntroSection.jsx
+++ b/src/pages/Notes/NextJs/sections/IntroSection.jsx
@@ -1,6 +1,8 @@
 import React from "react";
+import { useTheme } from "../../../../ThemeContext";
 
 const IntroSection = ({ copyCode, copiedCode }) => {
+  const {theme} = useTheme();
   const nextjsIntro = `// What is Next.js?
 // Next.js is a React framework that provides additional features
 // for building production-ready applications
@@ -125,19 +127,19 @@ export default function About() {
 
   return (
     <div>
-      <h2 style={{ color: "#000000", marginBottom: "1.5rem" }}>
+      <h2 className={`${theme === 'dark' ? '!text-gray-50' : '!text-gray-900'}`} style={{marginBottom: "1.5rem" }}>
         Introduction to Next.js
       </h2>
       
       <div style={{ marginBottom: "2rem" }}>
-        <p style={{ fontSize: "1.1rem", lineHeight: "1.6", marginBottom: "1rem" }}>
+        <p style={{ fontSize: "1.1rem", lineHeight: "1.6", marginBottom: "1rem",color:'var(--text-primary)' }}>
           Next.js is a React framework that provides additional features for building production-ready applications. 
           It extends React with powerful capabilities like server-side rendering, static site generation, and file-based routing.
         </p>
       </div>
 
       <div style={{ marginBottom: "2rem" }}>
-        <h3 style={{ color: "#000000", marginBottom: "1rem" }}>What is Next.js?</h3>
+        <h3 style={{ marginBottom: "1rem" }}>What is Next.js?</h3>
         <div style={{ position: "relative" }}>
           <pre
             style={{
@@ -157,9 +159,7 @@ export default function About() {
             style={{
               position: "absolute",
               top: "0.5rem",
-              right: "0.5rem",
-              background: "#374151",
-              color: "white",
+              right: "0.5rem", 
               border: "none",
               padding: "0.5rem",
               borderRadius: "4px",
@@ -173,7 +173,7 @@ export default function About() {
       </div>
 
       <div style={{ marginBottom: "2rem" }}>
-        <h3 style={{ color: "#000000", marginBottom: "1rem" }}>Next.js vs React</h3>
+        <h3 style={{  marginBottom: "1rem" }}>Next.js vs React</h3>
         <div style={{ position: "relative" }}>
           <pre
             style={{
@@ -193,9 +193,7 @@ export default function About() {
             style={{
               position: "absolute",
               top: "0.5rem",
-              right: "0.5rem",
-              background: "#374151",
-              color: "white",
+              right: "0.5rem", 
               border: "none",
               padding: "0.5rem",
               borderRadius: "4px",
@@ -209,7 +207,7 @@ export default function About() {
       </div>
 
       <div style={{ marginBottom: "2rem" }}>
-        <h3 style={{ color: "#000000", marginBottom: "1rem" }}>Project Setup</h3>
+        <h3 style={{  marginBottom: "1rem" }}>Project Setup</h3>
         <div style={{ position: "relative" }}>
           <pre
             style={{
@@ -229,9 +227,7 @@ export default function About() {
             style={{
               position: "absolute",
               top: "0.5rem",
-              right: "0.5rem",
-              background: "#374151",
-              color: "white",
+              right: "0.5rem", 
               border: "none",
               padding: "0.5rem",
               borderRadius: "4px",

--- a/src/pages/Notes/NextJs/sections/MiddlewareSection.jsx
+++ b/src/pages/Notes/NextJs/sections/MiddlewareSection.jsx
@@ -1,6 +1,8 @@
 import React from "react";
+import { useTheme } from "../../../../ThemeContext";
 
 const MiddlewareSection = ({ copyCode, copiedCode }) => {
+  const {theme} = useTheme();
   const basicMiddleware = `// Next.js Middleware
 // middleware.js (in root directory)
 
@@ -146,7 +148,7 @@ export const config = {
 
   return (
     <div>
-      <h2 style={{ color: "#000000", marginBottom: "1.5rem" }}>
+      <h2 className={`${theme === 'dark' ? '!text-gray-50' : '!text-gray-900'}`} style={{ marginBottom: "1.5rem" }}>
         Middleware
       </h2>
       
@@ -158,7 +160,7 @@ export const config = {
       </div>
 
       <div style={{ marginBottom: "2rem" }}>
-        <h3 style={{ color: "#000000", marginBottom: "1rem" }}>Basic Middleware</h3>
+        <h3 style={{  marginBottom: "1rem" }}>Basic Middleware</h3>
         <div style={{ position: "relative" }}>
           <pre
             style={{
@@ -178,9 +180,7 @@ export const config = {
             style={{
               position: "absolute",
               top: "0.5rem",
-              right: "0.5rem",
-              background: "#374151",
-              color: "white",
+              right: "0.5rem", 
               border: "none",
               padding: "0.5rem",
               borderRadius: "4px",
@@ -194,7 +194,7 @@ export const config = {
       </div>
 
       <div style={{ marginBottom: "2rem" }}>
-        <h3 style={{ color: "#000000", marginBottom: "1rem" }}>Authentication Middleware</h3>
+        <h3 style={{   marginBottom: "1rem" }}>Authentication Middleware</h3>
         <div style={{ position: "relative" }}>
           <pre
             style={{
@@ -214,9 +214,7 @@ export const config = {
             style={{
               position: "absolute",
               top: "0.5rem",
-              right: "0.5rem",
-              background: "#374151",
-              color: "white",
+              right: "0.5rem", 
               border: "none",
               padding: "0.5rem",
               borderRadius: "4px",
@@ -230,7 +228,7 @@ export const config = {
       </div>
 
       <div style={{ marginBottom: "2rem" }}>
-        <h3 style={{ color: "#000000", marginBottom: "1rem" }}>Geolocation Middleware</h3>
+        <h3 style={{  marginBottom: "1rem" }}>Geolocation Middleware</h3>
         <div style={{ position: "relative" }}>
           <pre
             style={{
@@ -250,9 +248,7 @@ export const config = {
             style={{
               position: "absolute",
               top: "0.5rem",
-              right: "0.5rem",
-              background: "#374151",
-              color: "white",
+              right: "0.5rem", 
               border: "none",
               padding: "0.5rem",
               borderRadius: "4px",

--- a/src/pages/Notes/NextJs/sections/OptimizationSection.jsx
+++ b/src/pages/Notes/NextJs/sections/OptimizationSection.jsx
@@ -1,6 +1,8 @@
 import React from "react";
+import { useTheme } from "../../../../ThemeContext";
 
 const OptimizationSection = ({ copyCode, copiedCode }) => {
+  const {theme} = useTheme();
   const imageOptimization = `// Image Optimization in Next.js
 import Image from 'next/image';
 
@@ -188,8 +190,8 @@ function Posts() {
 }`;
 
   return (
-    <div>
-      <h2 style={{ color: "#000000", marginBottom: "1.5rem" }}>
+    <div >
+      <h2 className={`${theme === 'dark' ? '!text-gray-50' : '!text-gray-900'}`} style={{  marginBottom: "1.5rem" }}>
         Optimization
       </h2>
       
@@ -201,7 +203,7 @@ function Posts() {
       </div>
 
       <div style={{ marginBottom: "2rem" }}>
-        <h3 style={{ color: "#000000", marginBottom: "1rem" }}>Image Optimization</h3>
+        <h3 style={{  marginBottom: "1rem" }}>Image Optimization</h3>
         <div style={{ position: "relative" }}>
           <pre
             style={{
@@ -221,9 +223,7 @@ function Posts() {
             style={{
               position: "absolute",
               top: "0.5rem",
-              right: "0.5rem",
-              background: "#374151",
-              color: "white",
+              right: "0.5rem", 
               border: "none",
               padding: "0.5rem",
               borderRadius: "4px",
@@ -237,7 +237,7 @@ function Posts() {
       </div>
 
       <div style={{ marginBottom: "2rem" }}>
-        <h3 style={{ color: "#000000", marginBottom: "1rem" }}>Font Optimization</h3>
+        <h3 style={{  marginBottom: "1rem" }}>Font Optimization</h3>
         <div style={{ position: "relative" }}>
           <pre
             style={{
@@ -257,9 +257,7 @@ function Posts() {
             style={{
               position: "absolute",
               top: "0.5rem",
-              right: "0.5rem",
-              background: "#374151",
-              color: "white",
+              right: "0.5rem", 
               border: "none",
               padding: "0.5rem",
               borderRadius: "4px",
@@ -273,7 +271,7 @@ function Posts() {
       </div>
 
       <div style={{ marginBottom: "2rem" }}>
-        <h3 style={{ color: "#000000", marginBottom: "1rem" }}>Performance Optimization</h3>
+        <h3 style={{  marginBottom: "1rem" }}>Performance Optimization</h3>
         <div style={{ position: "relative" }}>
           <pre
             style={{
@@ -293,9 +291,7 @@ function Posts() {
             style={{
               position: "absolute",
               top: "0.5rem",
-              right: "0.5rem",
-              background: "#374151",
-              color: "white",
+              right: "0.5rem", 
               border: "none",
               padding: "0.5rem",
               borderRadius: "4px",
@@ -309,7 +305,7 @@ function Posts() {
       </div>
 
       <div style={{ marginBottom: "2rem" }}>
-        <h3 style={{ color: "#000000", marginBottom: "1rem" }}>SEO Optimization</h3>
+        <h3 style={{   marginBottom: "1rem" }}>SEO Optimization</h3>
         <div style={{ position: "relative" }}>
           <pre
             style={{
@@ -329,9 +325,7 @@ function Posts() {
             style={{
               position: "absolute",
               top: "0.5rem",
-              right: "0.5rem",
-              background: "#374151",
-              color: "white",
+              right: "0.5rem", 
               border: "none",
               padding: "0.5rem",
               borderRadius: "4px",
@@ -345,7 +339,7 @@ function Posts() {
       </div>
 
       <div style={{ marginBottom: "2rem" }}>
-        <h3 style={{ color: "#000000", marginBottom: "1rem" }}>Caching Strategies</h3>
+        <h3 style={{ marginBottom: "1rem" }}>Caching Strategies</h3>
         <div style={{ position: "relative" }}>
           <pre
             style={{
@@ -365,9 +359,7 @@ function Posts() {
             style={{
               position: "absolute",
               top: "0.5rem",
-              right: "0.5rem",
-              background: "#374151",
-              color: "white",
+              right: "0.5rem", 
               border: "none",
               padding: "0.5rem",
               borderRadius: "4px",

--- a/src/pages/Notes/NextJs/sections/RoutingSection.jsx
+++ b/src/pages/Notes/NextJs/sections/RoutingSection.jsx
@@ -1,6 +1,7 @@
 import React from "react";
-
+import { useTheme } from "../../../../ThemeContext";
 const RoutingSection = ({ copyCode, copiedCode }) => {
+  const {theme} = useTheme();
   const fileBasedRouting = `// File-based Routing in Next.js
 // No need to install React Router - routing is automatic
 
@@ -124,7 +125,7 @@ export default function Users() {
 
   return (
     <div>
-      <h2 style={{ color: "#000000", marginBottom: "1.5rem" }}>
+      <h2 className={`${theme === 'dark' ? '!text-gray-50' : '!text-gray-900'}`} style={{ marginBottom: "1.5rem" }}>
         File-based Routing
       </h2>
       
@@ -136,7 +137,7 @@ export default function Users() {
       </div>
 
       <div style={{ marginBottom: "2rem" }}>
-        <h3 style={{ color: "#000000", marginBottom: "1rem" }}>Basic File-based Routing</h3>
+        <h3 style={{  marginBottom: "1rem" }}>Basic File-based Routing</h3>
         <div style={{ position: "relative" }}>
           <pre
             style={{
@@ -156,9 +157,7 @@ export default function Users() {
             style={{
               position: "absolute",
               top: "0.5rem",
-              right: "0.5rem",
-              background: "#374151",
-              color: "white",
+              right: "0.5rem", 
               border: "none",
               padding: "0.5rem",
               borderRadius: "4px",
@@ -172,7 +171,7 @@ export default function Users() {
       </div>
 
       <div style={{ marginBottom: "2rem" }}>
-        <h3 style={{ color: "#000000", marginBottom: "1rem" }}>Dynamic Routes</h3>
+        <h3 style={{   marginBottom: "1rem" }}>Dynamic Routes</h3>
         <div style={{ position: "relative" }}>
           <pre
             style={{
@@ -192,9 +191,7 @@ export default function Users() {
             style={{
               position: "absolute",
               top: "0.5rem",
-              right: "0.5rem",
-              background: "#374151",
-              color: "white",
+              right: "0.5rem", 
               border: "none",
               padding: "0.5rem",
               borderRadius: "4px",
@@ -208,7 +205,7 @@ export default function Users() {
       </div>
 
       <div style={{ marginBottom: "2rem" }}>
-        <h3 style={{ color: "#000000", marginBottom: "1rem" }}>Navigation</h3>
+        <h3 style={{   marginBottom: "1rem" }}>Navigation</h3>
         <div style={{ position: "relative" }}>
           <pre
             style={{
@@ -228,9 +225,7 @@ export default function Users() {
             style={{
               position: "absolute",
               top: "0.5rem",
-              right: "0.5rem",
-              background: "#374151",
-              color: "white",
+              right: "0.5rem", 
               border: "none",
               padding: "0.5rem",
               borderRadius: "4px",
@@ -244,7 +239,7 @@ export default function Users() {
       </div>
 
       <div style={{ marginBottom: "2rem" }}>
-        <h3 style={{ color: "#000000", marginBottom: "1rem" }}>Nested Routes</h3>
+        <h3 style={{   marginBottom: "1rem" }}>Nested Routes</h3>
         <div style={{ position: "relative" }}>
           <pre
             style={{
@@ -264,9 +259,7 @@ export default function Users() {
             style={{
               position: "absolute",
               top: "0.5rem",
-              right: "0.5rem",
-              background: "#374151",
-              color: "white",
+              right: "0.5rem", 
               border: "none",
               padding: "0.5rem",
               borderRadius: "4px",

--- a/src/pages/Notes/Python/Fundamentals.jsx
+++ b/src/pages/Notes/Python/Fundamentals.jsx
@@ -44,16 +44,16 @@ const PythonFundamentals = () => {
       {/* Navigation */}
       <nav
         style={{
-          position: "sticky",
+          position: "relative",
           top: "2rem",
           background:  "var(--card-bg, #ffffff)",
           borderRadius: "12px",
           padding: "1.5rem",
           boxShadow: "0 6px 18px rgba(16,24,40,0.04)",
-          marginBottom: "2rem"
+          marginBottom: "4rem"
         }}
       >
-        <h3 style={{ marginTop: 0, color: "#0f172a" }}>
+        <h3 style={{ marginTop: 0, color: "var(--text-primary)" }}>
           <i className="fas fa-bookmark" style={{ marginRight: "0.5rem", color: "#4f46e5" }}></i>
           Contents
         </h3>

--- a/src/styles/notesSideBar.css
+++ b/src/styles/notesSideBar.css
@@ -1,8 +1,8 @@
  
 .sidebar {
   position: fixed;
-  top: 4.4rem;
-  left: 3px; 
+  top: 2rem;
+  left: 4.5rem; 
   opacity: 0;
   padding: 2rem 1.8rem;  
   height: 100vh;
@@ -62,9 +62,11 @@
 }
 .menu-btn {
   position: absolute;
-  top: 4rem;
-  left: 0px;
+  top: 2rem;
+  left: 3rem;
   z-index: 10;
+  max-width: 150px;
+  height: 45px;
   background-color: #6b6bff;
   border: none;
   color: white !important;


### PR DESCRIPTION


## Which issue does this PR close-> #1542  
- Closes #1542

## Rationale for this change
1->Fixed colors in content of next.js notes page in both dark and light mode
<img width="953" height="658" alt="image" src="https://github.com/user-attachments/assets/174a0d0e-fbf2-4394-b42c-ae059c789b8f" />
<img width="999" height="674" alt="image" src="https://github.com/user-attachments/assets/00b8e6dc-110d-4da7-a546-6db12ceda32e" />

2->fixed side bar overridden in java notes
<img width="717" height="705" alt="image" src="https://github.com/user-attachments/assets/15253672-57b3-44ac-8fc6-04735c907064" />

3->fixed content hidden by main section -->now it's visible to all notes pages
<img width="1057" height="694" alt="image" src="https://github.com/user-attachments/assets/0eee4fe6-d3d1-4ca4-9425-847028816ce0" />
  
## Are these changes tested-> yes
 


 
 