### PR TITLE
fixed nav-items, nav-links and logo clipping when sidebar is expanded

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -259,7 +259,7 @@ const Navbar = () => {
 
         {/* Desktop nav */}
         <div
-          className="hidden md:flex flex-col items-start gap-3 w-full desktop-nav-menu"
+          className="md:flex flex-col items-start gap-3 w-full desktop-nav-menu"
           ref={navMenuRef}
         >
           {/* Render nav items excluding "Notes" */}

--- a/src/styles/navbar-top.css
+++ b/src/styles/navbar-top.css
@@ -71,7 +71,7 @@ body {
 }
 
 .navbar.expanded {
-  width: 260px; /* Expanded width */
+  width: 280px; /* Expanded width */
 }
 
 .navbar-container {
@@ -160,6 +160,7 @@ body {
   flex: 1;
 }
 .navbar-item {
+  width: 100%;
   font-size: 0.9rem;
   position: relative;
   margin: 0;
@@ -171,6 +172,8 @@ body {
 .navbar-link {
   display: flex;
   align-items: center;
+  justify-content: flex-start;
+  width: 100%;
   gap: 1.25rem; /* Increased gap for better spacing */
   padding: 0.875rem 1.5rem; /* Standardized padding */
   border-radius: 12px;
@@ -241,6 +244,7 @@ body {
 .dropdown-toggle {
   display: flex;
   align-items: center;
+  justify-content: flex-start;
   gap: 1.25rem; /* Increased gap */
   padding: 0.875rem 1.5rem; /* Standardized padding */
   border-radius: 12px;
@@ -391,6 +395,8 @@ body {
 
 /* Slide-out text label styles */
 .navbar-label {
+  flex-grow: 1;
+  text-align: start;
   display: inline-block;
   max-width: 0; 
   opacity: 0; 
@@ -437,6 +443,10 @@ body {
 
 .navbar:not(.expanded) .sidebar-footer {
   align-items: center;
+}
+
+.sidebar-footer button {
+  min-width: 70px;
 }
 
 /* Hide mobile menu button as it's not needed for sidebar */


### PR DESCRIPTION
- Closes #1469.

Transparency issue is fixed in a separate PR. In this pr, I have fixed the logo clipping issue when the navbar is expanded. also, i have made the nav items and links take full width in an expanded sidebar