### PR TITLE
Give visibility to dropdown of sidebar

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -25,6 +25,7 @@ import { useTheme } from "../ThemeContext";
 import { navbarNavigationItems } from "../utils/navigation";
 import UserDropdown from "./UserDropdown";
 import ThemeToggle from "./ThemeToggle";
+// import { backgroundClip } from "html2canvas/dist/types/css/property-descriptors/background-clip";
 
 const ICON_COMPONENTS = {
   BarChart3,
@@ -82,7 +83,7 @@ const DesktopNavItem = ({
           </span>
           {isSidebarExpanded && (
             <ChevronDown
-              size={16}
+              size={20}
               className={`dropdown-arrow ${isOpen === index ? "rotated" : ""}`}
             />
           )}

--- a/src/styles/navbar.css
+++ b/src/styles/navbar.css
@@ -98,6 +98,10 @@
   transform: translateX(-50%) translateY(0);
 }
 
+.dropdown-arrow{
+  color:black;
+}
+
 /* ✨ little top pointer */
 .mega-menu::before {
   content: "";
@@ -428,7 +432,6 @@
 .navbar.light .feature-desc { 
   color: #3a4253; 
 }
-
 
 @media (max-width: 768px) {
   .navbar .mega-menu {


### PR DESCRIPTION
I give visibility to the dropdown menu button  of the sidebar .

Now it is like this -

<img width="1264" height="1016" alt="Screenshot 2025-10-31 000253" src="https://github.com/user-attachments/assets/11746f8c-046e-4dcb-9b75-845810a81a46" />

Hi @RhythmPahwa14 please check this PR and merge it with hacktoberfest-accepted label.
Thanks!