### PR TITLE
Enhanced the UI of  Java page

### DIFF
--- a/src/pages/Notes/Java/Fundamentals.jsx
+++ b/src/pages/Notes/Java/Fundamentals.jsx
@@ -435,7 +435,7 @@ const Fundamentals = () => {
           textAlign: "center",
           marginBottom: "3rem",
           padding: "2rem 0",
-          background: "linear-gradient(135deg, #4f46e5, #4338ca)",
+          background:"linear-gradient(135deg, #a78bfa, #60a5fa)",
           color: "white",
           borderRadius: "12px",
           boxShadow: "0 10px 25px rgba(79, 70, 229, 0.3)",

--- a/src/styles/fundamentals.css
+++ b/src/styles/fundamentals.css
@@ -16,7 +16,6 @@
   color: #ffffff !important;
 }
 .card {
-  /* background: var(--card-bg, #ffffff); */
   background:#b3cdf8;
   border-radius: 12px;
   box-shadow: 0 6px 18px rgba(16, 24, 40, 0.04);
@@ -112,3 +111,10 @@ strong {
   color: #1664e0;
 }
  
+.menu-btn{
+  background-color:cornflowerblue;
+}
+
+.sidebar{
+  background-color:#abc4ed;
+}


### PR DESCRIPTION
I enhanced the UI of the Java page of the Notes page section.

Now it is looking like this -

Sidebar of Java page-
 
<img width="1870" height="718" alt="Screenshot 2025-10-31 004759" src="https://github.com/user-attachments/assets/bae7146d-1447-4e0e-826e-c97de433303a" />

Java Main page-

<img width="1889" height="861" alt="Screenshot 2025-10-31 004829" src="https://github.com/user-attachments/assets/313b4f84-41c4-487b-83cb-0d7a405b1b9a" />

Hi @RhythmPahwa14 please check this PR and merge it with hacktoberfest-accpepted label.
Thanks!

