### PR TITLE
FAQ Questions Styling Improved

### DIFF
--- a/src/styles/faq.css
+++ b/src/styles/faq.css
@@ -331,3 +331,46 @@ color: #1f3a57;
 [data-theme="dark"] .faq-footer-content p {
   color: #b0b0b0;
 }
+
+.faq-container,
+.faq-content,
+.faq-category,
+.faq-questions,
+.faq-item,
+.faq-question,
+.faq-answer,
+.faq-answer-content {
+  box-sizing: border-box !important;
+  width: 100% !important;
+  max-width: none !important;
+}
+
+.faq-question {
+  display: flex !important;
+  width: 100% !important;
+  margin: 0 !important;
+  padding: 1.5rem 2rem !important;
+  box-sizing: border-box !important;
+  justify-content: space-between !important;
+  align-items: center !important;
+  border: none !important;
+  background: transparent !important;
+}
+
+.faq-question .faq-question-text {
+  display: block !important;
+  max-width: calc(100% - 56px) !important; /* leave room for chevron */
+  word-break: break-word !important;
+  white-space: normal !important;
+}
+
+.faq-content {
+  display: flex !important;
+  flex-direction: column !important;
+  align-items: stretch !important;
+}
+
+.faq-question[style] {
+  min-width: 0 !important;
+  max-width: none !important;
+}


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #1557 .

## Rationale for this change
Earlier the questions were in the block form at the left side of the section and the right side of the sections was empty due to which is use to have a bad impression on the users.

## What changes are included in this PR?

Now, the questions are made perfectly same as the answers as the horizontally wide and it looks better than earlier as it is made inline as well as not any space is empty at the right side of the question.

## Are these changes tested?

Yes, all the changes are tested on the localhost.

## Are there any user-facing changes?

Yes now the faq page is having a better impression on the user and as well as also enhancing the user experience.

Image of the Updated FAQ Page:-
<img width="1860" height="910" alt="image" src="https://github.com/user-attachments/assets/0cd451fd-34b7-4afc-bbf9-4f90281889c2" />
<img width="1858" height="902" alt="image" src="https://github.com/user-attachments/assets/323787ce-6a41-4d88-b14b-b7eb05ff8ed2" />
